### PR TITLE
Proposal: BlockSmith for Canton

### DIFF
--- a/proposals/57b_blocksmith_canton.md
+++ b/proposals/57b_blocksmith_canton.md
@@ -1,0 +1,394 @@
+## Development Fund Proposal
+
+**Author:**  57Blocks  
+**Status:** Submitted  
+**Created:** 2026-03-13  
+
+---
+
+## Abstract
+
+BlockSmith for Canton is an operator-first toolkit that makes deploying, connecting, monitoring, and upgrading Canton nodes feel closer to "standard practice" in mature ecosystems (EVM-style: strong deployment automation + dashboards + runbooks). It targets the ecosystem's highest-reported friction — **environment setup & node operations** — by shipping opinionated node templates, deterministic diagnostics, a **web UI** (BlockSmith Console for Canton) for one-click topology/connectivity + health visibility (including handshake-related indicators where exposed), and an upgrade/migration assistant for Canton and Daml. The grant funds an open-source common-good core; sustainability comes from optional paid Pro/Cloud add-ons (fleet management, hosted UI/dashboards, enterprise support) layered on top.
+
+---
+
+## Specification
+
+### 1. Objective
+
+Deliver an open, production-minded node-ops toolkit that:
+
+- Reduces time-to-healthy Canton node setup from "days of infra debugging" to "hours/minutes with deterministic checks."
+- Makes node connectivity and key health state visible via a simple topology dashboard.
+- Provides operator-grade monitoring defaults (metrics, dashboards, alerting) as a one-command bundle.
+- Makes upgrades and migrations less risky through an upgrade assistant, compatibility matrix, and scripted runbooks.
+
+**Target users**
+
+- **Node operators / infrastructure teams** (participants, integrators): need reliable deployment, monitoring, and upgrades.
+- **App teams**: benefit indirectly from faster onboarding and fewer "infrastructure rabbit holes".
+
+**Success looks like:**
+
+- A new team can deploy a reference topology and reach "connected + healthy" state with deterministic checks and dashboards.
+- Operators can verify connectivity and key health indicators without tailing logs, and can detect common failure modes via `doctor`.
+- Upgrades are guided by a tool-generated plan and verified preflight checks, reducing downtime and trial-and-error.
+
+---
+
+### 2. Implementation Mechanics
+
+#### Component overview
+
+**1) Unified operator CLI (entrypoint)**
+
+A single CLI (`blocksmith-canton`) that provides:
+
+- `blocksmith-canton init`: create an opinionated node workspace (configs, secrets stubs, directory layout, environment profiles).
+- `blocksmith-canton up|down|restart`: bring up/down a topology in a reproducible way (local-dev via Docker Compose in grant scope).
+- `blocksmith-canton status`: health summary across nodes and APIs, including "what's broken and why".
+- `blocksmith-canton logs`: structured log access and known-issue signatures.
+- `blocksmith-canton doctor`: deterministic diagnostics (ports, docker prerequisites, JVM, time drift, TLS/certs where applicable, API reachability, and connectivity indicators).
+
+**1a) DevNet/Quickstart operator automation (make the "hard parts" one command)**
+
+Codify and automate the operational primitives that appear repeatedly in real-world guides:
+
+- **Network info discovery**: fetch and validate values like "migration id" and active version where applicable, and persist them as artifacts for repeatable starts ([Deploy Quickstart to DevNet](https://docs.digitalasset.com/build/3.3/quickstart/operate/deploy-quickstart-to-devnet.html)).
+- **Onboarding secret workflow**: support known sponsor-SV endpoints where accessible, and always support manual secret input + TTL checks (guides note secrets may be short-lived and are often the first troubleshooting step).
+- **Host-based routing helpers**: generate `/etc/hosts` entries and validate required hostnames for local routing (nginx virtual hosting is used in Quickstart/validator setups).
+- **Profiled start commands**: generate (or wrap) the correct `start` command arguments for common flows (e.g., sponsor SV URL, onboarding secret, party hint, migration id, wait-for-ready, auth enabled).
+- **Reset semantics**: provide a safe "reset" that removes stale containers/volumes when needed (guides often recommend a clean `down -v` to resolve unhealthy/stale states).
+
+**2) Opinionated node deployment templates ("golden paths")**
+
+Provide versioned, well-documented templates that teams can fork and adapt:
+
+- **Local-dev**: single-machine Docker Compose topology suitable for onboarding and integration testing.
+- **Team-dev** (post-grant / commercial or follow-on): Helm charts for a shared dev cluster, with sane defaults and clear overrides.
+
+**3) BlockSmith Console for Canton (web UI) + monitoring/observability (one-click)**
+
+The Canton DevEx survey explicitly calls for "one-click visual dashboards" to validate node handshakes without complex terminal commands, and a more visual, human-friendly debugging experience ([survey analysis](https://discuss.daml.com/t/canton-network-developer-experience-and-tooling-survey-analysis-2026/8412)). BlockSmith for Canton ships a real UI as a first-class deliverable:
+
+- `blocksmith-canton ui up|down`: start the BlockSmith Console for Canton locally (and connect it to your topology).
+- **Setup wizard**: guided bring-up of a "golden path" topology (local-dev first), including routing prerequisites and connectivity checks.
+- **Topology/connectivity graph**: participant↔synchronizer connectivity and health indicators, with actionable next steps on failure. Handshake-specific status is shown where exposed by the deployment's health/status surfaces.
+- **Health & readiness**: unified health view (gRPC/HTTP/admin where available), plus links to the relevant logs and suggested fixes.
+- **Observability bundle**: `blocksmith-canton obs up|down` starts a bundled stack (Prometheus + Grafana + log aggregation where feasible) and the UI deep-links into relevant dashboards.
+- **Diagnostics center**: download a single support-quality archive (`collect-diagnostics`) and view what is inside (versions, health summaries, key logs).
+- **Connection artifact export**: export a single machine-readable file (JSON) that captures "what to connect to" for operators and app teams (endpoints/ports/hostnames, enabled auth mode, and detected version info where available). This directly reduces the "opaque discovery" friction called out in the survey.
+- **Auth/JWT checklist page**: a guided checklist for common auth setups (OIDC/JWT), plus "is auth enabled?" checks where visible from configuration/health surfaces. (This is guidance + validation, not a full managed identity product.)
+- **Package visibility (where exposed)**: a simple "Packages" page that lists installed packages/DARs when the deployment exposes a supported API for it; otherwise, the UI shows the operator which API/setting to enable to make package discovery possible.
+
+In addition to the BlockSmith Console for Canton UI, prebuilt dashboards covering "golden signals" for node operations (liveness, API availability, error rates, resource usage) and Canton-specific connectivity indicators where available will be provided.
+
+Observability choices explicitly align with established component patterns where available. For example, PQS exposes metrics (including Prometheus exposition), structured logging controls, and diagnostics export (metrics + thread dumps) that are natural inputs to a bundled operator dashboard and "collect diagnostics" command ([PQS Observe](https://docs.digitalasset.com/build/3.3/component-howtos/pqs/observe.html)).
+
+**4) Upgrade & migration assistant (Canton + Daml)**
+
+Reduce the operational burden of upgrades:
+
+- `blocksmith-canton upgrade plan`: detect current versions, compare against a target, and generate a step-by-step plan (including preflight checks).
+- `blocksmith-canton upgrade preflight`: validate prerequisites, config compatibility, and run smoke checks in a staging profile.
+- Maintain a public **compatibility matrix** and "known pitfalls" playbooks for supported versions.
+
+The upgrade assistant is grounded in the official "upgrade to a new release" model: upgrading binaries/config and applying database schema migrations (e.g., Flyway), then separately coordinating protocol version changes across nodes — with explicit emphasis on backups/testing and the reality that certain migrations cannot be rolled back once started ([Upgrade To a New Release](https://docs.digitalasset.com/operate/3.3/howtos/upgrade/index.html)).
+
+The assistant focuses on repeatable operational steps and validations. It does not attempt to "magically fix" protocol-level incompatibilities; instead it makes them visible early and provides safe, operator-friendly workflows.
+
+#### Technical approach (high level)
+
+- CLI implemented in a widely adopted language for devops tooling (Rust or Go), designed for extensibility (subcommands/plugins).
+- Orchestration via Docker Compose in grant scope (lowest friction); Helm charts are post-grant/follow-on.
+- Health checks via HTTP/gRPC endpoints where available; plus log signature detection for known failure states.
+- Observability shipped as versioned assets and started via a single command.
+- Upgrade assistant built around explicit version detection, preflight validation, and scripted steps with checkpoints.
+
+#### Non-goals (explicitly out of scope)
+
+- Replacing Canton core components or modifying protocol behavior.
+- Building a full explorer/indexer.
+- Providing a proprietary-only solution: the funded deliverables are open-source and usable by the whole ecosystem (commercial options are additive).
+
+#### Sustainability model (open core)
+
+To ensure long-term sustainability, BlockSmith for Canton uses an **open-core** model:
+
+- **Open-source core (grant-funded)**: CLI, templates, BlockSmith Console for Canton, dashboards, diagnostics, upgrade playbooks, and compatibility matrix.
+- **Paid Pro/Cloud add-ons (post-grant, optional)**: fleet management across multiple environments, hosted Console UI/dashboards + alert routing (Slack/PagerDuty), role-based access control, compliance reporting, long-term support (LTS) builds, and enterprise onboarding/support packages.
+
+This structure keeps the ecosystem's fundamentals open while enabling a sustainable business to maintain and evolve the tool.
+
+---
+
+### 3. Architectural Alignment
+
+This proposal aligns with Development Fund priorities as it delivers:
+
+- **Critical ecosystem infrastructure** and **developer/operator tooling** used by multiple participants ([fund repo](https://github.com/canton-foundation/canton-dev-fund)).
+- Direct response to the survey's top friction: environment setup & node operations, plus the high-demand area of observability/topology dashboards ([survey analysis](https://discuss.daml.com/t/canton-network-developer-experience-and-tooling-survey-analysis-2026/8412)).
+
+The scope is deliberately bounded to operator tooling and does not touch Canton core protocol components, smart contract execution, or ledger storage. All deliverables are additive, open-source, and composable with existing Canton infrastructure.
+
+---
+
+### 4. Backward Compatibility
+
+*No backward compatibility impact.* BlockSmith for Canton is entirely additive — a standalone CLI, web UI, and observability bundle that wraps and observes existing Canton components via published health/gRPC/HTTP APIs. It does not modify Canton core components, protocol behavior, or existing node configurations. Teams can adopt incrementally without disrupting any running infrastructure.
+
+---
+
+## Milestones and Deliverables
+
+### Milestone 1: Golden-path bootstrap + console foundation
+
+- **Estimated Delivery:** ~4–5 weeks from project kickoff
+- **Focus:** Core CLI, environment automation, and the initial BlockSmith Console for Canton web UI
+- **Deliverables / Value Metrics:**
+  - `blocksmith-canton init/up/down/status/logs/doctor`
+  - `blocksmith-canton preflight`: environment readiness checks (Docker resources, ports, routing prereqs)
+  - `blocksmith-canton reset --mode safe|full` with explicit "what will be removed" output
+  - `blocksmith-canton env doctor` detecting common corporate TLS/proxy failure modes with actionable remediation
+  - DevNet operator automation: network info discovery, onboarding secret workflow, host-based routing helpers, profiled start commands, and reset semantics
+  - **BlockSmith Console for Canton**: local web UI showing topology status, node health summary, and "next actions" on common failures
+  - **Connection artifact export**: export endpoints/ports/hostnames and operator notes into a single JSON file
+  - Versioned Local-dev template (Docker Compose) with a reference topology
+  - Documentation: "operator quickstart" and troubleshooting guide
+  - CI for releases and reproducible artifacts
+
+### Milestone 2: Observability + console expansion + diagnostics
+
+- **Estimated Delivery:** ~4–5 weeks after Milestone 1
+- **Focus:** Full observability bundle, expanded web UI, and diagnostics tooling
+- **Deliverables / Value Metrics:**
+  - `blocksmith-canton obs up|down` to run the observability bundle
+  - Prebuilt dashboards + basic alert rules for the reference topology
+  - **BlockSmith Console for Canton (expanded)**:
+    - Topology/connectivity graph with actionable guidance
+    - Health drill-down (link to failing component checks)
+    - Deep links to relevant Grafana dashboards/log views
+    - Auth/JWT checklist page + basic validations
+    - Package visibility page (where exposed)
+  - `blocksmith-canton collect-diagnostics`: gather logs, metrics snapshots, and component diagnostics exports into a single archive suitable for issue reports (where supported by components such as PQS)
+  - `blocksmith-canton health`: unified health view (gRPC/HTTP health + operator-friendly summary)
+  - `blocksmith-canton logs capture`: standardized log capture with optional `lnav` bootstrap for trace-id and component filtering
+
+### Milestone 3: Upgrade planning + hardening + adoption package
+
+- **Estimated Delivery:** ~4–6 weeks after Milestone 2
+- **Focus:** Upgrade and migration assistant, expanded diagnostics, and external pilot onboarding
+- **Deliverables / Value Metrics:**
+  - `blocksmith-canton upgrade plan/preflight` (guarded workflows)
+  - Version detection + compatibility matrix + "known pitfalls" playbooks
+  - Staging profile + smoke-test script for upgrades
+  - **Upgrade Wizard (in the BlockSmith Console for Canton)**:
+    - Detects current node versions and protocol versions where exposed via health/status surfaces
+    - Generates an operator runbook aligned with Canton's documented upgrade flow (backup → config parse with `--manual-start` → `db.migrate` when needed → reconnect/ping)
+    - Generates copy/paste-ready Canton console scripts for the safest verifications (e.g., `health.status`, `health.dump`, `health.ping`, `synchronizers.list_connected`)
+    - Provides protocol-upgrade guidance (plan-only) that reflects Canton's constraints: protocol upgrades require a new synchronizer and participant migration (no in-place protocol upgrade for a synchronizer)
+  - `blocksmith-canton daml check`: SDK/runtime consistency verification and guided "repair" workflow for common local SDK corruption scenarios
+  - `blocksmith-canton compat report`: compatibility report (node version, protocol version, client API expectations) for change management and approvals
+  - Expanded doctor rules and dashboards based on pilot feedback
+  - Adoption package: onboarding docs, runbooks, and sample CI checks
+  - Stable versioning and a published roadmap
+  - At least 2 pilot teams/operators (external or partner teams) complete documented onboarding and provide actionable feedback/issues
+
+---
+
+## Acceptance Criteria
+
+The Tech & Ops Committee will evaluate completion based on:
+
+- Deliverables completed as specified for each milestone
+- Demonstrated functionality or operational readiness
+- Documentation and knowledge transfer provided
+- Alignment with stated value metrics
+
+**Milestone 1 — specific criteria:**
+
+- A fresh machine (Docker installed) can bring up the reference topology and reach "healthy" status in a deterministic way.
+- `status` clearly indicates each node/service as Healthy/Unhealthy with an actionable reason.
+- `doctor` detects at least 10 common setup/connectivity failures with clear remediation steps.
+- The tool can generate/validate host-based routing prerequisites for local setups (where required by the topology), and can "reset" cleanly to remove stale volumes when troubleshooting calls for it (mirroring common guidance in operational docs).
+
+**Milestone 2 — specific criteria:**
+
+- With one command, an operator can open dashboards and verify "connected + healthy" without tailing logs.
+- Topology view reflects current health/connectivity indicators with short periodic refresh and suggests next actions on failure.
+- Diagnostics command produces a single archive that materially improves bug reports (includes timestamps, versions, and the key health signals).
+
+**Milestone 3 — specific criteria:**
+
+- Given a supported source→target upgrade pair, the tool generates an upgrade plan and preflight checks catch misconfigurations before changes are applied.
+- Upgrade preflight produces a clear checklist and documented rollback guidance (tool-generated runbook).
+- Protocol upgrade plan includes the concrete documented steps and prerequisites (e.g., enable repair commands, idle participants, disconnect/reconnect, and run a migration command) without executing them automatically.
+- At least 2 pilot teams/operators (external or partner teams) complete documented onboarding and provide actionable feedback/issues.
+
+---
+
+## Funding
+
+**Total Funding Request:** $98,000 USD equivalent in Canton Coin (CC), milestone-based
+
+Funding on the Development Fund is denominated in **Canton Coin (CC)**. The budget below is a **USD-equivalent** to make the request concrete; milestone payments would be paid in CC using an agreed conversion method at the time of payment (e.g., a spot or trailing-average CC/USD rate agreed with Tech & Ops).
+
+**Team & cost assumptions**
+
+- **Tech lead**: 0.25 FTE for ~14 weeks (architecture, delivery, code review, integrations, stakeholder coordination)
+- **Developers**: 2.0 FTE for ~14 weeks (CLI + backend services + UI implementation)
+- **DevRel / technical writing**: included in the tech lead allocation (docs owned by the team; no separate FTE assumed)
+- **Fully-loaded rates**: Tech lead: $14,000/month · Developer: $11,000/month
+- **Non-labor**: $4,000 total (CI minutes, small test environments, design assets, incidentals)
+- **Contingency**: 5% for schedule risk and unknowns
+
+> Scope note: this budget focuses the grant deliverables on (1) a golden-path local-dev topology, (2) the BlockSmith Console for Canton web UI for topology/connectivity + health, (3) diagnostics capture, and (4) upgrade planning + preflight checks. Team-dev Helm templates and any "Tenderly-like" stretch features are deferred to post-grant work.
+
+**Budget summary (USD-equivalent)**
+
+- Tech lead: 3.5 months × $14,000 × 0.25 FTE = **$12,250**
+- Developers: 3.5 months × $11,000 × 2 FTE = **$77,000**
+- Labor subtotal: **$89,250**
+- Non-labor: **$4,000**
+- Contingency (5%): **$4,750**
+- **Total: $98,000 USD equivalent in CC**
+
+### Payment Breakdown by Milestone
+
+- Milestone 1 — Golden-path bootstrap + console foundation: **$35,000 in $CC** upon committee acceptance
+- Milestone 2 — Observability + console expansion + diagnostics: **$35,000 in $CC** upon committee acceptance
+- Milestone 3 — Upgrade planning + hardening + adoption package: **$28,000 in $CC** upon final release and acceptance
+
+### Volatility Stipulation
+
+The project duration is **under 6 months** (~14 weeks). Should the project timeline extend beyond 6 months due to Committee-requested scope changes, any remaining milestones must be renegotiated to account for significant USD/CC price volatility.
+
+---
+
+## Co-Marketing
+
+Upon release, 57blocks will collaborate with the Canton Foundation on:
+
+- Announcement coordination for each major milestone release
+- A technical blog post or case study covering how BlockSmith for Canton addresses the top DevEx pain points identified in the 2026 survey
+- Developer and ecosystem promotion (e.g., presentation at a Canton community call, forum posts, and tooling showcase)
+- Feedback loops with pilot teams to validate adoption and publish usage outcomes
+
+---
+
+## Motivation
+
+### Problem: environment setup & node operations are Canton's highest-friction area
+
+The Canton Foundation's 2026 DevEx survey highlights that **environment setup & node operations** are the longest-to-get-right task for many developers. It also repeatedly calls out the need for **one-click visual dashboards** to validate node handshakes (Sequencer/Mediator/Participant) without relying on complex terminal commands, plus broader **observability & monitoring** as a high-consensus priority ([survey analysis](https://discuss.daml.com/t/canton-network-developer-experience-and-tooling-survey-analysis-2026/8412)).
+
+For teams used to EVM ecosystems, there is an expectation of reliable "golden path" node deployment templates, standardized metrics + dashboards + alerts (and a usable UI, not only CLI), and predictable upgrade/migration playbooks. Today, deploying a Canton topology, connecting correctly, keeping it healthy, and migrating across version changes (including Daml upgrades) often requires teams to become infrastructure specialists before they can ship product.
+
+A concrete example is the Quickstart DevNet workflow, which includes steps like VPN connectivity, managing host-based routing (`/etc/hosts` + nginx virtual hosting), retrieving network "migration id" and matching versions, generating short-lived onboarding secrets, and passing the right flags to startup scripts — none of which are "product work", but all of which are required to get a node connected and stable ([Deploy Quickstart to DevNet](https://docs.digitalasset.com/build/3.3/quickstart/operate/deploy-quickstart-to-devnet.html)).
+
+### Specific operator difficulties observed in official documentation
+
+**Environment + orchestration friction**
+
+- **Docker resources / unhealthy containers**: Quickstart highlights that LocalNet commonly becomes "unhealthy" due to insufficient Docker memory and recommends allocating ≥ 8GB and sometimes disabling observability to fit smaller machines ([CNQS FAQ](https://docs.digitalasset.com/build/3.3/quickstart/troubleshoot/cnqs-faq.html)).
+- **Dependency management complexity (direnv/nix/JVM)**: Quickstart uses `direnv`, `nix`, and Docker Compose, and the FAQ calls out corporate proxy / TLS certificate issues (Nix SSL certs, JVM trust stores) that can block setup in enterprise environments ([CNQS FAQ](https://docs.digitalasset.com/build/3.3/quickstart/troubleshoot/cnqs-faq.html)).
+- **Stale state + "reset" runbooks**: Docs recommend sequences like `make stop`, `make clean-all`, or `docker compose down -v` to clear stale containers/volumes and recover from unhealthy states ([CNQS FAQ](https://docs.digitalasset.com/build/3.3/quickstart/troubleshoot/cnqs-faq.html); [Deploy Quickstart to DevNet](https://docs.digitalasset.com/build/3.3/quickstart/operate/deploy-quickstart-to-devnet.html)).
+
+**Versioning, upgrades, and migrations**
+
+- **Daml SDK / runtime version drift**: FAQ highlights that the Daml SDK version is pinned via environment variables (e.g., `DAML_RUNTIME_VERSION`) and that interrupted installs can corrupt SDK snapshots and require manual cleanup ([CNQS FAQ](https://docs.digitalasset.com/build/3.3/quickstart/troubleshoot/cnqs-faq.html)).
+- **Database migrations and upgrade sequencing**: Canton console docs note that persistent nodes require explicit database migrations (`db.migrate`) when upgrading, that `migrate-and-start` can be enabled, and that data continuity is only guaranteed across minor/patch updates ([Canton Console](https://docs.digitalasset.com/operate/3.3/howtos/operate/console/console.html)).
+- **Client/API breaking changes across versions**: The gRPC Ledger API migration guide documents concrete breakpoints (e.g., `domain`→`synchronizer`, `application_id`→`user_id`, event identifier changes), which are easy to miss during upgrades ([gRPC Ledger API Migration Guide](https://docs.digitalasset.com/build/3.3/reference/lapi-migration-guide.html)).
+
+**Monitoring, diagnostics, and "what is healthy?"**
+
+- **Multiple health surfaces**: Participant health is exposed via gRPC health checks, optional HTTP health endpoints, and richer console/admin status (`health.status`) with component-level details ([Participant Node Health](https://docs.digitalasset.com/operate/3.3/howtos/observe/health.html)).
+- **Health dumps are essential for troubleshooting**: Docs describe `health.dump()` producing a ZIP with sanitized config, logs extract, metrics snapshot, and thread dumps, and note this is commonly needed when troubleshooting or working with support ([Participant Node Health](https://docs.digitalasset.com/operate/3.3/howtos/observe/health.html)).
+- **Log analysis complexity**: Quickstart recommends capturing container logs (`make capture-logs`) and using `lnav` with a Canton-specific log format config to filter by component, errors, and OpenTelemetry trace IDs across services ([lnav guide](https://docs.digitalasset.com/build/3.5/quickstart/operate/lnav-in-cn.html); [CNQS FAQ](https://docs.digitalasset.com/build/3.3/quickstart/troubleshoot/cnqs-faq.html)).
+
+### How BlockSmith for Canton directly addresses the survey's top pain points
+
+- **Environment setup & node operations (highest friction)**: Golden-path local topology (`docker compose`) + deterministic `preflight`, `doctor`, and safe `reset` flows. Localhost UI (BlockSmith Console for Canton) that shows "what's running, what's unhealthy, and what to do next". Grounded in documented operational runbooks and failure modes (e.g., resource constraints, stale volumes) ([CNQS FAQ](https://docs.digitalasset.com/build/3.3/quickstart/troubleshoot/cnqs-faq.html)).
+- **"One-click visual dashboards" for operators**: BlockSmith Console for Canton provides topology/connectivity view + health drill-down, and deep-links into Grafana dashboards where enabled. Handshake-specific indicators are shown where exposed by health/status surfaces (avoids over-promising topology introspection everywhere) ([Participant Node Health](https://docs.digitalasset.com/operate/3.3/howtos/observe/health.html)).
+- **Observability & monitoring (broad consensus priority)**: One-command observability bundle for local-dev (Prometheus + Grafana), plus "collect diagnostics" archives for reproducible bug reports. PQS metrics integration aligns with documented OTel/Prometheus approaches where PQS is part of the topology ([PQS Observe](https://docs.digitalasset.com/build/3.3/component-howtos/pqs/observe.html)).
+- **Integration friction ("opaque discovery", repeated JWT/auth hurdles)**: Connection artifact export (single JSON) so app teams/operators don't reverse-engineer endpoints/ports/hostnames. Auth/JWT checklist UI: guidance + validation for common OIDC/JWT setups (reachability and configuration sanity checks), without becoming an identity platform. Package visibility (where exposed): best-effort listing of installed packages/DARs when a supported API is available; otherwise, clear guidance on what to enable.
+- **Upgrades and migrations (Canton + Daml)**: Upgrade Wizard (plan/preflight) generates runbooks aligned with the official upgrade flow (config parse with `--manual-start`, `db.migrate()` when needed, reconnect/ping verification). Protocol upgrades are supported as runbook/script generation only (no unsafe automation), matching Canton's constraint that synchronizer protocol upgrades require deploying a new synchronizer and migrating participants ([Upgrade To a New Release](https://docs.digitalasset.com/operate/3.3/howtos/upgrade/index.html)).
+
+### Why this matters for Canton specifically
+
+1. **Canton's developer base is 83% TradFi or hybrid.** These teams have a compliance-conscious, uptime-critical mindset. They need hardened tooling that bridges traditional finance workflows with on-chain infrastructure — not bespoke tribal knowledge spread across docs.
+2. **The survey is unambiguous.** Environment setup & node operations top the friction list, and visual dashboards / observability are high-consensus asks. This is not speculative — it is a direct response to reported needs.
+3. **Multi-chain onboarding expertise is essential.** Teams moving from EVM to Canton face a paradigm shift (global state → need-to-know privacy, party-based identity). Reducing the infrastructure overhead lets them focus on that paradigm shift, rather than fighting the operational stack first.
+4. **An open-source common good raises all boats.** All operators — new teams, existing participants, integrators — benefit from a shared baseline of deployment templates, runbooks, and dashboards. This is infrastructure the ecosystem cannot afford to re-create individually.
+
+---
+
+## Rationale
+
+### Why 57blocks is the right team to deliver this
+
+57blocks has already shipped **BlockSmith**, a developer/operator toolchain for Stellar Soroban that unifies local node lifecycle management (`start/stop/reset`) into a deterministic workflow, one test suite runnable against both in-memory and real-node environments, and operational feedback loops like resource/limit measurement and developer-friendly outputs ([BlockSmith](https://www.blocksmith.co/)).
+
+BlockSmith emerged from the same insight driving this proposal: developers on newer chains are forced to become infrastructure specialists before they can build product. The toolchain was funded through multiple **Stellar Community Fund grants** (SCF #27, #29, #31) and evolved into a suite of four developer tools — a Timelock Smart Contract framework, an AutoAction DevTool for scheduled/event-driven smart contract execution, and a Resource Usage monitor that connects directly to localnet with alerts on overuse. This grant-funded-to-sustained-tooling arc is the exact model intended for Canton.
+
+**Deep Web3 infrastructure expertise across 20+ DeFi categories**
+
+57Blocks has been building and investing in Web3 since 2018. With 200+ product designers, AI experts, and engineers across six global offices (San Francisco, Seattle, Bogotá, Medellín, Wrocław, and three cities in China), the team brings full-stack depth: protocol design, smart contract development, chain infrastructure, backend services, frontend dApps, testing frameworks, CI/CD pipelines, and 24/7 monitoring.
+
+Trusted by 20+ protocols, we have built and invested across every major layer of the Web3 stack — from L1 infrastructure (Ethereum, Solana, Stellar, Canton, Cosmos, Sui) through DeFi protocols, wallets, compliance tools, cross-chain bridges, analytics platforms, and RWA applications. Our Web3 tech stack directly overlaps with BlockSmith for Canton's requirements: Docker, Kubernetes, Prometheus/Grafana monitoring, Daml, Go, Node.js, Java, Python, React, and deep experience with Hardhat, Foundry, and Soroban development environments.
+
+We have a trained engineering team and hands-on experience designing and building on Canton using Daml for a commercial, production-deployed solution.
+
+**Directly relevant case studies**
+
+**Huma Finance — Private Credit Protocol ($10.2B+ financed, 0% default)**
+We co-designed and implemented Huma's smart contract architecture from inception, led the development of V1/V2 Ethereum contracts, and subsequently drove the full migration to Solana. This engagement is relevant because Huma is a TradFi/DeFi hybrid — the same profile as 83% of Canton's developer base — and required building production-grade infrastructure that bridges traditional finance workflows with on-chain settlement. Our pod structure (2 smart contract engineers, 1 tokenomics advisor, 1 frontend architect) mirrors the focused team we'll deploy for BlockSmith for Canton.
+
+**Rain — Web3 Stablecoins Payments Platform**
+For Rain, we built the blockchain layer from scratch: smart contracts for settlement and liquidity, cross-chain interoperability, on/off-chain reconciliation, and secure upgrade-ready deployments. The technical parallels to BlockSmith for Canton are strong — we solved multi-chain system abstraction (refactoring a tightly-coupled EVM system to support Solana and Stellar), asynchronous transaction throughput with concurrent processing, idempotency and concurrency control, and automated transaction recovery with fault-tolerant event processing. These are exactly the kinds of operational resilience patterns that Canton node operators need.
+
+**Undisclosed Stablecoin Issuer — Stablecoin Platform Chain Expansion**
+57Blocks serves as the customer's strategic engineering partner for expanding their fiat-backed stablecoin platform across 20+ chains. One of four workstreams is explicitly "Delivery Excellence & Tooling" — streamlining integrations, standardizing developer interfaces, enabling faster onboarding, and building more scalable, maintainable platform evolution. This is the same mission as BlockSmith for Canton, applied to a different chain ecosystem.
+
+**LI.FI — Multi-Chain DEX Aggregation (50+ L2 chains)**
+We led development of LI.FI's DEX aggregator service, building scalable architecture to integrate DEXes across 50+ L2 chains with optimized swap routing algorithms. This engagement demonstrates our ability to build cross-chain infrastructure at scale — adapting to each chain's idiosyncrasies while maintaining a unified developer and operator experience.
+
+**Why this approach is preferred over alternatives**
+
+1. **We've done this before.** BlockSmith for Stellar proves we can identify operator pain points in a non-EVM ecosystem, translate them into opinionated tooling, secure ecosystem grant funding, and ship iteratively. The pattern is identical.
+2. **Enterprise/TradFi DNA.** Our deepest engagements — Huma (private credit), Rain (stablecoin payments), Brale (fiat-backed stablecoin issuance), Paxos (cross-chain token issuance) — are all regulated financial infrastructure. We understand the compliance-conscious, uptime-critical mindset these teams bring to Canton.
+3. **Multi-chain onboarding expertise.** We have repeatedly helped teams expand from EVM to non-EVM chains (Rain: EVM → Solana + Stellar; Undisclosed Stablecoin Issuer: 20+ chains; Huma: Ethereum → Solana & Stellar). This gives us firsthand understanding of the paradigm-shift friction Canton developers report.
+4. **Full-stack operator tooling capability.** BlockSmith for Canton requires CLI tooling, web dashboards, Docker orchestration, Prometheus/Grafana integration, and upgrade automation. Our team runs this exact stack in production across multiple clients — this is applying proven patterns to a new domain, not R&D.
+5. **Sustained delivery at scale.** Top client retention rate, 97% of clients report higher delivery quality, and a 200+ person team means we can commit a dedicated pod to BlockSmith for Canton without straining other obligations.
+
+## **Team Background**
+
+### Core team
+
+Diogo Silveira Mendonça, Ph.D., PMP (Product & Engineering Lead): Full-stack engineer and Web3 specialist with over 20 years of experience in software engineering and around 7 years in the Web3 space, with leadership experience delivering blockchain related projects. Currently Head of Web3 LATAM at 57Blocks and a Canton / Daml Certified professional.
+
+Implementation Team: 57Blocks will allocate experienced engineers with knowledge of and experience with Canton as needed to execute the grant milestones under Diogo’s technical direction and product leadership. The company currently has engineers certified in Canton / Daml skillset, hands-on with Canton production deployments, and we are actively expanding our team of Canton professionals.
+
+## Contact
+
+For questions, feedback, or to coordinate review please reach out:
+
+Diogo Silveira Mendonça, Head of Web3 LATAM - diogo.silveira@57blocks.com  
+Kamil Krupa, Head of Web3 BU - kamil@57blocks.com  
+
+
+---
+
+## References
+
+- Canton Development Fund process: https://github.com/canton-foundation/canton-dev-fund
+- 2026 Canton DevEx survey analysis: https://discuss.daml.com/t/canton-network-developer-experience-and-tooling-survey-analysis-2026/8412
+- BlockSmith (57blocks): https://www.blocksmith.co/
+- Deploy Quickstart to DevNet (representative operator workflow): https://docs.digitalasset.com/build/3.3/quickstart/operate/deploy-quickstart-to-devnet.html
+- PQS observability primitives (metrics/logs/diagnostics): https://docs.digitalasset.com/build/3.3/component-howtos/pqs/observe.html
+- Upgrade to a new release (operator upgrade model): https://docs.digitalasset.com/operate/3.3/howtos/upgrade/index.html
+- CN App Quickstart FAQ (resource constraints, resets, ops gotchas): https://docs.digitalasset.com/build/3.3/quickstart/troubleshoot/cnqs-faq.html
+- Participant node health checks and health dumps: https://docs.digitalasset.com/operate/3.3/howtos/observe/health.html
+- Canton console operations (remote admin, db.migrate/migrate-and-start): https://docs.digitalasset.com/operate/3.3/howtos/operate/console/console.html
+- Log debugging with lnav (trace-id correlation, capture logs): https://docs.digitalasset.com/build/3.5/quickstart/operate/lnav-in-cn.html
+- gRPC Ledger API migration guide (3.2→3.3 breaking changes): https://docs.digitalasset.com/build/3.3/reference/lapi-migration-guide.html

--- a/proposals/57b_blocksmith_canton.md
+++ b/proposals/57b_blocksmith_canton.md
@@ -376,6 +376,9 @@ For questions, feedback, or to coordinate review please reach out:
 Diogo Silveira Mendonça, Head of Web3 LATAM - diogo.silveira@57blocks.com  
 Kamil Krupa, Head of Web3 BU - kamil@57blocks.com  
 
+## Sponsorship
+
+This proposal is sponsored by the Canton Foundation.
 
 ---
 

--- a/proposals/57b_blocksmith_canton.md
+++ b/proposals/57b_blocksmith_canton.md
@@ -378,7 +378,7 @@ Kamil Krupa, Head of Web3 BU - kamil@57blocks.com
 
 ## Sponsorship
 
-This proposal is sponsored by the Canton Foundation.
+This proposal is sponsored by the Canton Foundation. Please reach out to Bo Zhang for more information.
 
 ---
 

--- a/proposals/57b_blocksmith_canton.md
+++ b/proposals/57b_blocksmith_canton.md
@@ -1,7 +1,7 @@
 ## Development Fund Proposal
 
-**Author:** 57Blocks 
-**Status:** Submitted, revised 2026-05-26 
+**Author:** 57Blocks  
+**Status:** Submitted, revised 2026-05-26  
 **Created:** 2026-03-13
 
 ---
@@ -228,6 +228,7 @@ Each milestone is accepted on operator-validated outcomes. The primary operator 
 - The topology export is generated successfully in both Grafana panel and standalone HTML forms.
 - The MCP server runs on our validator and the CLI MCP client connects over SSH from an operator host. At least one real debugging scenario from our own bring-up is resolved using the AI assistant with citations.
 - Recordings and logs of the bring-up and an AI-assisted debugging run are published with the release.
+- The BlockSmith for Canton repository is public on GitHub under the Apache 2.0 license, with contribution guidelines so the Canton community can open issues, submit pull requests, and review the implementation.
 
 **M2 (TestNet) accepted when:**
 
@@ -274,6 +275,10 @@ Canton's validators are mostly institutional operators with strict compliance an
 **Diogo Silveira Mendonça, PhD, PMP.** Product and Engineering Lead. 20+ years in software engineering, ~7 years in Web3, Canton and Daml certified. Currently leading the bring-up of 57Blocks's own Canton validator.
 
 **Implementation team.** A dedicated pod with at least one Canton-certified engineer at all times. The Canton-certified roster is being expanded in anticipation of the grant. Implementation is accelerated by AI coding agents and validated against our own validator deployment as it progresses through DevNet, TestNet, and a MainNet-ready configuration.
+
+## Open-source maintenance 
+
+BlockSmith for Canton will be maintained as an open-source project under Apache 2.0. 57Blocks will assign a project lead responsible for reviewing community issues and pull requests, accepting external contributions when they fit the roadmap and quality bar, and keeping the tool updated as we continue using it internally for our own Canton validator operations.
 
 
 ## Contact

--- a/proposals/57b_blocksmith_canton.md
+++ b/proposals/57b_blocksmith_canton.md
@@ -1,8 +1,8 @@
 ## Development Fund Proposal
 
-**Author:** 57Blocks  
-**Status:** Submitted, revised 2026-05-26  
-**Created:** 2026-03-13  
+**Author:** 57Blocks 
+**Status:** Submitted, revised 2026-05-26 
+**Created:** 2026-03-13
 
 ---
 
@@ -21,7 +21,7 @@ Two surfaces share one workspace:
 
 **In 2026, AI-assisted tools are the baseline. BlockSmith brings that baseline to Canton validator operations. Running a Canton validator should feel as supported as everything else we use today — that's what we're building.**
 
-Delivered across three milestones over 12 weeks for **$60,000 USD-equivalent in Canton Coin**, validated against 57Blocks's own validator as it moves through DevNet, TestNet, and a MainNet-ready configuration.
+Delivered across three milestones over 12 weeks for **375,000 CC**, based on a 30-day average price of **$0.16 per CC**, validated against 57Blocks's own validator as it moves through DevNet, TestNet, and a MainNet-ready configuration.
 
 ---
 
@@ -204,13 +204,13 @@ Each of the components above covers an important slice of the ecosystem. The sli
 
 ### 3. Milestones and Funding
 
-Three end-to-end milestones in a 12-week build, one milestone per environment. Total funding: **$60,000 USD-equivalent in Canton Coin**. The weight of the milestones reflects the weight of the deliverables: M3 carries HA topology, audit trail, scaling, plugins, and the data-extraction pipeline, and gets the most weeks and the most budget.
+Three end-to-end milestones in a 12-week build, one milestone per environment. Total funding: **375,000 CC**, based on a 30-day average price of **$0.16 per CC**. The weight of the milestones reflects the weight of the deliverables: M3 carries HA topology, audit trail, scaling, plugins, and the data-extraction pipeline, and gets the most weeks and the most budget.
 
 | Milestone | Scope | Timing | Funding |
 |---|---|---|---|
-| **M1: DevNet** | Onboarding ceremony, Compose / dev bring-up against upstream `validator_compose`, full CLI for the lifecycle (`init`, `onboard`, `up/down/restart`, `reset`, `status`, `doctor`, `logs`, `collect-diagnostics`, `monitor`, `topology`, `connection-info`), plan/apply seam across mutating commands, pre-built Prometheus + Grafana + Loki dashboards, topology export (Grafana panel + standalone HTML), MCP server with the ~20-tool read-only surface, BlockSmith CLI MCP client with bring-your-own-model. AI assistant ships in read-only mode covering configuration help and debugging. | Weeks 1–3 | $18,000 |
-| **M2: TestNet** | TestNet onboarding ceremony, production deployment paths (Compose prod, K8s dev, K8s prod), operator security primitives (key handling, secret management via `.env` + bring-your-own external store, TLS via Let's Encrypt + bring-your-own-cert). Cloud infrastructure templates for AWS + EKS, validated against a real AWS account. AI assistant gains the command proposal flow and interactive walkthroughs of `infra plan` for operators new to AWS, all gated by operator approval through the plan/apply seam. | Weeks 4–7 | $20,000 |
-| **M3: MainNet** | MainNet-ready HA topology profile (multi-replica participant + synchronizer with documented failover), signed audit-trail JSON export covering operator actions and AI assistant approvals, scaling estimation (`scaling status`) reading PQS, plugin catalog with utility UI / darsyncer / PQS, managed PQS deployment, archive bridge to S3 in partitioned Parquet, security checklist aligned with Canton's operational guidance ready for a follow-on third-party security review. AI assistant gains scaling and plugin reasoning on top of the audit trail. | Weeks 8–12 | $22,000 |
+| **M1: DevNet** | Onboarding ceremony, Compose / dev bring-up against upstream `validator_compose`, full CLI for the lifecycle (`init`, `onboard`, `up/down/restart`, `reset`, `status`, `doctor`, `logs`, `collect-diagnostics`, `monitor`, `topology`, `connection-info`), plan/apply seam across mutating commands, pre-built Prometheus + Grafana + Loki dashboards, topology export (Grafana panel + standalone HTML), MCP server with the ~20-tool read-only surface, BlockSmith CLI MCP client with bring-your-own-model. AI assistant ships in read-only mode covering configuration help and debugging. | Weeks 1–3 | 112,500 CC |
+| **M2: TestNet** | TestNet onboarding ceremony, production deployment paths (Compose prod, K8s dev, K8s prod), operator security primitives (key handling, secret management via `.env` + bring-your-own external store, TLS via Let's Encrypt + bring-your-own-cert). Cloud infrastructure templates for AWS + EKS, validated against a real AWS account. AI assistant gains the command proposal flow and interactive walkthroughs of `infra plan` for operators new to AWS, all gated by operator approval through the plan/apply seam. | Weeks 4–7 | 125,000 CC |
+| **M3: MainNet** | MainNet-ready HA topology profile (multi-replica participant + synchronizer with documented failover), signed audit-trail JSON export covering operator actions and AI assistant approvals, scaling estimation (`scaling status`) reading PQS, plugin catalog with utility UI / darsyncer / PQS, managed PQS deployment, archive bridge to S3 in partitioned Parquet, security checklist aligned with Canton's operational guidance ready for a follow-on third-party security review. AI assistant gains scaling and plugin reasoning on top of the audit trail. | Weeks 8–12 | 137,500 CC |
 
 **Build vs. acceptance windows.** The 12-week timeline above is the *build* effort. Operator validation depends on Foundation-paced onboarding (notification review, IP whitelist, network acceptance) and can extend past the build window; milestone payments release on milestone *acceptance*. Where acceptance would otherwise depend on third-party approvals 57Blocks does not control (MainNet network acceptance, third-party security review), those approvals are reported as follow-on events and do not gate the milestone.
 

--- a/proposals/57b_blocksmith_canton.md
+++ b/proposals/57b_blocksmith_canton.md
@@ -1,14 +1,27 @@
 ## Development Fund Proposal
 
-**Author:**  57Blocks  
-**Status:** Submitted  
+**Author:** 57Blocks  
+**Status:** Submitted, revised 2026-05-26  
 **Created:** 2026-03-13  
 
 ---
 
 ## Abstract
 
-BlockSmith for Canton is an operator-first toolkit that makes deploying, connecting, monitoring, and upgrading Canton nodes feel closer to "standard practice" in mature ecosystems (EVM-style: strong deployment automation + dashboards + runbooks). It targets the ecosystem's highest-reported friction — **environment setup & node operations** — by shipping opinionated node templates, deterministic diagnostics, a **web UI** (BlockSmith Console for Canton) for one-click topology/connectivity + health visibility (including handshake-related indicators where exposed), and an upgrade/migration assistant for Canton and Daml. The grant funds an open-source common-good core; sustainability comes from optional paid Pro/Cloud add-ons (fleet management, hosted UI/dashboards, enterprise support) layered on top.
+Setting up a Canton validator today is a multi-step process that spans a Foundation notification form, an IP whitelist form, two separate quorum-acceptance flows, sponsor super-validator selection, version-aligned dependencies, and a deployment-shape decision tree, then keeping the result healthy as the active contract set grows over months. Each step is well documented on docs.sync.global; BlockSmith adds the connective tissue that coordinates across them and holds state across what is typically a multi-week timeline.
+
+**BlockSmith for Canton is a guided UX surface on top of that existing tooling.** It composes `validator_compose`, the Splice Helm charts, PQS, and the rest of the Canton stack rather than replacing them. It walks the operator through what's already there, holds state across the steps, plans every mutation before applying it, and is what the operator keeps using for day-2 maintenance, monitoring, scaling, and data archive.
+
+Two surfaces share one workspace:
+
+- **CLI**, the deterministic substrate. Scriptable, auditable, the surface for known operations and CI.
+- **AI assistant via the Model Context Protocol (MCP)**, the operator companion for configuration, debugging, scaling, and upgrades. The MCP server runs on the validator with a small deterministic tool surface; the model and the agent loop run on the operator's own host over an existing SSH connection. No LLM runs on the production validator.
+
+**Where the scope comes from.** Two operator perspectives shape every feature in this proposal. 57Blocks's own DevNet bring-up in May 2026 surfaced the day-0 friction that motivated the guided workflow and the AI assistant: Foundation notification, IP whitelist, quorum waits, sponsor super-validator selection, and the 503 sequencer-reachability case used as a worked example later. Direct review from an active Canton MainNet validator operator before submission reinforced what hurts after DevNet at production scale: the MCP-on-validator architecture (no LLM on the production node), plan-then-apply transparency, cloud infrastructure templates, dynamic scaling, the plugin catalog, and the data-extraction pipeline. What follows is what these two perspectives said hurt the most, not what we guessed might.
+
+**In 2026, AI-assisted tools are the baseline. BlockSmith brings that baseline to Canton validator operations. Running a Canton validator should feel as supported as everything else we use today — that's what we're building.**
+
+Delivered across three milestones over 12 weeks for **$60,000 USD-equivalent in Canton Coin**, validated against 57Blocks's own validator as it moves through DevNet, TestNet, and a MainNet-ready configuration.
 
 ---
 
@@ -16,382 +29,269 @@ BlockSmith for Canton is an operator-first toolkit that makes deploying, connect
 
 ### 1. Objective
 
-Deliver an open, production-minded node-ops toolkit that:
+Canton validator setup is multi-step today, and the operational side after setup adds its own complexity. The validator API may return 503 because one sequencer endpoint is currently unreachable from the operator's network. A given sponsor super-validator's onboarding-secret endpoint may be temporarily unavailable, so the operator selects an alternate from the dozen-plus candidates listed by the Scan API. Upgrades can encounter Migration ID mismatches that need resolution. The validator's own Splice ans-web-ui needs to be locked down before a wider audience touches it. For cloud deployments, aligning cloud resources (VPC, IAM, RDS, security groups, storage classes) with what the validator needs is itself a significant effort. After bring-up the participant needs more CPU and disk, and the operator wants to extract ledger data to long-term object storage for compliance.
 
-- Reduces time-to-healthy Canton node setup from "days of infra debugging" to "hours/minutes with deterministic checks."
-- Makes node connectivity and key health state visible via a simple topology dashboard.
-- Provides operator-grade monitoring defaults (metrics, dashboards, alerting) as a one-command bundle.
-- Makes upgrades and migrations less risky through an upgrade assistant, compatibility matrix, and scripted runbooks.
+Today the typical operator loop is to run a CLI command, copy a log slice into a separate tab, paste it into a general-purpose chat tool alongside whatever context can be manually assembled, and apply suggested fixes back in. 57Blocks worked through this loop while bringing up our own DevNet validator, and BlockSmith is the tool we're building to turn the entire flow into a single guided experience on top of what Canton already ships.
 
-**Target users**
+**Target users.** Validator operators running Canton participant nodes on DevNet, TestNet, and MainNet, on Docker Compose or Kubernetes, on a self-managed VM or a cloud account. Application developers benefit indirectly: the same bring-up shipped for operators is what they would use if they want a real node alongside their Daml work. Sandbox and `cn-quickstart` remain the right entry points for daily contract iteration.
 
-- **Node operators / infrastructure teams** (participants, integrators): need reliable deployment, monitoring, and upgrades.
-- **App teams**: benefit indirectly from faster onboarding and fewer "infrastructure rabbit holes".
+**Success criteria.** The operator experience improves measurably across the full validator lifecycle, from DevNet through TestNet to a MainNet-ready configuration. Some steps will always live outside the tool (submitting forms to the Foundation, running `terraform apply` with the operator's own credentials, waiting for network acceptance); BlockSmith generates the inputs for those steps, holds state across the wait, and resumes the operator into what comes next.
 
-**Success looks like:**
-
-- A new team can deploy a reference topology and reach "connected + healthy" state with deterministic checks and dashboards.
-- Operators can verify connectivity and key health indicators without tailing logs, and can detect common failure modes via `doctor`.
-- Upgrades are guided by a tool-generated plan and verified preflight checks, reducing downtime and trial-and-error.
-
----
+- Operators get guided support at every step. When they need something, BlockSmith either configures it directly or makes the manual step clearly actionable with the right inputs and the next command ready to run.
+- Onboarding decisions reduce to a small number of upfront choices (environment, deployment shape); everything else is generated from those choices.
+- Persistent state on disk survives interruptions: operators close the laptop while Foundation review is pending and resume from where they left off.
+- Day-2 operations (maintenance, monitoring, scaling, plugins, data archive) live in the same tool as the bring-up, so the operator doesn't switch tools or re-read docs as the deployment matures.
+- Every mutating command shows a plan before applying. The operator reviews the diff before BlockSmith touches anything.
+- The AI assistant is available across the lifecycle (configuration, debugging, scaling, upgrades) and accepts natural-language questions when the right CLI command isn't obvious to the operator yet.
+- At the end of the engagement, operators describe the setup as more tractable than expected and the tool as supportive at each step, not as a black box or a pointer to more documentation to read.
 
 ### 2. Implementation Mechanics
 
-#### Component overview
+#### Walkthrough (DevNet, Docker Compose, dev configuration)
 
-**1) Unified operator CLI (entrypoint)**
+The walkthrough below is the bring-up 57Blocks is running on our own validator: two CLI sessions separated by a week of Foundation-paced waiting, and then the AI assistant for the part where something goes wrong.
 
-A single CLI (`blocksmith-canton`) that provides:
+**Day 0. Workspace setup and the onboarding ceremony.**
 
-- `blocksmith-canton init`: create an opinionated node workspace (configs, secrets stubs, directory layout, environment profiles).
-- `blocksmith-canton up|down|restart`: bring up/down a topology in a reproducible way (local-dev via Docker Compose in grant scope).
-- `blocksmith-canton status`: health summary across nodes and APIs, including "what's broken and why".
-- `blocksmith-canton logs`: structured log access and known-issue signatures.
-- `blocksmith-canton doctor`: deterministic diagnostics (ports, docker prerequisites, JVM, time drift, TLS/certs where applicable, API reachability, and connectivity indicators).
+```
+$ blocksmith-canton init
 
-**1a) DevNet/Quickstart operator automation (make the "hard parts" one command)**
+  ? What environment? .................. DevNet
+  ? Deployment shape? .................. Docker Compose, dev
 
-Codify and automate the operational primitives that appear repeatedly in real-world guides:
+  Workspace created at ./my-validator
+  Sizing check: disk 40 GB, RAM 16 GB, CPU 4 vCPU       ok
+  Dependency check: docker compose, curl, jq            ok
 
-- **Network info discovery**: fetch and validate values like "migration id" and active version where applicable, and persist them as artifacts for repeatable starts ([Deploy Quickstart to DevNet](https://docs.digitalasset.com/build/3.3/quickstart/operate/deploy-quickstart-to-devnet.html)).
-- **Onboarding secret workflow**: support known sponsor-SV endpoints where accessible, and always support manual secret input + TTL checks (guides note secrets may be short-lived and are often the first troubleshooting step).
-- **Host-based routing helpers**: generate `/etc/hosts` entries and validate required hostnames for local routing (nginx virtual hosting is used in Quickstart/validator setups).
-- **Profiled start commands**: generate (or wrap) the correct `start` command arguments for common flows (e.g., sponsor SV URL, onboarding secret, party hint, migration id, wait-for-ready, auth enabled).
-- **Reset semantics**: provide a safe "reset" that removes stale containers/volumes when needed (guides often recommend a clean `down -v` to resolve unhealthy/stale states).
+  Step 1 of 4: Notify the Foundation
+    Form payload generated. Submit at https://forms.canton.foundation/...
+  Step 2 of 4: Whitelist your IP for DevNet
+    Detected 34.28.122.5. Submitted.
+  Step 3 of 4: Wait for network acceptance (typically 2 to 7 days)
+    Polling hourly in the background. Close the terminal anytime.
+      Super-validators:  ██████████████░░░░░░    14/20 (70%)   reached
+      Sequencers:        █████████░░░░░░░░░░░     9/20 (45%)   waiting
+```
 
-**2) Opinionated node deployment templates ("golden paths")**
+The workspace holds the tool's state on disk. The operator closes the terminal, comes back days later, and `blocksmith-canton` picks up where it left off.
 
-Provide versioned, well-documented templates that teams can fork and adapt:
+**Day 7. Both quorums met. Plan, then apply the bring-up.**
 
-- **Local-dev**: single-machine Docker Compose topology suitable for onboarding and integration testing.
-- **Team-dev** (post-grant / commercial or follow-on): Helm charts for a shared dev cluster, with sane defaults and clear overrides.
+```
+$ blocksmith-canton up --plan
+  Selecting sponsor super-validator... 4 of 13 currently responding with valid secrets.
+    Using: sv-candidate-04 (selection redacted; chosen automatically by reachability).
+  Files to write:    .env (MIGRATION_ID=1, IMAGE_TAG=0.6.3), compose.override.yaml
+  Containers to start: postgres, participant, ans-web-ui, validator
+  Apply with: blocksmith-canton up --apply
 
-**3) BlockSmith Console for Canton (web UI) + monitoring/observability (one-click)**
+$ blocksmith-canton up --apply
+  Writing .env, compose.override.yaml                  ok
+  splice-validator-postgres-splice-1      healthy
+  splice-validator-participant-1          healthy
+  splice-validator-ans-web-ui-1           healthy
+  splice-validator-validator-1            unhealthy (still trying)
 
-The Canton DevEx survey explicitly calls for "one-click visual dashboards" to validate node handshakes without complex terminal commands, and a more visual, human-friendly debugging experience ([survey analysis](https://discuss.daml.com/t/canton-network-developer-experience-and-tooling-survey-analysis-2026/8412)). BlockSmith for Canton ships a real UI as a first-class deliverable:
+  Validator API returns 503. Run `blocksmith-canton ask` to investigate.
+```
 
-- `blocksmith-canton ui up|down`: start the BlockSmith Console for Canton locally (and connect it to your topology).
-- **Setup wizard**: guided bring-up of a "golden path" topology (local-dev first), including routing prerequisites and connectivity checks.
-- **Topology/connectivity graph**: participant↔synchronizer connectivity and health indicators, with actionable next steps on failure. Handshake-specific status is shown where exposed by the deployment's health/status surfaces.
-- **Health & readiness**: unified health view (gRPC/HTTP/admin where available), plus links to the relevant logs and suggested fixes.
-- **Observability bundle**: `blocksmith-canton obs up|down` starts a bundled stack (Prometheus + Grafana + log aggregation where feasible) and the UI deep-links into relevant dashboards.
-- **Diagnostics center**: download a single support-quality archive (`collect-diagnostics`) and view what is inside (versions, health summaries, key logs).
-- **Connection artifact export**: export a single machine-readable file (JSON) that captures "what to connect to" for operators and app teams (endpoints/ports/hostnames, enabled auth mode, and detected version info where available). This directly reduces the "opaque discovery" friction called out in the survey.
-- **Auth/JWT checklist page**: a guided checklist for common auth setups (OIDC/JWT), plus "is auth enabled?" checks where visible from configuration/health surfaces. (This is guidance + validation, not a full managed identity product.)
-- **Package visibility (where exposed)**: a simple "Packages" page that lists installed packages/DARs when the deployment exposes a supported API for it; otherwise, the UI shows the operator which API/setting to enable to make package discovery possible.
+A meaningful share of the DevNet bring-ups we've watched land here on the first attempt: most containers come up healthy, one container does not.
 
-In addition to the BlockSmith Console for Canton UI, prebuilt dashboards covering "golden signals" for node operations (liveness, API availability, error rates, resource usage) and Canton-specific connectivity indicators where available will be provided.
+**Day 7, a few minutes later. The AI assistant investigates.**
 
-Observability choices explicitly align with established component patterns where available. For example, PQS exposes metrics (including Prometheus exposition), structured logging controls, and diagnostics export (metrics + thread dumps) that are natural inputs to a bundled operator dashboard and "collect diagnostics" command ([PQS Observe](https://docs.digitalasset.com/build/3.3/component-howtos/pqs/observe.html)).
+```
+$ blocksmith-canton ask "validator readyz keeps returning 503"
+  [connecting to my-validator via mcp-over-ssh ... ok]
+  [model: claude-sonnet-4 · 7 sec]
 
-**4) Upgrade & migration assistant (Canton + Daml)**
+  The participant container can't reach one of the configured sequencers from this
+  network position.
+  Recent log line: "Stopping internal-sequencer-connection-SEQ:: sequencer-02 ..."
+  Source: docs.sync.global validator network requirements 3.2.
 
-Reduce the operational burden of upgrades:
+  Probing sequencer reachability...
+    sequencer-01    reachable
+    sequencer-02    unreachable (TCP timeout)
+    sequencer-03    reachable
+    sequencer-04    reachable
 
-- `blocksmith-canton upgrade plan`: detect current versions, compare against a target, and generate a step-by-step plan (including preflight checks).
-- `blocksmith-canton upgrade preflight`: validate prerequisites, config compatibility, and run smoke checks in a staging profile.
-- Maintain a public **compatibility matrix** and "known pitfalls" playbooks for supported versions.
+  3 of 4 reachable. Quorum is 2/3; you meet it.
+  Restart to force fresh sequencer selection? [y/N]
+```
 
-The upgrade assistant is grounded in the official "upgrade to a new release" model: upgrading binaries/config and applying database schema migrations (e.g., Flyway), then separately coordinating protocol version changes across nodes — with explicit emphasis on backups/testing and the reality that certain migrations cannot be rolled back once started ([Upgrade To a New Release](https://docs.digitalasset.com/operate/3.3/howtos/upgrade/index.html)).
+Every fact in this example is from a real debugging session during our own bring-up between May 7 and May 13, 2026. We will publish recordings and logs of the bring-up and an AI-assisted debugging slice with the M1 release so reviewers can see BlockSmith working in practice against a real Canton DevNet rather than evaluating a sketch.
 
-The assistant focuses on repeatable operational steps and validations. It does not attempt to "magically fix" protocol-level incompatibilities; instead it makes them visible early and provides safe, operator-friendly workflows.
+#### Commands
 
-#### Technical approach (high level)
+Every mutating command goes through plan first. Lifecycle commands use `--plan` / `--apply` flags; workflow commands use explicit `plan` / `apply` subcommands. File diffs are unified-diff, container diffs are before/after summaries, cloud IaC diffs reuse `terraform plan` and `cdk diff` so the operator applies with their existing pipeline.
 
-- CLI implemented in a widely adopted language for devops tooling (Rust or Go), designed for extensibility (subcommands/plugins).
-- Orchestration via Docker Compose in grant scope (lowest friction); Helm charts are post-grant/follow-on.
-- Health checks via HTTP/gRPC endpoints where available; plus log signature detection for known failure states.
-- Observability shipped as versioned assets and started via a single command.
-- Upgrade assistant built around explicit version detection, preflight validation, and scripted steps with checkpoints.
+| Command | Purpose |
+|---|---|
+| `init` | Create workspace; choose environment and deployment shape; run sizing and dependency checks. |
+| `onboard notify\|whitelist\|quorum` | Run individual onboarding sub-flows: form payloads, IP whitelist, quorum tracking. |
+| `up\|down\|restart` | Lifecycle of the deployment with `--plan` / `--apply`. |
+| `reset --mode safe\|full` | Clean reset; `full` also drops volumes (useful for DevNet recovery scenarios). |
+| `status`, `doctor`, `logs`, `collect-diagnostics` | Health, deterministic checks, structured log access, redacted support bundle. |
+| `ask`, `chat` | One-shot or interactive AI assistant via MCP. From M2, proposes mutating actions for operator approval. |
+| `monitor up\|down` | Bring up Prometheus + Grafana + Loki alongside the deployment with BlockSmith's pre-built dashboards (handshake state, sequencer connectivity, ledger advancement, sponsor SV history, alerts). |
+| `topology` | Topology and connectivity graph as an interactive Grafana panel or self-contained HTML artifact. Answers the 2026 DevEx survey's "one-click visual dashboard" ask. |
+| `connection-info` | Emit machine-readable JSON of reachable endpoints, auth mode, and version info for integrating teams. |
+| `upgrade plan\|preflight\|apply` | Guided upgrade workflow grounded in the Splice validator-upgrade documentation. |
+| `infra plan\|apply --cloud=aws\|gcp\|azure --shape=docker\|k8s-dev\|k8s-prod` | Generate reference IaC sized to the workspace (Terraform module for AWS in M2). BlockSmith never holds cloud credentials; the operator runs `terraform apply`. |
+| `pqs up\|down\|status` | Deploy and lifecycle-manage the Participant Query Store as a sibling component. |
+| `archive plan\|apply\|status` | Stream PQS data to S3 (M3), GCS, or Azure Blob in partitioned Parquet, with operator-defined redaction. Resumable against the PQS offset. |
+| `scaling status` | Read CPU/RAM/disk pressure and ACS growth from PQS; emit a sizing recommendation with concrete numbers; feed into `infra plan --resize-from-recommendation`. |
+| `plugin list\|enable\|disable` | Catalog of optional Splice components (utility UI, darsyncer, PQS) shipped as first-party plugins. Documented contract for third-party plugins. |
 
-#### Non-goals (explicitly out of scope)
+#### Monitoring, cloud, day-2, data archive
 
-- Replacing Canton core components or modifying protocol behavior.
-- Building a full explorer/indexer.
-- Providing a proprietary-only solution: the funded deliverables are open-source and usable by the whole ecosystem (commercial options are additive).
+BlockSmith does not add a parallel operations console. Canton operators already use Grafana for metrics, Loki for logs, and the validator's own Splice UIs for participant operations. `monitor up` deploys Prometheus + Grafana + Loki with BlockSmith's pre-built dashboards aligned to the Canton-published observability baseline. `topology` and `connection-info` produce artifacts that open in the operator's existing tools, not a new browser tab to bookmark.
 
-#### Sustainability model (open core)
+For cloud, `infra plan --cloud=aws --shape=k8s-prod` generates a Terraform module for an EKS-based validator (VPC, IAM, EKS, RDS, security groups, storage classes) sized to the workspace. The operator runs `terraform init && plan && apply` with their own credentials. M2 ships AWS + EKS validated against a real AWS account; GCP and Azure architectures use the same templating engine and are follow-on paths.
 
-To ensure long-term sustainability, BlockSmith for Canton uses an **open-core** model:
+For day-2 operations, `scaling status` reads the participant's CPU/RAM/disk and ACS growth from PQS and emits a sizing recommendation that feeds back into `infra plan`. The `plugin` catalog ships utility UI, darsyncer, and PQS as first-party plugins; the contract is documented so third parties can add their own.
 
-- **Open-source core (grant-funded)**: CLI, templates, BlockSmith Console for Canton, dashboards, diagnostics, upgrade playbooks, and compatibility matrix.
-- **Paid Pro/Cloud add-ons (post-grant, optional)**: fleet management across multiple environments, hosted Console UI/dashboards + alert routing (Slack/PagerDuty), role-based access control, compliance reporting, long-term support (LTS) builds, and enterprise onboarding/support packages.
+For long-term data storage, `pqs up` deploys the Participant Query Store as a managed sibling component (we don't replace it; we package and operate it), and `archive plan|apply` streams its output into S3 in partitioned Parquet with operator-defined redaction, resumable against the PQS offset. Cold-storage targets in M3 are S3-first; GCS and Azure Blob are follow-on paths on the same engine.
 
-This structure keeps the ecosystem's fundamentals open while enabling a sustainable business to maintain and evolve the tool.
+#### AI assistant via MCP
+
+The AI assistant is the operator companion across the lifecycle: configuration choices on first setup, cloud walkthroughs, debugging, scaling decisions, upgrade reasoning. The CLI is the deterministic substrate for known operations; the assistant is the surface for the open-ended ones.
+
+```
+[operator's host]
+  blocksmith-canton ask "..."
+       │  ssh validator-vm "blocksmith-mcp serve --stdio"
+       ▼
+[validator] blocksmith-mcp serve --stdio
+            started by SSH, dies when the CLI exits, runs as the operator's SSH user
+            ~30-tool surface: read logs, check ports, query Scan API, inspect
+            workspace, generate Compose/Helm/Terraform diffs, query PQS,
+            archive status (from M2: gated mutating tools)
+```
+
+No new port on the validator, no TLS cert to provision, no daemon. The MCP server is small, audited, and deterministic. There is no LLM, no embeddings, no outbound network call on the validator. The model backend is the operator's choice (Claude, AWS Bedrock, Azure OpenAI, OpenAI, or a local Ollama on the laptop), configured once in `~/.blocksmith/config.yaml`. Because the protocol is the open Anthropic MCP standard, operators already using Claude Code or Cursor can point those at the same server.
+
+Read-only across the wire in M1 (logs, port checks, workspace inspection). M2 adds a small set of mutating tools (apply config diff, restart container, advance archive offset) that always go through the plan/apply seam. M3 writes every assistant suggestion and operator approval to the audit-trail described in the MainNet milestone.
+
+#### How BlockSmith fits with existing Canton tooling and differs from existing alternatives
+
+BlockSmith composes upstream Canton tooling rather than replacing it. The table below covers the components we call into and the proposals adjacent to ours:
+
+| Existing component or alternative | Relationship |
+|---|---|
+| `validator_compose`, Splice Helm charts | BlockSmith generates `.env`, compose overrides, and `values.yaml` against the upstream files. Not vendored. |
+| Scan API | Polled to compute quorum, sponsor SV selection, and the topology graph. |
+| Validator notification + IP whitelist forms | BlockSmith generates form payloads; submission and Foundation review remain human-in-the-loop. |
+| Validator upgrade documentation | `upgrade plan/preflight/apply` reproduces the documented procedure as a guided flow. |
+| Participant Query Store (PQS / `scribe`) | Deployed and lifecycle-managed by `pqs`; output flows into the `archive` bridge. Not replaced. |
+| Splice utility UI, darsyncer | First-party plugins in the catalog. |
+| Anthropic Model Context Protocol | BlockSmith ships an MCP server with operator tools. Any MCP client (Claude Code, Cursor, BlockSmith CLI) can connect. |
+| **`cantonctl`** | Project-local, Splice-aware developer orchestration. Its scope is the developer's local workspace; BlockSmith covers the complementary surface of validator onboarding to real networks and ongoing operations. The two are compatible alongside one another. |
+| **Canton DevKit (#18)** | Local Daml developer environment for application developers. Sits next to BlockSmith rather than overlapping with it. |
+| **#324 Canton MCP + Skills** | MCP server for Daml/Canton **developers** (docs search, scaffolds, lint). BlockSmith's MCP is for **operators** (logs, container health, infra diffs, PQS, archive). Complementary; both can be plugged into Claude Code or Cursor on the same workstation. |
+| **#148 Operator Console** | Runtime-admin Web UI for already-running nodes. BlockSmith targets the onboarding-through-day-2 lifecycle and uses Grafana plus the existing Splice UIs for browser views, so the two surfaces are complementary. |
+| **#136 Observability Standard** | Adopted by the monitoring helper, not redefined. |
+| **#64 Launchpad** | Adjacent infra config generation; BlockSmith wraps the workflow around it. |
+
+Each of the components above covers an important slice of the ecosystem. The slice BlockSmith focuses on is the operator's path from "I want to be a Canton validator" to a healthy MainNet validator, plus the day-2 operations that follow.
+
+#### Non-goals
+
+- Not a replacement for any upstream Canton component (`validator_compose`, Helm charts, PQS, observability standard). BlockSmith composes them.
+- Not a cloud-provisioning service. BlockSmith generates reference IaC; the operator runs `terraform apply` with their own credentials.
+- Not a runtime-admin Web UI. We ship Grafana dashboards and a topology export, not a new operations console.
+- Not an autonomous operator. The AI assistant is read-only in M1 and gated by operator approval through the plan/apply seam from M2 onward.
+
+### 3. Milestones and Funding
+
+Three end-to-end milestones in a 12-week build, one milestone per environment. Total funding: **$60,000 USD-equivalent in Canton Coin**. The weight of the milestones reflects the weight of the deliverables: M3 carries HA topology, audit trail, scaling, plugins, and the data-extraction pipeline, and gets the most weeks and the most budget.
+
+| Milestone | Scope | Timing | Funding |
+|---|---|---|---|
+| **M1: DevNet** | Onboarding ceremony, Compose / dev bring-up against upstream `validator_compose`, full CLI for the lifecycle (`init`, `onboard`, `up/down/restart`, `reset`, `status`, `doctor`, `logs`, `collect-diagnostics`, `monitor`, `topology`, `connection-info`), plan/apply seam across mutating commands, pre-built Prometheus + Grafana + Loki dashboards, topology export (Grafana panel + standalone HTML), MCP server with the ~20-tool read-only surface, BlockSmith CLI MCP client with bring-your-own-model. AI assistant ships in read-only mode covering configuration help and debugging. | Weeks 1–3 | $18,000 |
+| **M2: TestNet** | TestNet onboarding ceremony, production deployment paths (Compose prod, K8s dev, K8s prod), operator security primitives (key handling, secret management via `.env` + bring-your-own external store, TLS via Let's Encrypt + bring-your-own-cert). Cloud infrastructure templates for AWS + EKS, validated against a real AWS account. AI assistant gains the command proposal flow and interactive walkthroughs of `infra plan` for operators new to AWS, all gated by operator approval through the plan/apply seam. | Weeks 4–7 | $20,000 |
+| **M3: MainNet** | MainNet-ready HA topology profile (multi-replica participant + synchronizer with documented failover), signed audit-trail JSON export covering operator actions and AI assistant approvals, scaling estimation (`scaling status`) reading PQS, plugin catalog with utility UI / darsyncer / PQS, managed PQS deployment, archive bridge to S3 in partitioned Parquet, security checklist aligned with Canton's operational guidance ready for a follow-on third-party security review. AI assistant gains scaling and plugin reasoning on top of the audit trail. | Weeks 8–12 | $22,000 |
+
+**Build vs. acceptance windows.** The 12-week timeline above is the *build* effort. Operator validation depends on Foundation-paced onboarding (notification review, IP whitelist, network acceptance) and can extend past the build window; milestone payments release on milestone *acceptance*. Where acceptance would otherwise depend on third-party approvals 57Blocks does not control (MainNet network acceptance, third-party security review), those approvals are reported as follow-on events and do not gate the milestone.
+
+**Development methodology.** 57Blocks engineers use AI coding agents in production every day on other Web3 client engagements. The 12-week scope reflects that velocity: a small dedicated pod with AI-assisted development covers ground a larger team or a longer timeline would otherwise need. Deliverables, code, and documentation are produced and reviewed by the human team.
+
+### 4. Acceptance Criteria
+
+Each milestone is accepted on operator-validated outcomes. The primary operator is 57Blocks itself, driving its own validator through DevNet, TestNet, and a MainNet-ready configuration on BlockSmith.
+
+**M1 (DevNet) accepted when:**
+
+- 57Blocks's DevNet validator is up and healthy (Validator API responsive, ledger advancing, super-validator and sequencer quorum confirmed), brought up end-to-end through the BlockSmith CLI with the four-step ceremony driven by the tool.
+- At least one mutating command is exercised through the plan/apply seam, with the plan output published.
+- The monitoring helper produces a working Prometheus + Grafana + Loki stack with BlockSmith's pre-built dashboards.
+- The topology export is generated successfully in both Grafana panel and standalone HTML forms.
+- The MCP server runs on our validator and the CLI MCP client connects over SSH from an operator host. At least one real debugging scenario from our own bring-up is resolved using the AI assistant with citations.
+- Recordings and logs of the bring-up and an AI-assisted debugging run are published with the release.
+
+**M2 (TestNet) accepted when:**
+
+- 57Blocks's validator is promoted to TestNet using BlockSmith.
+- At least one production deployment path (Compose prod, K8s dev, K8s prod) is exercised end-to-end and passes operator security checks (key handling, TLS, no plaintext secrets in the workspace). The other two production paths are smoke-validated in a staging deployment.
+- The AWS + EKS Terraform module is generated by `infra plan`, validated against a real AWS account, and the operator's `terraform apply` is documented and executed end-to-end.
+- The AI assistant's command proposal flow is functional. Every mutating tool call passes through operator approval via the plan/apply seam.
+
+**M3 (MainNet) accepted when:**
+
+- BlockSmith drives 57Blocks's validator to a MainNet-ready configuration with the HA topology profile, validated against a production-equivalent deployment.
+- The signed audit-trail export is produced (covering operator actions, AI suggestions, operator approvals) and the Canton-aligned security checklist is in place.
+- PQS is deployed via `blocksmith-canton pqs` and feeding the archive bridge. At least one archive run lands in S3 in partitioned Parquet and is queryable from an analytics workspace.
+- The plugin catalog has utility-ui and darsyncer enabled successfully on at least one deployment.
+- `scaling status` produces a recommendation on a real workload.
+- MainNet network acceptance and any independent third-party security review are reported as follow-on events and do not gate this milestone.
 
 ---
 
-### 3. Architectural Alignment
+## Ecosystem Benefit
 
-This proposal aligns with Development Fund priorities as it delivers:
+The 2026 Canton Developer Experience and Tooling Survey identified environment setup and node operations as a top friction across the ecosystem. The Canton validator population is small relative to the Daml developer population, which makes the per-operator value of any onboarding-time reduction high: every new validator that joins the network after BlockSmith ships is in the addressable population, as is every existing operator promoting across environments.
 
-- **Critical ecosystem infrastructure** and **developer/operator tooling** used by multiple participants ([fund repo](https://github.com/canton-foundation/canton-dev-fund)).
-- Direct response to the survey's top friction: environment setup & node operations, plus the high-demand area of observability/topology dashboards ([survey analysis](https://discuss.daml.com/t/canton-network-developer-experience-and-tooling-survey-analysis-2026/8412)).
+BlockSmith reduces operator effort and tribal-knowledge cost for:
 
-The scope is deliberately bounded to operator tooling and does not touch Canton core protocol components, smart contract execution, or ledger storage. All deliverables are additive, open-source, and composable with existing Canton infrastructure.
+- New validator teams onboarding to DevNet for the first time.
+- Existing validators promoting their setup across DevNet, TestNet, and MainNet.
+- Operators on Kubernetes / EKS: aligning cloud resources with the validator's needs is condensed into a reproducible cycle of `infra plan` plus `terraform apply` with the operator's own credentials.
+- Recovery scenarios where an operator must rebuild a node from a workspace.
+- Hackathon and proof-of-concept validator deployments that today get blocked on infrastructure setup before they reach application work.
+- Operators carrying ledger data for compliance and analytics: BlockSmith deploys PQS and bridges its output into cold object storage.
+- Operators in regulated environments who cannot run an LLM on the production validator: the MCP architecture keeps the model on the operator's chosen host.
 
----
-
-### 4. Backward Compatibility
-
-*No backward compatibility impact.* BlockSmith for Canton is entirely additive — a standalone CLI, web UI, and observability bundle that wraps and observes existing Canton components via published health/gRPC/HTTP APIs. It does not modify Canton core components, protocol behavior, or existing node configurations. Teams can adopt incrementally without disrupting any running infrastructure.
-
----
-
-## Milestones and Deliverables
-
-### Milestone 1: Golden-path bootstrap + console foundation
-
-- **Estimated Delivery:** ~4–5 weeks from project kickoff
-- **Focus:** Core CLI, environment automation, and the initial BlockSmith Console for Canton web UI
-- **Deliverables / Value Metrics:**
-  - `blocksmith-canton init/up/down/status/logs/doctor`
-  - `blocksmith-canton preflight`: environment readiness checks (Docker resources, ports, routing prereqs)
-  - `blocksmith-canton reset --mode safe|full` with explicit "what will be removed" output
-  - `blocksmith-canton env doctor` detecting common corporate TLS/proxy failure modes with actionable remediation
-  - DevNet operator automation: network info discovery, onboarding secret workflow, host-based routing helpers, profiled start commands, and reset semantics
-  - **BlockSmith Console for Canton**: local web UI showing topology status, node health summary, and "next actions" on common failures
-  - **Connection artifact export**: export endpoints/ports/hostnames and operator notes into a single JSON file
-  - Versioned Local-dev template (Docker Compose) with a reference topology
-  - Documentation: "operator quickstart" and troubleshooting guide
-  - CI for releases and reproducible artifacts
-
-### Milestone 2: Observability + console expansion + diagnostics
-
-- **Estimated Delivery:** ~4–5 weeks after Milestone 1
-- **Focus:** Full observability bundle, expanded web UI, and diagnostics tooling
-- **Deliverables / Value Metrics:**
-  - `blocksmith-canton obs up|down` to run the observability bundle
-  - Prebuilt dashboards + basic alert rules for the reference topology
-  - **BlockSmith Console for Canton (expanded)**:
-    - Topology/connectivity graph with actionable guidance
-    - Health drill-down (link to failing component checks)
-    - Deep links to relevant Grafana dashboards/log views
-    - Auth/JWT checklist page + basic validations
-    - Package visibility page (where exposed)
-  - `blocksmith-canton collect-diagnostics`: gather logs, metrics snapshots, and component diagnostics exports into a single archive suitable for issue reports (where supported by components such as PQS)
-  - `blocksmith-canton health`: unified health view (gRPC/HTTP health + operator-friendly summary)
-  - `blocksmith-canton logs capture`: standardized log capture with optional `lnav` bootstrap for trace-id and component filtering
-
-### Milestone 3: Upgrade planning + hardening + adoption package
-
-- **Estimated Delivery:** ~4–6 weeks after Milestone 2
-- **Focus:** Upgrade and migration assistant, expanded diagnostics, and external pilot onboarding
-- **Deliverables / Value Metrics:**
-  - `blocksmith-canton upgrade plan/preflight` (guarded workflows)
-  - Version detection + compatibility matrix + "known pitfalls" playbooks
-  - Staging profile + smoke-test script for upgrades
-  - **Upgrade Wizard (in the BlockSmith Console for Canton)**:
-    - Detects current node versions and protocol versions where exposed via health/status surfaces
-    - Generates an operator runbook aligned with Canton's documented upgrade flow (backup → config parse with `--manual-start` → `db.migrate` when needed → reconnect/ping)
-    - Generates copy/paste-ready Canton console scripts for the safest verifications (e.g., `health.status`, `health.dump`, `health.ping`, `synchronizers.list_connected`)
-    - Provides protocol-upgrade guidance (plan-only) that reflects Canton's constraints: protocol upgrades require a new synchronizer and participant migration (no in-place protocol upgrade for a synchronizer)
-  - `blocksmith-canton daml check`: SDK/runtime consistency verification and guided "repair" workflow for common local SDK corruption scenarios
-  - `blocksmith-canton compat report`: compatibility report (node version, protocol version, client API expectations) for change management and approvals
-  - Expanded doctor rules and dashboards based on pilot feedback
-  - Adoption package: onboarding docs, runbooks, and sample CI checks
-  - Stable versioning and a published roadmap
-  - At least 2 pilot teams/operators (external or partner teams) complete documented onboarding and provide actionable feedback/issues
-
----
-
-## Acceptance Criteria
-
-The Tech & Ops Committee will evaluate completion based on:
-
-- Deliverables completed as specified for each milestone
-- Demonstrated functionality or operational readiness
-- Documentation and knowledge transfer provided
-- Alignment with stated value metrics
-
-**Milestone 1 — specific criteria:**
-
-- A fresh machine (Docker installed) can bring up the reference topology and reach "healthy" status in a deterministic way.
-- `status` clearly indicates each node/service as Healthy/Unhealthy with an actionable reason.
-- `doctor` detects at least 10 common setup/connectivity failures with clear remediation steps.
-- The tool can generate/validate host-based routing prerequisites for local setups (where required by the topology), and can "reset" cleanly to remove stale volumes when troubleshooting calls for it (mirroring common guidance in operational docs).
-
-**Milestone 2 — specific criteria:**
-
-- With one command, an operator can open dashboards and verify "connected + healthy" without tailing logs.
-- Topology view reflects current health/connectivity indicators with short periodic refresh and suggests next actions on failure.
-- Diagnostics command produces a single archive that materially improves bug reports (includes timestamps, versions, and the key health signals).
-
-**Milestone 3 — specific criteria:**
-
-- Given a supported source→target upgrade pair, the tool generates an upgrade plan and preflight checks catch misconfigurations before changes are applied.
-- Upgrade preflight produces a clear checklist and documented rollback guidance (tool-generated runbook).
-- Protocol upgrade plan includes the concrete documented steps and prerequisites (e.g., enable repair commands, idle participants, disconnect/reconnect, and run a migration command) without executing them automatically.
-- At least 2 pilot teams/operators (external or partner teams) complete documented onboarding and provide actionable feedback/issues.
-
----
-
-## Funding
-
-**Total Funding Request:** $98,000 USD equivalent in Canton Coin (CC), milestone-based
-
-Funding on the Development Fund is denominated in **Canton Coin (CC)**. The budget below is a **USD-equivalent** to make the request concrete; milestone payments would be paid in CC using an agreed conversion method at the time of payment (e.g., a spot or trailing-average CC/USD rate agreed with Tech & Ops).
-
-**Team & cost assumptions**
-
-- **Tech lead**: 0.25 FTE for ~14 weeks (architecture, delivery, code review, integrations, stakeholder coordination)
-- **Developers**: 2.0 FTE for ~14 weeks (CLI + backend services + UI implementation)
-- **DevRel / technical writing**: included in the tech lead allocation (docs owned by the team; no separate FTE assumed)
-- **Fully-loaded rates**: Tech lead: $14,000/month · Developer: $11,000/month
-- **Non-labor**: $4,000 total (CI minutes, small test environments, design assets, incidentals)
-- **Contingency**: 5% for schedule risk and unknowns
-
-> Scope note: this budget focuses the grant deliverables on (1) a golden-path local-dev topology, (2) the BlockSmith Console for Canton web UI for topology/connectivity + health, (3) diagnostics capture, and (4) upgrade planning + preflight checks. Team-dev Helm templates and any "Tenderly-like" stretch features are deferred to post-grant work.
-
-**Budget summary (USD-equivalent)**
-
-- Tech lead: 3.5 months × $14,000 × 0.25 FTE = **$12,250**
-- Developers: 3.5 months × $11,000 × 2 FTE = **$77,000**
-- Labor subtotal: **$89,250**
-- Non-labor: **$4,000**
-- Contingency (5%): **$4,750**
-- **Total: $98,000 USD equivalent in CC**
-
-### Payment Breakdown by Milestone
-
-- Milestone 1 — Golden-path bootstrap + console foundation: **$35,000 in $CC** upon committee acceptance
-- Milestone 2 — Observability + console expansion + diagnostics: **$35,000 in $CC** upon committee acceptance
-- Milestone 3 — Upgrade planning + hardening + adoption package: **$28,000 in $CC** upon final release and acceptance
-
-### Volatility Stipulation
-
-The project duration is **under 6 months** (~14 weeks). Should the project timeline extend beyond 6 months due to Committee-requested scope changes, any remaining milestones must be renegotiated to account for significant USD/CC price volatility.
-
----
-
-## Co-Marketing
-
-Upon release, 57blocks will collaborate with the Canton Foundation on:
-
-- Announcement coordination for each major milestone release
-- A technical blog post or case study covering how BlockSmith for Canton addresses the top DevEx pain points identified in the 2026 survey
-- Developer and ecosystem promotion (e.g., presentation at a Canton community call, forum posts, and tooling showcase)
-- Feedback loops with pilot teams to validate adoption and publish usage outcomes
-
----
-
-## Motivation
-
-### Problem: environment setup & node operations are Canton's highest-friction area
-
-The Canton Foundation's 2026 DevEx survey highlights that **environment setup & node operations** are the longest-to-get-right task for many developers. It also repeatedly calls out the need for **one-click visual dashboards** to validate node handshakes (Sequencer/Mediator/Participant) without relying on complex terminal commands, plus broader **observability & monitoring** as a high-consensus priority ([survey analysis](https://discuss.daml.com/t/canton-network-developer-experience-and-tooling-survey-analysis-2026/8412)).
-
-For teams used to EVM ecosystems, there is an expectation of reliable "golden path" node deployment templates, standardized metrics + dashboards + alerts (and a usable UI, not only CLI), and predictable upgrade/migration playbooks. Today, deploying a Canton topology, connecting correctly, keeping it healthy, and migrating across version changes (including Daml upgrades) often requires teams to become infrastructure specialists before they can ship product.
-
-A concrete example is the Quickstart DevNet workflow, which includes steps like VPN connectivity, managing host-based routing (`/etc/hosts` + nginx virtual hosting), retrieving network "migration id" and matching versions, generating short-lived onboarding secrets, and passing the right flags to startup scripts — none of which are "product work", but all of which are required to get a node connected and stable ([Deploy Quickstart to DevNet](https://docs.digitalasset.com/build/3.3/quickstart/operate/deploy-quickstart-to-devnet.html)).
-
-### Specific operator difficulties observed in official documentation
-
-**Environment + orchestration friction**
-
-- **Docker resources / unhealthy containers**: Quickstart highlights that LocalNet commonly becomes "unhealthy" due to insufficient Docker memory and recommends allocating ≥ 8GB and sometimes disabling observability to fit smaller machines ([CNQS FAQ](https://docs.digitalasset.com/build/3.3/quickstart/troubleshoot/cnqs-faq.html)).
-- **Dependency management complexity (direnv/nix/JVM)**: Quickstart uses `direnv`, `nix`, and Docker Compose, and the FAQ calls out corporate proxy / TLS certificate issues (Nix SSL certs, JVM trust stores) that can block setup in enterprise environments ([CNQS FAQ](https://docs.digitalasset.com/build/3.3/quickstart/troubleshoot/cnqs-faq.html)).
-- **Stale state + "reset" runbooks**: Docs recommend sequences like `make stop`, `make clean-all`, or `docker compose down -v` to clear stale containers/volumes and recover from unhealthy states ([CNQS FAQ](https://docs.digitalasset.com/build/3.3/quickstart/troubleshoot/cnqs-faq.html); [Deploy Quickstart to DevNet](https://docs.digitalasset.com/build/3.3/quickstart/operate/deploy-quickstart-to-devnet.html)).
-
-**Versioning, upgrades, and migrations**
-
-- **Daml SDK / runtime version drift**: FAQ highlights that the Daml SDK version is pinned via environment variables (e.g., `DAML_RUNTIME_VERSION`) and that interrupted installs can corrupt SDK snapshots and require manual cleanup ([CNQS FAQ](https://docs.digitalasset.com/build/3.3/quickstart/troubleshoot/cnqs-faq.html)).
-- **Database migrations and upgrade sequencing**: Canton console docs note that persistent nodes require explicit database migrations (`db.migrate`) when upgrading, that `migrate-and-start` can be enabled, and that data continuity is only guaranteed across minor/patch updates ([Canton Console](https://docs.digitalasset.com/operate/3.3/howtos/operate/console/console.html)).
-- **Client/API breaking changes across versions**: The gRPC Ledger API migration guide documents concrete breakpoints (e.g., `domain`→`synchronizer`, `application_id`→`user_id`, event identifier changes), which are easy to miss during upgrades ([gRPC Ledger API Migration Guide](https://docs.digitalasset.com/build/3.3/reference/lapi-migration-guide.html)).
-
-**Monitoring, diagnostics, and "what is healthy?"**
-
-- **Multiple health surfaces**: Participant health is exposed via gRPC health checks, optional HTTP health endpoints, and richer console/admin status (`health.status`) with component-level details ([Participant Node Health](https://docs.digitalasset.com/operate/3.3/howtos/observe/health.html)).
-- **Health dumps are essential for troubleshooting**: Docs describe `health.dump()` producing a ZIP with sanitized config, logs extract, metrics snapshot, and thread dumps, and note this is commonly needed when troubleshooting or working with support ([Participant Node Health](https://docs.digitalasset.com/operate/3.3/howtos/observe/health.html)).
-- **Log analysis complexity**: Quickstart recommends capturing container logs (`make capture-logs`) and using `lnav` with a Canton-specific log format config to filter by component, errors, and OpenTelemetry trace IDs across services ([lnav guide](https://docs.digitalasset.com/build/3.5/quickstart/operate/lnav-in-cn.html); [CNQS FAQ](https://docs.digitalasset.com/build/3.3/quickstart/troubleshoot/cnqs-faq.html)).
-
-### How BlockSmith for Canton directly addresses the survey's top pain points
-
-- **Environment setup & node operations (highest friction)**: Golden-path local topology (`docker compose`) + deterministic `preflight`, `doctor`, and safe `reset` flows. Localhost UI (BlockSmith Console for Canton) that shows "what's running, what's unhealthy, and what to do next". Grounded in documented operational runbooks and failure modes (e.g., resource constraints, stale volumes) ([CNQS FAQ](https://docs.digitalasset.com/build/3.3/quickstart/troubleshoot/cnqs-faq.html)).
-- **"One-click visual dashboards" for operators**: BlockSmith Console for Canton provides topology/connectivity view + health drill-down, and deep-links into Grafana dashboards where enabled. Handshake-specific indicators are shown where exposed by health/status surfaces (avoids over-promising topology introspection everywhere) ([Participant Node Health](https://docs.digitalasset.com/operate/3.3/howtos/observe/health.html)).
-- **Observability & monitoring (broad consensus priority)**: One-command observability bundle for local-dev (Prometheus + Grafana), plus "collect diagnostics" archives for reproducible bug reports. PQS metrics integration aligns with documented OTel/Prometheus approaches where PQS is part of the topology ([PQS Observe](https://docs.digitalasset.com/build/3.3/component-howtos/pqs/observe.html)).
-- **Integration friction ("opaque discovery", repeated JWT/auth hurdles)**: Connection artifact export (single JSON) so app teams/operators don't reverse-engineer endpoints/ports/hostnames. Auth/JWT checklist UI: guidance + validation for common OIDC/JWT setups (reachability and configuration sanity checks), without becoming an identity platform. Package visibility (where exposed): best-effort listing of installed packages/DARs when a supported API is available; otherwise, clear guidance on what to enable.
-- **Upgrades and migrations (Canton + Daml)**: Upgrade Wizard (plan/preflight) generates runbooks aligned with the official upgrade flow (config parse with `--manual-start`, `db.migrate()` when needed, reconnect/ping verification). Protocol upgrades are supported as runbook/script generation only (no unsafe automation), matching Canton's constraint that synchronizer protocol upgrades require deploying a new synchronizer and migrating participants ([Upgrade To a New Release](https://docs.digitalasset.com/operate/3.3/howtos/upgrade/index.html)).
-
-### Why this matters for Canton specifically
-
-1. **Canton's developer base is 83% TradFi or hybrid.** These teams have a compliance-conscious, uptime-critical mindset. They need hardened tooling that bridges traditional finance workflows with on-chain infrastructure — not bespoke tribal knowledge spread across docs.
-2. **The survey is unambiguous.** Environment setup & node operations top the friction list, and visual dashboards / observability are high-consensus asks. This is not speculative — it is a direct response to reported needs.
-3. **Multi-chain onboarding expertise is essential.** Teams moving from EVM to Canton face a paradigm shift (global state → need-to-know privacy, party-based identity). Reducing the infrastructure overhead lets them focus on that paradigm shift, rather than fighting the operational stack first.
-4. **An open-source common good raises all boats.** All operators — new teams, existing participants, integrators — benefit from a shared baseline of deployment templates, runbooks, and dashboards. This is infrastructure the ecosystem cannot afford to re-create individually.
-
----
+Canton's validators are mostly institutional operators with strict compliance and uptime requirements. An open-source tool that builds on the existing Canton tooling raises the baseline for every operator on the network while keeping the ecosystem consolidated on the same upstream stack. The 57Blocks dogfooding loop means every UX gap surfaces against our own deployment before it lands on anyone else's.
 
 ## Rationale
 
-### Why 57blocks is the right team to deliver this
+57Blocks has shipped this kind of guided UX tooling for blockchain workflows before. BlockSmith for Stellar Soroban, funded by the Stellar Community Fund, is a developer toolchain that helps smart contract teams build, test, and deploy on Soroban (Stellar's architecture doesn't require users to run their own nodes, so the natural audience there is the contract developer rather than the operator). The transferable observation is the same: complex multi-step blockchain workflows become friction that blocks teams from shipping, and a guided CLI + AI experience meaningfully changes that. The difference on Canton is that we're targeting validator operators, we're the first operator using the tool so it gets validated on a real validator before anything ships externally, and the scope was shaped by direct review from another active Canton operator before submission.
 
-57blocks has already shipped **BlockSmith**, a developer/operator toolchain for Stellar Soroban that unifies local node lifecycle management (`start/stop/reset`) into a deterministic workflow, one test suite runnable against both in-memory and real-node environments, and operational feedback loops like resource/limit measurement and developer-friendly outputs ([BlockSmith](https://www.blocksmith.co/)).
+## Team Background
 
-BlockSmith emerged from the same insight driving this proposal: developers on newer chains are forced to become infrastructure specialists before they can build product. The toolchain was funded through multiple **Stellar Community Fund grants** (SCF #27, #29, #31) and evolved into a suite of four developer tools — a Timelock Smart Contract framework, an AutoAction DevTool for scheduled/event-driven smart contract execution, and a Resource Usage monitor that connects directly to localnet with alerts on overuse. This grant-funded-to-sustained-tooling arc is the exact model intended for Canton.
+**57Blocks.** Building Web3 infrastructure since 2018. 200+ engineering organization across six offices. Operator and developer tooling experience across Ethereum, Solana, Stellar, and Canton.
 
-**Deep Web3 infrastructure expertise across 20+ DeFi categories**
+**Diogo Silveira Mendonça, PhD, PMP.** Product and Engineering Lead. 20+ years in software engineering, ~7 years in Web3, Canton and Daml certified. Currently leading the bring-up of 57Blocks's own Canton validator.
 
-57Blocks has been building and investing in Web3 since 2018. With 200+ product designers, AI experts, and engineers across six global offices (San Francisco, Seattle, Bogotá, Medellín, Wrocław, and three cities in China), the team brings full-stack depth: protocol design, smart contract development, chain infrastructure, backend services, frontend dApps, testing frameworks, CI/CD pipelines, and 24/7 monitoring.
+**Implementation team.** A dedicated pod with at least one Canton-certified engineer at all times. The Canton-certified roster is being expanded in anticipation of the grant. Implementation is accelerated by AI coding agents and validated against our own validator deployment as it progresses through DevNet, TestNet, and a MainNet-ready configuration.
 
-Trusted by 20+ protocols, we have built and invested across every major layer of the Web3 stack — from L1 infrastructure (Ethereum, Solana, Stellar, Canton, Cosmos, Sui) through DeFi protocols, wallets, compliance tools, cross-chain bridges, analytics platforms, and RWA applications. Our Web3 tech stack directly overlaps with BlockSmith for Canton's requirements: Docker, Kubernetes, Prometheus/Grafana monitoring, Daml, Go, Node.js, Java, Python, React, and deep experience with Hardhat, Foundry, and Soroban development environments.
-
-We have a trained engineering team and hands-on experience designing and building on Canton using Daml for a commercial, production-deployed solution.
-
-**Directly relevant case studies**
-
-**Huma Finance — Private Credit Protocol ($10.2B+ financed, 0% default)**
-We co-designed and implemented Huma's smart contract architecture from inception, led the development of V1/V2 Ethereum contracts, and subsequently drove the full migration to Solana. This engagement is relevant because Huma is a TradFi/DeFi hybrid — the same profile as 83% of Canton's developer base — and required building production-grade infrastructure that bridges traditional finance workflows with on-chain settlement. Our pod structure (2 smart contract engineers, 1 tokenomics advisor, 1 frontend architect) mirrors the focused team we'll deploy for BlockSmith for Canton.
-
-**Rain — Web3 Stablecoins Payments Platform**
-For Rain, we built the blockchain layer from scratch: smart contracts for settlement and liquidity, cross-chain interoperability, on/off-chain reconciliation, and secure upgrade-ready deployments. The technical parallels to BlockSmith for Canton are strong — we solved multi-chain system abstraction (refactoring a tightly-coupled EVM system to support Solana and Stellar), asynchronous transaction throughput with concurrent processing, idempotency and concurrency control, and automated transaction recovery with fault-tolerant event processing. These are exactly the kinds of operational resilience patterns that Canton node operators need.
-
-**Undisclosed Stablecoin Issuer — Stablecoin Platform Chain Expansion**
-57Blocks serves as the customer's strategic engineering partner for expanding their fiat-backed stablecoin platform across 20+ chains. One of four workstreams is explicitly "Delivery Excellence & Tooling" — streamlining integrations, standardizing developer interfaces, enabling faster onboarding, and building more scalable, maintainable platform evolution. This is the same mission as BlockSmith for Canton, applied to a different chain ecosystem.
-
-**LI.FI — Multi-Chain DEX Aggregation (50+ L2 chains)**
-We led development of LI.FI's DEX aggregator service, building scalable architecture to integrate DEXes across 50+ L2 chains with optimized swap routing algorithms. This engagement demonstrates our ability to build cross-chain infrastructure at scale — adapting to each chain's idiosyncrasies while maintaining a unified developer and operator experience.
-
-**Why this approach is preferred over alternatives**
-
-1. **We've done this before.** BlockSmith for Stellar proves we can identify operator pain points in a non-EVM ecosystem, translate them into opinionated tooling, secure ecosystem grant funding, and ship iteratively. The pattern is identical.
-2. **Enterprise/TradFi DNA.** Our deepest engagements — Huma (private credit), Rain (stablecoin payments), Brale (fiat-backed stablecoin issuance), Paxos (cross-chain token issuance) — are all regulated financial infrastructure. We understand the compliance-conscious, uptime-critical mindset these teams bring to Canton.
-3. **Multi-chain onboarding expertise.** We have repeatedly helped teams expand from EVM to non-EVM chains (Rain: EVM → Solana + Stellar; Undisclosed Stablecoin Issuer: 20+ chains; Huma: Ethereum → Solana & Stellar). This gives us firsthand understanding of the paradigm-shift friction Canton developers report.
-4. **Full-stack operator tooling capability.** BlockSmith for Canton requires CLI tooling, web dashboards, Docker orchestration, Prometheus/Grafana integration, and upgrade automation. Our team runs this exact stack in production across multiple clients — this is applying proven patterns to a new domain, not R&D.
-5. **Sustained delivery at scale.** Top client retention rate, 97% of clients report higher delivery quality, and a 200+ person team means we can commit a dedicated pod to BlockSmith for Canton without straining other obligations.
-
-## **Team Background**
-
-### Core team
-
-Diogo Silveira Mendonça, Ph.D., PMP (Product & Engineering Lead): Full-stack engineer and Web3 specialist with over 20 years of experience in software engineering and around 7 years in the Web3 space, with leadership experience delivering blockchain related projects. Currently Head of Web3 LATAM at 57Blocks and a Canton / Daml Certified professional.
-
-Implementation Team: 57Blocks will allocate experienced engineers with knowledge of and experience with Canton as needed to execute the grant milestones under Diogo’s technical direction and product leadership. The company currently has engineers certified in Canton / Daml skillset, hands-on with Canton production deployments, and we are actively expanding our team of Canton professionals.
 
 ## Contact
 
-For questions, feedback, or to coordinate review please reach out:
-
-Diogo Silveira Mendonça, Head of Web3 LATAM - diogo.silveira@57blocks.com  
-Kamil Krupa, Head of Web3 BU - kamil@57blocks.com  
+- Diogo Silveira Mendonça, Head of Web3 LATAM, [diogo.silveira@57blocks.com](mailto:diogo.silveira@57blocks.com)
+- Kamil Krupa, Head of Web3 BU, [kamil@57blocks.com](mailto:kamil@57blocks.com)
 
 ## Sponsorship
 
-This proposal is sponsored by the Canton Foundation. Please reach out to Bo Zhang for more information.
-
----
+Sponsored by the Canton Foundation. Please contact Bo Zhang for additional context.
 
 ## References
 
-- Canton Development Fund process: https://github.com/canton-foundation/canton-dev-fund
-- 2026 Canton DevEx survey analysis: https://discuss.daml.com/t/canton-network-developer-experience-and-tooling-survey-analysis-2026/8412
-- BlockSmith (57blocks): https://www.blocksmith.co/
-- Deploy Quickstart to DevNet (representative operator workflow): https://docs.digitalasset.com/build/3.3/quickstart/operate/deploy-quickstart-to-devnet.html
-- PQS observability primitives (metrics/logs/diagnostics): https://docs.digitalasset.com/build/3.3/component-howtos/pqs/observe.html
-- Upgrade to a new release (operator upgrade model): https://docs.digitalasset.com/operate/3.3/howtos/upgrade/index.html
-- CN App Quickstart FAQ (resource constraints, resets, ops gotchas): https://docs.digitalasset.com/build/3.3/quickstart/troubleshoot/cnqs-faq.html
-- Participant node health checks and health dumps: https://docs.digitalasset.com/operate/3.3/howtos/observe/health.html
-- Canton console operations (remote admin, db.migrate/migrate-and-start): https://docs.digitalasset.com/operate/3.3/howtos/operate/console/console.html
-- Log debugging with lnav (trace-id correlation, capture logs): https://docs.digitalasset.com/build/3.5/quickstart/operate/lnav-in-cn.html
-- gRPC Ledger API migration guide (3.2→3.3 breaking changes): https://docs.digitalasset.com/build/3.3/reference/lapi-migration-guide.html
+- 2026 Canton DevEx survey analysis: [https://discuss.daml.com/t/canton-network-developer-experience-and-tooling-survey-analysis-2026/8412](https://discuss.daml.com/t/canton-network-developer-experience-and-tooling-survey-analysis-2026/8412)
+- Validator deployment via Docker Compose: [https://docs.sync.global/validator_operator/validator_compose.html](https://docs.sync.global/validator_operator/validator_compose.html)
+- Validator upgrade procedure: [https://docs.sync.global/validator_operator/validator_upgrades.html](https://docs.sync.global/validator_operator/validator_upgrades.html)
+- Validator observability: [https://docs.sync.global/deployment/observability/index.html](https://docs.sync.global/deployment/observability/index.html)
+- Participant Query Store (PQS): [https://docs.digitalasset.com/build/3.5/component-howtos/pqs/index.html](https://docs.digitalasset.com/build/3.5/component-howtos/pqs/index.html)
+- Anthropic Model Context Protocol: [https://modelcontextprotocol.io](https://modelcontextprotocol.io)
+- Canton Dev Fund #324 (Canton MCP + Skills, VertexPoint Labs): [https://github.com/canton-foundation/canton-dev-fund/pull/324](https://github.com/canton-foundation/canton-dev-fund/pull/324)
+- BlockSmith for Stellar (precedent project): [https://www.blocksmith.co/](https://www.blocksmith.co/)


### PR DESCRIPTION
## Development Fund Proposal Submission

**Proposal file:**  
proposals/57b_blocksmith_canton.md

---

## Summary
BlockSmith for Canton is an operator-first toolkit that makes deploying, connecting, monitoring, and upgrading Canton nodes feel closer to "standard practice" in mature ecosystems (EVM-style: strong deployment automation + dashboards + runbooks). It targets the ecosystem's highest-reported friction — environment setup & node operations — by shipping opinionated node templates, deterministic diagnostics, a web UI (BlockSmith Console for Canton) for one-click topology/connectivity + health visibility (including handshake-related indicators where exposed), and an upgrade/migration assistant for Canton and Daml.

---

## Checklist
- [x] Proposal file added under `/proposals/`
- [x] Milestones and funding amounts defined
- [x] Acceptance criteria included
- [x] Alignment with Canton priorities described

---

## Notes for Reviewers
This proposal is sponsored by the Canton Foundation. Please reach out to Bo Zhang for more information.
More on 57Blocks: https://57blocks.com/
For questions or to discuss this proposal, please reach out:
Diogo Silveira Mendonça, Head of Web3 LATAM - diogo.silveira@57blocks.com
Kamil Krupa, Head of Web3 BU - kamil@57blocks.com
