### PR TITLE
Proposal: Arch–Canton Bridge — Leverage and Yield Infrastructure for CBTC

### DIFF
--- a/proposals/arch-bitcoin-capital-markets-stack.md
+++ b/proposals/arch-bitcoin-capital-markets-stack.md
@@ -10,226 +10,7 @@ Arch and Canton are structurally complementary institutions. Canton provides the
 
 Bitcoin is a $2T+ asset with no scalable form of native yield. The most viable strategy for making BTC productive — for institutions, family offices, and sophisticated investors — is the credit carry trade: borrow against BTC collateral, deploy stablecoins into yield-generating strategies (private credit, yield ETFs, money market instruments), collect yield, repay the loan, keep the spread as net BTC yield. This strategy requires fast execution, deterministic collateral enforcement, and deep liquidity — exactly what Arch's infrastructure provides.
 
-This proposal describes five infrastructure components that deliver a full Bitcoin financial services stack for Canton to facilitate this:
-
-1. **Arch–Canton Bridge** — Foundational interoperability infrastructure connecting native BTC to Canton Network. Also serves as the connectivity layer for Arch's financial services (DEX, lending, vaults) to Canton participants. Institutions interact through existing custody relationships (Anchorage, Ceffu, Utila) — no new custody required.
-
-2. **BTC Financial Services Access (DEX + Lending)** — Canton participants gain access to Arch Swap (deep BTC/stablecoin liquidity) and Arch Lend (stablecoin loans against BTC collateral) through the bridge. These are the financial primitives that make BTC productive — without them, BTC on Canton is a holding asset, not a working one.
-
-3. **Canton Vault Standard** — A standardized, composable vault interface written in Daml (analogous to Ethereum's ERC-4626) that enables institutional yield strategies on Canton. Once credit infrastructure exists, vaults become the vehicle for deploying it — private credit strategies, yield ETFs, debt tranches, corporate bonds, subscription agreements with fund asset managers, and other tradfi yield strategies, all accessible through a standard interface.
-
-4. **BTC Capital Markets Integration for DA's Tokenization Utility** — An integration layer connecting Arch's financial services to DA's existing issuance infrastructure, enabling aBTC as a native subscription and settlement asset for tokenized securities on Canton.
-
-5. **Compliant Tokenization Service** — A compliant securities issuance service that enables the tokenization of yield instruments, fund shares, structured products, and other securities on top of the BTC infrastructure with proper regulatory compliance. This is a public good for Canton's ecosystem: any issuer can use it to create compliant tokenized securities backed by or denominated in BTC.
-
-Together, these components deliver a complete Bitcoin capital markets stack for Canton: bridge access, deep swaps, institutional lending, tradfi yield infrastructure, compliant securities tokenization — and the capital markets integration that connects all of it to Canton's existing $9T+ tokenized asset base.
-
-## Specification
-
-### 1. Objective
-
-Connect Bitcoin's $2T+ asset class to Canton's $9T+ institutional ecosystem through purpose-built financial infrastructure. Specifically: enable institutional BTC holders to earn yield on their Bitcoin without leaving the Canton compliance framework, and enable Canton-native asset issuers to access BTC-denominated capital for the first time.
-
-The five infrastructure components solve three problems that Canton cannot solve internally:
-
-- **No programmable BTC bridge with execution capabilities.** Canton has CBTC (custodial holding), but no mechanism for BTC capital to flow into lending, trading, or yield strategies. The Arch–Canton Bridge solves this.
-- **No standardized vault primitive.** Ethereum's ERC-4626 has enabled billions in composable DeFi strategies. Canton has no equivalent. The Canton Vault Standard fills this gap.
-- **No BTC capital onramp for tokenized assets.** DA's Tokenization Utility provides world-class issuance infrastructure, but there is no mechanism for BTC capital to subscribe to Canton-issued securities. The BTC Capital Markets Integration builds that connection.
-
-### 2. Implementation Mechanics
-
-**Arch–Canton Bridge**
-
-The bridge uses a relayer-based architecture with FROST threshold signatures for security:
-
-- Arch → Canton: User locks BTC on Arch → validators produce signed attestation → relayer transmits to Canton → Canton bridge contract verifies and mints CIP-56 aBTC token via Offer-Accept protocol.
-- Canton → Arch: User transfers aBTC to bridge contract → bridge burns aBTC and emits withdrawal attestation → relayer transmits to Arch → validators construct and sign Bitcoin unlock transaction → user receives native BTC.
-- Security: (⌈2N/3⌉ + 1)-of-N FROST threshold signatures, per-epoch volume caps, emergency pause, reorg handling via DAG-based transaction tracking and UTXO anchoring.
-- Relayer model: Permissionless — any party can relay valid attestations. Minimum 3 independent operators recommended.
-
-**aBTC Token (CIP-56)**
-
-- Standard: CIP-56 compliant, 8 decimals (matching BTC), mint authority restricted to bridge contract only.
-- Compliance: Configurable transfer restrictions (KYC, jurisdictional, accredited investor checks), regulatory observer support.
-- Oracle: Dual-oracle design (RedStone primary, Chainlink secondary), 5-minute staleness threshold, 2% divergence handling, 10-minute TWAP, circuit breaker.
-
-**Canton Vault Standard**
-
-- Daml-based interface analogous to ERC-4626: deposit/withdraw via CIP-56 Offer-Accept, share token accounting, compliance-gated deposits.
-- View functions: totalAssets, totalShares, convertToShares, convertToAssets, maxDeposit, maxWithdraw.
-- Composability: Vault shares usable as collateral in Acme/Palladium, settleable via DvP, nestable in other vaults.
-- Reference implementations: HoneyB vault (private credit yield via Simplify, $13B AUM ETF platform), delta-neutral vault (funding rate capture).
-
-**BTC Capital Markets Integration**
-
-- aBTC Subscription Interface: Enables atomic DvP subscriptions denominated in aBTC into DA Tokenization Utility-issued assets.
-- Vault Share Composability: Vault share tokens registered as eligible collateral and subscription assets within DA's credential layer.
-- BTC Settlement Pairs: aBTC/tokenized-treasury, aBTC/money-market-fund, aBTC/private-credit DvP settlement pairs.
-- Open source integration guides, Daml templates, and TypeScript examples for issuers.
-
-**Compliant Tokenization Service**
-
-- Compliant issuance of securities as tokens on Canton — open, permissionless infrastructure.
-- Supports yield instruments, fund shares, structured products, and other securities with proper regulatory compliance.
-- KYC/AML, accreditation, and jurisdictional controls enforced at issuance level.
-
-### 3. Architectural Alignment
-
-This proposal aligns with Canton's architecture and ecosystem priorities:
-
-- **CIP-56 compliance:** aBTC is a native CIP-56 token, fully compatible with Canton's Offer-Accept transfer model, sub-transaction privacy, and regulatory observer framework.
-- **DvP settlement:** All components support Canton's atomic DvP settlement — aBTC subscriptions, vault share trades, and BTC settlement pairs all settle atomically via the Global Synchronizer.
-- **Daml-native:** Bridge contracts, vault standard, and tokenization protocol are implemented in Daml, leveraging Canton's smart contract model and benefiting from its privacy and composability guarantees.
-- **Canton Improvement Proposal:** The Canton Vault Standard will be submitted as a formal CIP for community adoption, contributing to Canton's standards ecosystem.
-- **DA Tokenization Utility integration:** The BTC Capital Markets Integration builds on top of DA's existing issuance infrastructure rather than replacing it — aBTC becomes a new payment and collateral leg for assets already issued via DA's Tokenization Utility.
-- **Institutional compliance model:** Vault-level compliance gating (KYC, accreditation, jurisdictional rules) enforced at deposit, aligned with Canton's institutional-grade compliance framework.
-
-### 4. Backward Compatibility
-
-No backward compatibility impact. All components are additive:
-
-- aBTC is a new CIP-56 token — does not modify existing token contracts or standards.
-- The Canton Vault Standard is a new primitive — does not change existing Daml contracts.
-- The bridge introduces new contracts (BridgeController, DepositAttestation, MintAuthority, WithdrawalRequest) that interact with Canton via standard CIP-56 mechanics.
-- BTC Capital Markets Integration adds subscription and settlement interfaces on top of DA's existing Tokenization Utility — no modifications to DA's contracts required.
-- Compliant Tokenization Service is independent infrastructure, available to any Canton participant.
-
-## Milestones and Deliverables
-
-### Milestone 1: Bridge Architecture + aBTC Token (Q2 2026)
-
-- **Estimated Delivery:** Q2 2026 (April–June)
-- **Focus:** Bridge design, Daml contract development, aBTC token deployment on testnet, relayer prototype
-- **Deliverables / Value Metrics:**
-  - Bridge design specification — published technical document covering architecture, security model, message format, and failure modes. Reviewed by at least one independent Daml ecosystem developer.
-  - Daml bridge contracts — BridgeController, DepositAttestation, MintAuthority, WithdrawalRequest implemented with >90% unit test coverage. Source code published on GitHub. Reviewed by selected Daml development partner.
-  - Arch-side lock/burn contracts — UTXO-based contracts deployed on Arch testnet with passing integration tests.
-  - aBTC CIP-56 token — Compliant token contract with compliance hooks, transfer restrictions, and DvP support. Deployed on Canton testnet. Passes Canton token standard conformance tests.
-  - Relayer prototype — Functional relayer transmitting attestations between Arch testnet and Canton testnet. At least 100 successful cross-chain transfers demonstrated.
-  - Integration tests — End-to-end tests (Arch deposit → Canton mint, Canton burn → Arch unlock). Minimum 50 test cases covering normal and failure paths. Test suite published.
-  - Documentation — Developer guide for bridge integration. aBTC token specification. Published on GitHub with README and quickstart.
-
-### Milestone 2: Vault Standard + Bridge Production (Q2 2026)
-
-- **Estimated Delivery:** Q2 2026 (April–June)
-- **Focus:** Canton Vault Standard specification and reference implementations, bridge security audit, mainnet deployment, aBTC mainnet launch
-- **Deliverables / Value Metrics:**
-  - Canton Vault Standard specification — Published standard with Daml interface definitions, deposit/withdraw flows, share accounting, compliance integration. Formally submitted as a Canton Improvement Proposal (CIP).
-  - Reference vault implementation — Daml vault contract using aBTC as underlying. Deposit, withdraw, redeem, share accounting functional on Canton testnet with >90% unit test coverage. Reviewed by Daml development partner.
-  - Vault composability demonstration — Vault shares used as collateral in an atomic DvP settlement with another CIP-56 asset on Canton testnet. Documented with transaction logs.
-  - Bridge security audit — Third-party audit by a recognized firm (Certora, Trail of Bits, or equivalent). 0 critical findings, 0 unresolved high findings. Audit report published publicly.
-  - Bridge mainnet deployment — Contracts deployed on Arch mainnet and Canton mainnet. Relayer operational with uptime monitoring and alerting. At least 10 mainnet bridge transfers processed.
-  - aBTC mainnet launch — aBTC live on Canton mainnet, mintable via bridge. At least one institutional participant has minted aBTC.
-  - Documentation — Vault standard developer guide, bridge operational runbook, aBTC integration guide. All published on GitHub.
-
-### Milestone 3: BTC Capital Markets Integration + Ecosystem Launch (Q3 2026)
-
-- **Estimated Delivery:** Q3 2026 (July–September)
-- **Focus:** DA Tokenization Utility integration, aBTC subscription interfaces, BTC settlement pairs, ecosystem launch
-- **Deliverables / Value Metrics:**
-  - aBTC Subscription Interface — CIP-56 Daml contract enabling atomic DvP subscriptions denominated in aBTC into DA Tokenization Utility-issued assets. Tested end-to-end on Canton testnet.
-  - Vault Share Composability — Canton Vault Standard share tokens registered as eligible collateral and subscription assets within DA's credential layer. Demonstrated on Canton testnet.
-  - BTC Settlement Pairs — aBTC/tokenized-treasury and aBTC/money-market-fund DvP settlement pairs live on Canton mainnet. At least 2 atomic DvP settlements using aBTC executed and documented.
-  - Integration documentation & templates — Open source guides, Daml templates, and TypeScript examples. Published on GitHub. Validated by at least one external developer.
-  - Live demonstration — At least one end-to-end aBTC subscription into a Canton-issued asset on mainnet. Documented with transaction logs and participant attestation.
-  - Full documentation suite — Complete user guides, API reference, and integration guides for all five components. Published on GitHub.
-
-## Acceptance Criteria
-
-The Tech & Ops Committee will evaluate completion based on:
-
-- Deliverables completed as specified for each milestone
-- Demonstrated functionality or operational readiness
-- Documentation and knowledge transfer provided
-- Alignment with stated value metrics
-- Security audit results (Milestone 2) — 0 critical, 0 unresolved high findings
-- Mainnet operational status (Milestones 2–3) — bridge operational, aBTC mintable, vaults live
-- Adoption evidence (Milestone 3) — minimum TVL thresholds met, at least one institutional participant engaged
-
-## Funding
-
-**Total Funding Request:** $250,000 USD (payable in CC at prevailing rate)
-
-### Payment Breakdown by Milestone
-
-- **Milestone 1 (Bridge Architecture + aBTC Token):** $100,000 upon committee acceptance
-- **Milestone 2 (Vault Standard + Bridge Production):** $87,500 upon committee acceptance
-- **Milestone 3 (BTC Capital Markets Integration + Ecosystem Launch):** $62,500 upon committee acceptance
-
-### Volatility Stipulation
-
-Should the project timeline extend beyond 6 months due to Committee-requested scope changes, any remaining milestones must be renegotiated to account for significant USD/CC price volatility.
-
-## Co-Marketing
-
-Upon release, Arch Network will collaborate with the Foundation on:
-
-- Announcement coordination
-- Joint case study or technical blog highlighting the Arch-Canton integration
-- Developer or ecosystem promotion
-
-**Economic Design Audit & Bitcoin Credit Markets Study:** Arch is currently underway on a comprehensive economic design audit and case study of Bitcoin credit markets that supports the thesis behind this proposal. The study demonstrates that Arch’s architecture is structurally more efficient for scaling Bitcoin lending than existing alternatives. We would welcome the opportunity to include Canton in this study — examining how Canton’s institutional settlement layer combined with Arch’s execution infrastructure creates a uniquely efficient credit market design for institutional BTC participants. This joint research could serve as a powerful co-marketing asset for both ecosystems.
-
-## Motivation
-
-Canton hosts over $9 trillion in tokenized assets and processes approximately $350 billion in daily volume. Institutional participants — including Goldman Sachs (DAP), Broadridge (DLR), and Versana — use Canton for compliant, privacy-preserving financial operations.
-
-However, Canton's connection to Bitcoin — a $2T+ asset class and the most widely held digital asset among institutions — remains underdeveloped. While CBTC provides custodial wrapped BTC on Canton, there is no programmable bridge to Bitcoin-native infrastructure with execution capabilities (lending, trading, structured products), no standardized vault primitive for composable yield strategies, and no mechanism for BTC capital to subscribe to Canton-issued securities.
-
-These gaps limit Canton's ability to attract Bitcoin-denominated capital, restrict the yield strategies available to institutional participants, and raise the barrier to entry for new issuers.
-
-This proposal directly addresses these gaps by delivering open infrastructure that connects Bitcoin's $2T+ asset class to Canton's institutional ecosystem — creating new utility, new capital flows, and new reasons for institutional participants to build on Canton.
-
-**Public Good / Ecosystem Value Justification:**
-
-Two of the five components are genuine public goods — open, permissionless infrastructure available to any Canton participant:
-
-- **Arch–Canton Bridge:** Free, open source bridging infrastructure. Arch does not charge fees for bridging, minting, or burning aBTC. Reusable pattern for other networks to build Canton bridges.
-- **Compliant Tokenization Service:** Open issuance infrastructure for compliant tokenized securities. Any Canton issuer can use it.
-
-The remaining three components generate ecosystem value with built-in maintenance incentives — Arch's revenue depends on their functioning, ensuring durable maintenance:
-
-- **BTC Financial Services Access (DEX + Lending):** Makes Bitcoin productive on Canton. More activity drives Arch Lend and Arch Swap revenue, ensuring continued investment.
-- **Canton Vault Standard:** Open CIP for community adoption. More vault activity drives more lending and trading on Arch infrastructure.
-- **BTC Capital Markets Integration:** Connects Canton's $9T+ asset base to BTC capital. More integrations drive more volume.
-
-## Rationale
-
-**Why Arch Network is the right team:**
-
-Arch Network is an $18M-funded Bitcoin infrastructure company with a 20-person team that has been building for over 2.5 years. Our funding rounds were led by Multicoin Capital and Pantera Capital — two of the most respected institutional crypto investors — reflecting deep conviction in Arch’s technical approach and market positioning. The team has delivered: a production-grade blockchain with BFT consensus, 300ms blocks, and ~1,000 TPS; a Bitcoin-native DEX (Arch Swap); a credit and lending protocol (Arch Lend); and an institutional portfolio dashboard (Arch Prime).
-
-**Why this approach:**
-
-The vertically integrated approach (bridge + financial services + vault standard + capital markets integration + tokenization) is deliberate. Each component's value is amplified by the others — the bridge enables aBTC, aBTC enables lending, lending enables vaults, vaults enable structured products, and the capital markets integration connects all of it to Canton's existing asset base. Delivering these as an integrated stack rather than independent components creates a self-reinforcing adoption flywheel.
-
-**Why not CBTC alone:**
-
-CBTC serves BTC custody and holding on Canton. It does not support programmable lending, vault strategies, or capital markets integration. Critically, CBTC requires 6 Bitcoin confirmations (~60 minutes) for issuance or redemption, creating a collateral enforcement bottleneck that constrains safe LTVs to 25–30% and limits carry trade competitiveness. Arch's 300ms execution eliminates this bottleneck, structurally enabling higher LTVs and more capital-efficient credit markets. CBTC and aBTC are complementary — CBTC for custody, aBTC (and Arch's service stack) for capital markets.
-
-**Alternatives considered:**
-
-- *Build on an existing EVM bridge:* Canton's privacy model and CIP-56 standard require native Daml integration. EVM bridges cannot provide sub-transaction privacy or Canton's Offer-Accept transfer model.
-- *Wait for Canton-native BTC lending:* No Canton-native protocol has the execution speed (300ms) or liquidation infrastructure required for safe BTC-collateralized lending at scale.
-- *Use CBTC as collateral base:* The 6-confirmation bottleneck structurally constrains LTVs and makes downstream carry trades less competitive. A purpose-built execution layer is required.
-
-**Existing ecosystem partnerships providing day-one demand:**
-
-- Institutional custodian integrations: Anchorage, Ceffu, Utila — custody partners who will distribute aBTC vault strategies to their client bases.
-- HoneyB: Active asset management partnership for BTC private credit yield strategies. The HoneyB credit carry trade (LP deposits BTC → borrow stables via Arch Lend → deploy into tradfi yield → collect yield → repatriate to BTC via Arch Swap → distribute to LPs) demonstrates the complete service stack in a single workflow.
-- Institutional liquidity providers: Galaxy, Pantera — committed to seeding initial vault liquidity.
-- DAT partners: Digital Asset Trusts going live with $10–20M BTC yield pilots.
-# Development Fund Proposal
-
-**Author:** Arch Network (Matt Mudano)
-**Status:** Draft
-**Created:** 2026-04-01
-
-## Abstract
-
-Arch and Canton are structurally complementary institutions. Canton provides the institutional compliance layer, sub-transaction privacy, and atomic DvP settlement that capital markets require. Arch provides Bitcoin-native execution and settlement infrastructure — 300ms blocks, ~1,000 TPS, validator-secured collateral enforcement, and native Bitcoin settlement. Together, they can create the capital markets corridor between Bitcoin's $2T+ and Canton's $9T+ institutional asset ecosystem.
-
-Bitcoin is a $2T+ asset with no scalable form of native yield. The most viable strategy for making BTC productive — for institutions, family offices, and sophisticated investors — is the credit carry trade: borrow against BTC collateral, deploy stablecoins into yield-generating strategies (private credit, yield ETFs, money market instruments), collect yield, repay the loan, keep the spread as net BTC yield. This strategy requires fast execution, deterministic collateral enforcement, and deep liquidity — exactly what Arch's infrastructure provides.
+All five of the infrastructure primitives described below are already fully built and deployed on Arch Network. This proposal does not request funding to build these products from scratch — it requests funding to build the Daml contracts and integration layer that connect Arch's existing, production-tested infrastructure to Canton Network. The $250K budget covers Canton-side Daml contract development, bridge relayer integration, testing, security audits, and documentation — executed by IntellectEU, a specialist Daml development firm with Canton production experience.
 
 This proposal describes five infrastructure components that deliver a full Bitcoin financial services stack for Canton to facilitate this:
 
@@ -256,7 +37,6 @@ The five infrastructure components solve three problems that Canton cannot solve
 - **No programmable BTC bridge with execution capabilities.** Canton has CBTC (custodial holding), but no mechanism for BTC capital to flow into lending, trading, or yield strategies. The Arch–Canton Bridge solves this.
 - **No standardized vault primitive.** Ethereum's ERC-4626 has enabled billions in composable DeFi strategies. Canton has no equivalent. The Canton Vault Standard fills this gap.
 - **No BTC capital onramp for tokenized assets.** DA's Tokenization Utility provides world-class issuance infrastructure, but there is no mechanism for BTC capital to subscribe to Canton-issued securities. The BTC Capital Markets Integration builds that connection.
-
 ### 2. Implementation Mechanics
 
 **Arch–Canton Bridge**
@@ -280,7 +60,6 @@ The bridge uses a relayer-based architecture with FROST threshold signatures for
 - View functions: totalAssets, totalShares, convertToShares, convertToAssets, maxDeposit, maxWithdraw.
 - Composability: Vault shares usable as collateral in Acme/Palladium, settleable via DvP, nestable in other vaults.
 - Reference implementations: HoneyB vault (private credit yield via Simplify, $13B AUM ETF platform), delta-neutral vault (funding rate capture).
-
 **BTC Capital Markets Integration**
 
 - aBTC Subscription Interface: Enables atomic DvP subscriptions denominated in aBTC into DA Tokenization Utility-issued assets.
@@ -304,7 +83,6 @@ This proposal aligns with Canton's architecture and ecosystem priorities:
 - **Canton Improvement Proposal:** The Canton Vault Standard will be submitted as a formal CIP for community adoption, contributing to Canton's standards ecosystem.
 - **DA Tokenization Utility integration:** The BTC Capital Markets Integration builds on top of DA's existing issuance infrastructure rather than replacing it — aBTC becomes a new payment and collateral leg for assets already issued via DA's Tokenization Utility.
 - **Institutional compliance model:** Vault-level compliance gating (KYC, accreditation, jurisdictional rules) enforced at deposit, aligned with Canton's institutional-grade compliance framework.
-
 ### 4. Backward Compatibility
 
 No backward compatibility impact. All components are additive:
@@ -317,40 +95,52 @@ No backward compatibility impact. All components are additive:
 
 ## Milestones and Deliverables
 
-### Milestone 1: Bridge Architecture + aBTC Token (Q2 2026)
+All milestones below cover Canton-side Daml integration work only. The underlying Arch primitives (bridge logic, DEX, lending protocol, vault infrastructure, tokenization service) are already built and deployed. IntellectEU will lead Daml contract development across all milestones.
 
-- **Estimated Delivery:** Q2 2026 (April–June)
+### Milestone 1A: Bridge Testnet Delivery (Q2 2026)
+
+- **Estimated Delivery:** Q2 2026 (April–May)
+- **Funding:** $50,000
 - **Focus:** Bridge design, Daml contract development, aBTC token deployment on testnet, relayer prototype
 - **Deliverables / Value Metrics:**
   - Bridge design specification — published technical document covering architecture, security model, message format, and failure modes. Reviewed by at least one independent Daml ecosystem developer.
-  - Daml bridge contracts — BridgeController, DepositAttestation, MintAuthority, WithdrawalRequest implemented with >90% unit test coverage. Source code published on GitHub. Reviewed by selected Daml development partner.
+  - Daml bridge contracts — BridgeController, DepositAttestation, MintAuthority, WithdrawalRequest implemented with >90% unit test coverage. Source code published on GitHub. Reviewed by IntellectEU.
   - Arch-side lock/burn contracts — UTXO-based contracts deployed on Arch testnet with passing integration tests.
   - aBTC CIP-56 token — Compliant token contract with compliance hooks, transfer restrictions, and DvP support. Deployed on Canton testnet. Passes Canton token standard conformance tests.
   - Relayer prototype — Functional relayer transmitting attestations between Arch testnet and Canton testnet. At least 100 successful cross-chain transfers demonstrated.
   - Integration tests — End-to-end tests (Arch deposit → Canton mint, Canton burn → Arch unlock). Minimum 50 test cases covering normal and failure paths. Test suite published.
   - Documentation — Developer guide for bridge integration. aBTC token specification. Published on GitHub with README and quickstart.
+### Milestone 1B: Bridge Mainnet Readiness (Q2–Q3 2026)
 
-### Milestone 2: Vault Standard + Bridge Production (Q2 2026)
-
-- **Estimated Delivery:** Q2 2026 (April–June)
-- **Focus:** Canton Vault Standard specification and reference implementations, bridge security audit, mainnet deployment, aBTC mainnet launch
+- **Estimated Delivery:** Q2–Q3 2026 (June–July)
+- **Funding:** $50,000
+- **Focus:** Bridge security audit, mainnet deployment, aBTC mainnet launch
 - **Deliverables / Value Metrics:**
-  - Canton Vault Standard specification — Published standard with Daml interface definitions, deposit/withdraw flows, share accounting, compliance integration. Formally submitted as a Canton Improvement Proposal (CIP).
-  - Reference vault implementation — Daml vault contract using aBTC as underlying. Deposit, withdraw, redeem, share accounting functional on Canton testnet with >90% unit test coverage. Reviewed by Daml development partner.
-  - Vault composability demonstration — Vault shares used as collateral in an atomic DvP settlement with another CIP-56 asset on Canton testnet. Documented with transaction logs.
   - Bridge security audit — Third-party audit by a recognized firm (Certora, Trail of Bits, or equivalent). 0 critical findings, 0 unresolved high findings. Audit report published publicly.
   - Bridge mainnet deployment — Contracts deployed on Arch mainnet and Canton mainnet. Relayer operational with uptime monitoring and alerting. At least 10 mainnet bridge transfers processed.
   - aBTC mainnet launch — aBTC live on Canton mainnet, mintable via bridge. At least one institutional participant has minted aBTC.
-  - Documentation — Vault standard developer guide, bridge operational runbook, aBTC integration guide. All published on GitHub.
+  - Documentation — Bridge operational runbook, aBTC integration guide. Published on GitHub.
 
-### Milestone 3: BTC Capital Markets Integration + Ecosystem Launch (Q3 2026)
+### Milestone 2: Vault Standard + Financial Services Integration (Q3 2026)
 
-- **Estimated Delivery:** Q3 2026 (July–September)
-- **Focus:** DA Tokenization Utility integration, aBTC subscription interfaces, BTC settlement pairs, ecosystem launch
+- **Estimated Delivery:** Q3 2026 (August–September)
+- **Funding:** $75,000
+- **Focus:** Canton Vault Standard specification and reference implementations, financial services integration
+- **Deliverables / Value Metrics:**
+  - Canton Vault Standard specification — Published standard with Daml interface definitions, deposit/withdraw flows, share accounting, compliance integration. Formally submitted as a Canton Improvement Proposal (CIP).
+  - Reference vault implementation — Daml vault contract using aBTC as underlying. Deposit, withdraw, redeem, share accounting functional on Canton testnet with >90% unit test coverage. Reviewed by IntellectEU.
+  - Vault composability demonstration — Vault shares used as collateral in an atomic DvP settlement with another CIP-56 asset on Canton testnet. Documented with transaction logs.
+  - Documentation — Vault standard developer guide. Published on GitHub.
+### Milestone 3: BTC Capital Markets Integration + Ecosystem Launch (Q4 2026)
+
+- **Estimated Delivery:** Q4 2026 (October–December)
+- **Funding:** $75,000
+- **Focus:** DA Tokenization Utility integration, aBTC subscription interfaces, BTC settlement pairs, compliant tokenization service integration, ecosystem launch
 - **Deliverables / Value Metrics:**
   - aBTC Subscription Interface — CIP-56 Daml contract enabling atomic DvP subscriptions denominated in aBTC into DA Tokenization Utility-issued assets. Tested end-to-end on Canton testnet.
   - Vault Share Composability — Canton Vault Standard share tokens registered as eligible collateral and subscription assets within DA's credential layer. Demonstrated on Canton testnet.
   - BTC Settlement Pairs — aBTC/tokenized-treasury and aBTC/money-market-fund DvP settlement pairs live on Canton mainnet. At least 2 atomic DvP settlements using aBTC executed and documented.
+  - Compliant Tokenization Service — Canton-side Daml integration for compliant securities issuance. Functional on Canton testnet with documentation.
   - Integration documentation & templates — Open source guides, Daml templates, and TypeScript examples. Published on GitHub. Validated by at least one external developer.
   - Live demonstration — At least one end-to-end aBTC subscription into a Canton-issued asset on mainnet. Documented with transaction logs and participant attestation.
   - Full documentation suite — Complete user guides, API reference, and integration guides for all five components. Published on GitHub.
@@ -363,19 +153,21 @@ The Tech & Ops Committee will evaluate completion based on:
 - Demonstrated functionality or operational readiness
 - Documentation and knowledge transfer provided
 - Alignment with stated value metrics
-- Security audit results (Milestone 2) — 0 critical, 0 unresolved high findings
-- Mainnet operational status (Milestones 2–3) — bridge operational, aBTC mintable, vaults live
+- Security audit results (Milestone 1B) — 0 critical, 0 unresolved high findings
+- Mainnet operational status (Milestones 1B–3) — bridge operational, aBTC mintable, vaults live
 - Adoption evidence (Milestone 3) — minimum TVL thresholds met, at least one institutional participant engaged
-
 ## Funding
 
-**Total Funding Request:** $250,000 USD (payable in CC at prevailing rate)
+**Total Funding Request:** $250,000 USD (payable in CC equivalent)
+
+This budget covers Canton-side Daml contract development, bridge relayer integration, security audits, testing, and documentation. All underlying Arch primitives (DEX, lending protocol, vault infrastructure, tokenization service) are already built and funded by Arch Network independently.
 
 ### Payment Breakdown by Milestone
 
-- **Milestone 1 (Bridge Architecture + aBTC Token):** $100,000 upon committee acceptance
-- **Milestone 2 (Vault Standard + Bridge Production):** $87,500 upon committee acceptance
-- **Milestone 3 (BTC Capital Markets Integration + Ecosystem Launch):** $62,500 upon committee acceptance
+- **Milestone 1A (Bridge Testnet Delivery):** $50,000 upon committee acceptance
+- **Milestone 1B (Bridge Mainnet Readiness):** $50,000 upon committee acceptance
+- **Milestone 2 (Vault Standard + Financial Services Integration):** $75,000 upon committee acceptance
+- **Milestone 3 (BTC Capital Markets Integration + Ecosystem Launch):** $75,000 upon committee acceptance
 
 ### Volatility Stipulation
 
@@ -386,39 +178,37 @@ Should the project timeline extend beyond 6 months due to Committee-requested sc
 Upon release, Arch Network will collaborate with the Foundation on:
 
 - Announcement coordination
-- Joint case study or technical blog highlighting the Arch-Canton integration
+- Case study or technical blog
 - Developer or ecosystem promotion
-
-**Economic Design Audit & Bitcoin Credit Markets Study:** Arch is currently underway on a comprehensive economic design audit and case study of Bitcoin credit markets that supports the thesis behind this proposal. The study demonstrates that Arch’s architecture is structurally more efficient for scaling Bitcoin lending than existing alternatives. We would welcome the opportunity to include Canton in this study — examining how Canton’s institutional settlement layer combined with Arch’s execution infrastructure creates a uniquely efficient credit market design for institutional BTC participants. This joint research could serve as a powerful co-marketing asset for both ecosystems.
-
 ## Motivation
 
 Canton hosts over $9 trillion in tokenized assets and processes approximately $350 billion in daily volume. Institutional participants — including Goldman Sachs (DAP), Broadridge (DLR), and Versana — use Canton for compliant, privacy-preserving financial operations.
 
 However, Canton's connection to Bitcoin — a $2T+ asset class and the most widely held digital asset among institutions — remains underdeveloped. While CBTC provides custodial wrapped BTC on Canton, there is no programmable bridge to Bitcoin-native infrastructure with execution capabilities (lending, trading, structured products), no standardized vault primitive for composable yield strategies, and no mechanism for BTC capital to subscribe to Canton-issued securities.
 
-These gaps limit Canton's ability to attract Bitcoin-denominated capital, restrict the yield strategies available to institutional participants, and raise the barrier to entry for new issuers.
+These gaps mean Canton participants who hold BTC — or whose clients hold BTC — cannot put that capital to work within Canton's compliance framework.
 
-This proposal directly addresses these gaps by delivering open infrastructure that connects Bitcoin's $2T+ asset class to Canton's institutional ecosystem — creating new utility, new capital flows, and new reasons for institutional participants to build on Canton.
+This proposal directly addresses these gaps by delivering open infrastructure that connects Bitcoin's $2T+ asset class to Canton's institutional ecosystem — creating new utility for existing participants and lowering the barrier for new ones.
 
 **Public Good / Ecosystem Value Justification:**
 
-Two of the five components are genuine public goods — open, permissionless infrastructure available to any Canton participant:
+Two of the five components are genuine public goods — open, permissionless infrastructure available to any Canton participant at no cost:
 
-- **Arch–Canton Bridge:** Free, open source bridging infrastructure. Arch does not charge fees for bridging, minting, or burning aBTC. Reusable pattern for other networks to build Canton bridges.
-- **Compliant Tokenization Service:** Open issuance infrastructure for compliant tokenized securities. Any Canton issuer can use it.
+- **Arch–Canton Bridge:** Free, open source bridging infrastructure. Arch does not charge fees for bridging, minting, or burning aBTC. The bridge is a reusable reference architecture — other networks can adapt it to build their own Canton bridges. This is the foundational interoperability layer that makes every other use case possible.
+- **Compliant Tokenization Service:** Open issuance infrastructure for compliant tokenized securities. Any Canton issuer can use it to tokenize securities with proper regulatory compliance on top of the BTC infrastructure. This is classic public good infrastructure that lowers the barrier for all Canton participants.
 
-The remaining three components generate ecosystem value with built-in maintenance incentives — Arch's revenue depends on their functioning, ensuring durable maintenance:
+These two public goods are the critical infrastructure that makes a broader set of commercially viable use cases possible. Arch also offers three commercially operated services that Canton participants gain access to through the public infrastructure:
 
-- **BTC Financial Services Access (DEX + Lending):** Makes Bitcoin productive on Canton. More activity drives Arch Lend and Arch Swap revenue, ensuring continued investment.
-- **Canton Vault Standard:** Open CIP for community adoption. More vault activity drives more lending and trading on Arch infrastructure.
-- **BTC Capital Markets Integration:** Connects Canton's $9T+ asset base to BTC capital. More integrations drive more volume.
+- **BTC Financial Services Access (DEX + Lending):** Makes Bitcoin productive on Canton — deep BTC/stablecoin swaps and stablecoin loans against BTC collateral.
+- **Canton Vault Standard:** An open CIP for community adoption, enabling composable institutional yield strategies.
+- **BTC Capital Markets Integration:** Connects Canton's $9T+ asset base to BTC capital for the first time.
 
+The commercial revenue Arch generates from these services is Arch's skin in the game. Arch is economically incentivized to maintain, scale, and improve the entire stack — including the public goods layer — precisely because the commercial services depend on it. This makes the ecosystem more durable than grant-funded-only infrastructure, where maintenance incentives disappear when grant funds are exhausted. Canton gains infrastructure with built-in, perpetual maintenance incentives that persist long after the grant term ends.
 ## Rationale
 
 **Why Arch Network is the right team:**
 
-Arch Network is an $18M-funded Bitcoin infrastructure company with a 20-person team that has been building for over 2.5 years. Our funding rounds were led by Multicoin Capital and Pantera Capital — two of the most respected institutional crypto investors — reflecting deep conviction in Arch’s technical approach and market positioning. The team has delivered: a production-grade blockchain with BFT consensus, 300ms blocks, and ~1,000 TPS; a Bitcoin-native DEX (Arch Swap); a credit and lending protocol (Arch Lend); and an institutional portfolio dashboard (Arch Prime).
+Arch Network is an $18M-funded Bitcoin infrastructure company with a 20-person team that has been building for over 2.5 years. The team has delivered: a production-grade blockchain with BFT consensus, 300ms blocks, and ~1,000 TPS; a Bitcoin-native DEX (Arch Swap); a credit and lending protocol (Arch Lend); and an institutional portfolio dashboard (Arch Prime).
 
 **Why this approach:**
 
@@ -434,9 +224,9 @@ CBTC serves BTC custody and holding on Canton. It does not support programmable 
 - *Wait for Canton-native BTC lending:* No Canton-native protocol has the execution speed (300ms) or liquidation infrastructure required for safe BTC-collateralized lending at scale.
 - *Use CBTC as collateral base:* The 6-confirmation bottleneck structurally constrains LTVs and makes downstream carry trades less competitive. A purpose-built execution layer is required.
 
-**Daml development partnership:**
+**Daml development partnership: IntellectEU**
 
-Arch aims to engage IntellectEU or Obsidian Systems as a specialist Daml development partner for Canton-side contract work. Both are recognized Daml ecosystem developers with Canton production experience. This converts the Daml learning curve from a team capability risk to a managed vendor relationship with defined deliverables and review gates.
+Arch has selected IntellectEU as its specialist Daml development partner for Canton-side contract work across all milestones. IntellectEU is a recognized Daml ecosystem developer with Canton production experience. This converts the Daml learning curve from a team capability risk to a managed vendor relationship with defined deliverables and review gates.
 
 **Existing ecosystem partnerships providing day-one demand:**
 

--- a/proposals/arch-bitcoin-capital-markets-stack.md
+++ b/proposals/arch-bitcoin-capital-markets-stack.md
@@ -6,37 +6,133 @@
 
 ## Abstract
 
-[PASTE YOUR FINAL DRAFT CONTENT HERE]
+Arch and Canton are structurally complementary institutions. Canton provides the institutional compliance layer, sub-transaction privacy, and atomic DvP settlement that capital markets require. Arch provides Bitcoin-native execution and settlement infrastructure — 300ms blocks, ~1,000 TPS, validator-secured collateral enforcement, and native Bitcoin settlement. Together, they can create the capital markets corridor between Bitcoin’s $2T+ and Canton’s $9T+ institutional asset ecosystem.
+
+Bitcoin is a $2T+ asset with no scalable form of native yield. The most viable strategy for making BTC productive — for institutions, family offices, and sophisticated investors — is the credit carry trade: borrow against BTC collateral, deploy stablecoins into yield-generating strategies (private credit, yield ETFs, money market instruments), collect yield, repay the loan, keep the spread as net BTC yield. This strategy requires fast execution, deterministic collateral enforcement, and deep liquidity — exactly what Arch’s infrastructure provides.
+
+This proposal describes five infrastructure components that deliver a full Bitcoin financial services stack for Canton to facilitate this:
+
+1. **Arch–Canton Bridge** — Foundational interoperability infrastructure connecting native BTC to Canton Network. Also serves as the connectivity layer for Arch’s financial services (DEX, lending, vaults) to Canton participants. Institutions interact through existing custody relationships (Anchorage, Ceffu, Utila) — no new custody required.
+
+2. **BTC Financial Services Access (DEX + Lending)** — Canton participants gain access to Arch Swap (deep BTC/stablecoin liquidity) and Arch Lend (stablecoin loans against BTC collateral) through the bridge. These are the financial primitives that make BTC productive — without them, BTC on Canton is a holding asset, not a working one.
+
+3. **Canton Vault Standard** — A standardized, composable vault interface written in Daml (analogous to Ethereum’s ERC-4626) that enables institutional yield strategies on Canton. Once credit infrastructure exists, vaults become the vehicle for deploying it — private credit strategies, yield ETFs, debt tranches, corporate bonds, subscription agreements with fund asset managers, and other tradfi yield strategies, all accessible through a standard interface.
+
+4. **BTC Capital Markets Integration for DA’s Tokenization Utility** — An integration layer connecting Arch’s financial services to DA’s existing issuance infrastructure, enabling aBTC as a native subscription and settlement asset for tokenized securities on Canton.
+
+5. **Compliant Tokenization Service** — A compliant securities issuance service that enables the tokenization of yield instruments, fund shares, structured products, and other securities on top of the BTC infrastructure with proper regulatory compliance. This is a public good for Canton’s ecosystem: any issuer can use it to create compliant tokenized securities backed by or denominated in BTC.
+
+Together, these components deliver a complete Bitcoin capital markets stack for Canton: bridge access, deep swaps, institutional lending, tradfi yield infrastructure, compliant securities tokenization — and the capital markets integration that connects all of it to Canton’s existing $9T+ tokenized asset base.
 
 ## Specification
 
 ### 1. Objective
 
-[Describe the specific problem being solved and the intended outcome.]
+Connect Bitcoin’s $2T+ asset class to Canton’s $9T+ institutional ecosystem through purpose-built financial infrastructure. Specifically: enable institutional BTC holders to earn yield on their Bitcoin without leaving the Canton compliance framework, and enable Canton-native asset issuers to access BTC-denominated capital for the first time.
+
+The five infrastructure components solve three problems that Canton cannot solve internally:
+
+- **No programmable BTC bridge with execution capabilities.** Canton has CBTC (custodial holding), but no mechanism for BTC capital to flow into lending, trading, or yield strategies. The Arch–Canton Bridge solves this.
+- **No standardized vault primitive.** Ethereum’s ERC-4626 has enabled billions in composable DeFi strategies. Canton has no equivalent. The Canton Vault Standard fills this gap.
+- **No BTC capital onramp for tokenized assets.** DA’s Tokenization Utility provides world-class issuance infrastructure, but there is no mechanism for BTC capital to subscribe to Canton-issued securities. The BTC Capital Markets Integration builds that connection.
 
 ### 2. Implementation Mechanics
 
-[Explain how the solution will be implemented. Include technologies, components, workflows, and operational approach.]
+**Arch–Canton Bridge**
+
+The bridge uses a relayer-based architecture with FROST threshold signatures for security:
+
+- Arch to Canton: User locks BTC on Arch, validators produce signed attestation, relayer transmits to Canton, Canton bridge contract verifies and mints CIP-56 aBTC token via Offer-Accept protocol.
+- Canton to Arch: User transfers aBTC to bridge contract, bridge burns aBTC and emits withdrawal attestation, relayer transmits to Arch, validators construct and sign Bitcoin unlock transaction, user receives native BTC.
+- Security: FROST threshold signatures, per-epoch volume caps, emergency pause, reorg handling via DAG-based transaction tracking and UTXO anchoring.
+- Relayer model: Permissionless — any party can relay valid attestations. Minimum 3 independent operators recommended.
+
+**aBTC Token (CIP-56)**
+
+- Standard: CIP-56 compliant, 8 decimals (matching BTC), mint authority restricted to bridge contract only.
+- Compliance: Configurable transfer restrictions (KYC, jurisdictional, accredited investor checks), regulatory observer support.
+- Oracle: Dual-oracle design (RedStone primary, Chainlink secondary), 5-minute staleness threshold, 2% divergence handling, 10-minute TWAP, circuit breaker.
+
+**Canton Vault Standard**
+
+- Daml-based interface analogous to ERC-4626: deposit/withdraw via CIP-56 Offer-Accept, share token accounting, compliance-gated deposits.
+- View functions: totalAssets, totalShares, convertToShares, convertToAssets, maxDeposit, maxWithdraw.
+- Composability: Vault shares usable as collateral in Acme/Palladium, settleable via DvP, nestable in other vaults.
+- Reference implementations: HoneyB vault (private credit yield via Simplify, $13B AUM ETF platform), delta-neutral vault (funding rate capture).
+
+**BTC Capital Markets Integration**
+
+- aBTC Subscription Interface: Enables atomic DvP subscriptions denominated in aBTC into DA Tokenization Utility-issued assets.
+- Vault Share Composability: Vault share tokens registered as eligible collateral and subscription assets within DA’s credential layer.
+- BTC Settlement Pairs: aBTC/tokenized-treasury, aBTC/money-market-fund, aBTC/private-credit DvP settlement pairs.
+- Open source integration guides, Daml templates, and TypeScript examples for issuers.
+
+**Compliant Tokenization Service**
+
+- Compliant issuance of securities as tokens on Canton — open, permissionless infrastructure.
+- Supports yield instruments, fund shares, structured products, and other securities with proper regulatory compliance.
+- KYC/AML, accreditation, and jurisdictional controls enforced at issuance level.
 
 ### 3. Architectural Alignment
 
-[Describe how this work aligns with Canton architecture, ecosystem priorities, and relevant CIPs.]
+This proposal aligns with Canton’s architecture and ecosystem priorities:
+
+- **CIP-56 compliance:** aBTC is a native CIP-56 token, fully compatible with Canton’s Offer-Accept transfer model, sub-transaction privacy, and regulatory observer framework.
+- **DvP settlement:** All components support Canton’s atomic DvP settlement — aBTC subscriptions, vault share trades, and BTC settlement pairs all settle atomically via the Global Synchronizer.
+- **Daml-native:** Bridge contracts, vault standard, and tokenization protocol are implemented in Daml, leveraging Canton’s smart contract model and benefiting from its privacy and composability guarantees.
+- **Canton Improvement Proposal:** The Canton Vault Standard will be submitted as a formal CIP for community adoption, contributing to Canton’s standards ecosystem.
+- **DA Tokenization Utility integration:** The BTC Capital Markets Integration builds on top of DA’s existing issuance infrastructure rather than replacing it — aBTC becomes a new payment and collateral leg for assets already issued via DA’s Tokenization Utility.
+- **Institutional compliance model:** Vault-level compliance gating (KYC, accreditation, jurisdictional rules) enforced at deposit, aligned with Canton’s institutional-grade compliance framework.
 
 ### 4. Backward Compatibility
 
-No backward compatibility impact.
+No backward compatibility impact. All components are additive:
+
+- aBTC is a new CIP-56 token — does not modify existing token contracts or standards.
+- The Canton Vault Standard is a new primitive — does not change existing Daml contracts.
+- The bridge introduces new contracts (BridgeController, DepositAttestation, MintAuthority, WithdrawalRequest) that interact with Canton via standard CIP-56 mechanics.
+- BTC Capital Markets Integration adds subscription and settlement interfaces on top of DA’s existing Tokenization Utility — no modifications to DA’s contracts required.
+- Compliant Tokenization Service is independent infrastructure, available to any Canton participant.
 
 ## Milestones and Deliverables
 
-### Milestone 1: (Name)
-- **Estimated Delivery:**
-- **Focus:**
-- **Deliverables / Value Metrics:**
+### Milestone 1: Bridge Architecture + aBTC Token (Q2 2026)
 
-### Milestone 2: (Name)
-- **Estimated Delivery:**
-- **Focus:**
+- **Estimated Delivery:** Q2 2026 (April–June)
+- **Focus:** Bridge design, Daml contract development, aBTC token deployment on testnet, relayer prototype
 - **Deliverables / Value Metrics:**
+  - Bridge design specification — published technical document covering architecture, security model, message format, and failure modes.
+  - Daml bridge contracts — BridgeController, DepositAttestation, MintAuthority, WithdrawalRequest implemented with >90% unit test coverage.
+  - Arch-side lock/burn contracts — UTXO-based contracts deployed on Arch testnet with passing integration tests.
+  - aBTC CIP-56 token — Compliant token contract with compliance hooks, transfer restrictions, and DvP support. Deployed on Canton testnet.
+  - Relayer prototype — Functional relayer with at least 100 successful cross-chain transfers demonstrated.
+  - Integration tests — End-to-end tests. Minimum 50 test cases covering normal and failure paths.
+  - Documentation — Developer guide for bridge integration. aBTC token specification. Published on GitHub.
+
+### Milestone 2: Vault Standard + Bridge Production (Q3 2026)
+
+- **Estimated Delivery:** Q3 2026 (July–September)
+- **Focus:** Canton Vault Standard specification, reference implementations, bridge security audit, mainnet deployment
+- **Deliverables / Value Metrics:**
+  - Canton Vault Standard specification — Published standard. Formally submitted as a Canton Improvement Proposal (CIP).
+  - Reference vault implementation — Daml vault contract using aBTC as underlying with >90% unit test coverage.
+  - Vault composability demonstration — Vault shares used as collateral in an atomic DvP settlement.
+  - Bridge security audit — Third-party audit. 0 critical findings, 0 unresolved high findings. Audit report published publicly.
+  - Bridge mainnet deployment — Contracts deployed on Arch mainnet and Canton mainnet. At least 10 mainnet bridge transfers.
+  - aBTC mainnet launch — aBTC live on Canton mainnet, mintable via bridge.
+  - Documentation — Vault standard developer guide, bridge operational runbook, aBTC integration guide.
+
+### Milestone 3: BTC Capital Markets Integration + Ecosystem Launch (Q4 2026)
+
+- **Estimated Delivery:** Q4 2026 (October–December)
+- **Focus:** DA Tokenization Utility integration, aBTC subscription interfaces, BTC settlement pairs, ecosystem launch
+- **Deliverables / Value Metrics:**
+  - aBTC Subscription Interface — CIP-56 Daml contract enabling atomic DvP subscriptions into DA Tokenization Utility-issued assets.
+  - Vault Share Composability — Share tokens registered as eligible collateral within DA’s credential layer.
+  - BTC Settlement Pairs — aBTC/tokenized-treasury and aBTC/money-market-fund DvP settlement pairs live on Canton mainnet.
+  - Integration documentation and templates — Open source guides, Daml templates, and TypeScript examples.
+  - Live demonstration — At least one end-to-end aBTC subscription into a Canton-issued asset on mainnet.
+  - Full documentation suite — Complete user guides, API reference, and integration guides for all five components.
 
 ## Acceptance Criteria
 
@@ -46,6 +142,9 @@ The Tech & Ops Committee will evaluate completion based on:
 - Demonstrated functionality or operational readiness
 - Documentation and knowledge transfer provided
 - Alignment with stated value metrics
+- Security audit results (Milestone 2) — 0 critical, 0 unresolved high findings
+- Mainnet operational status (Milestones 2–3) — bridge operational, aBTC mintable, vaults live
+- Adoption evidence (Milestone 3) — minimum TVL thresholds met, at least one institutional participant engaged
 
 ## Funding
 
@@ -53,8 +152,9 @@ The Tech & Ops Committee will evaluate completion based on:
 
 ### Payment Breakdown by Milestone
 
-- **Milestone 1 (Name):** XX CC upon committee acceptance
-- **Milestone 2 (Name):** XX CC upon committee acceptance
+- **Milestone 1 (Bridge Architecture + aBTC Token):** XX CC upon committee acceptance
+- **Milestone 2 (Vault Standard + Bridge Production):** XX CC upon committee acceptance
+- **Milestone 3 (BTC Capital Markets Integration + Ecosystem Launch):** XX CC upon committee acceptance
 
 ### Volatility Stipulation
 
@@ -70,8 +170,49 @@ Upon release, Arch Network will collaborate with the Foundation on:
 
 ## Motivation
 
-[Why is this valuable to the Canton ecosystem? Describe the ecosystem impact, expected adoption, or strategic importance.]
+Canton hosts over $9 trillion in tokenized assets and processes approximately $350 billion in daily volume. Institutional participants — including Goldman Sachs (DAP), Broadridge (DLR), and Versana — use Canton for compliant, privacy-preserving financial operations.
+
+However, Canton’s connection to Bitcoin — a $2T+ asset class and the most widely held digital asset among institutions — remains underdeveloped. While CBTC provides custodial wrapped BTC on Canton, there is no programmable bridge to Bitcoin-native infrastructure with execution capabilities, no standardized vault primitive for composable yield strategies, and no mechanism for BTC capital to subscribe to Canton-issued securities.
+
+These gaps limit Canton’s ability to attract Bitcoin-denominated capital, restrict yield strategies available to institutional participants, and raise the barrier to entry for new issuers.
+
+This proposal directly addresses these gaps by delivering open infrastructure that connects Bitcoin’s $2T+ asset class to Canton’s institutional ecosystem — creating new utility, new capital flows, and new reasons for institutional participants to build on Canton.
+
+**Public Good / Ecosystem Value Justification:**
+
+Two of the five components are genuine public goods — open, permissionless infrastructure available to any Canton participant:
+
+- **Arch–Canton Bridge:** Free, open source bridging infrastructure. Arch does not charge fees for bridging, minting, or burning aBTC.
+- **Compliant Tokenization Service:** Open issuance infrastructure for compliant tokenized securities. Any Canton issuer can use it.
+
+The remaining three generate ecosystem value with built-in maintenance incentives:
+
+- **BTC Financial Services Access (DEX + Lending):** Makes Bitcoin productive on Canton.
+- **Canton Vault Standard:** Open CIP for community adoption.
+- **BTC Capital Markets Integration:** Connects Canton’s $9T+ asset base to BTC capital.
 
 ## Rationale
 
-[Why is this the right approach to deliver that value? Explain design decisions, alternatives considered, and why this solution is preferred.]
+**Why Arch Network is the right team:**
+
+Arch Network is an $18M-funded Bitcoin infrastructure company with a 20-person team building for over 2.5 years. Delivered: production-grade blockchain with BFT consensus, 300ms blocks, ~1,000 TPS; Bitcoin-native DEX (Arch Swap); credit and lending protocol (Arch Lend); institutional portfolio dashboard (Arch Prime).
+
+**Why this approach:**
+
+The vertically integrated approach is deliberate. Each component’s value is amplified by the others — bridge enables aBTC, aBTC enables lending, lending enables vaults, vaults enable structured products, capital markets integration connects all of it to Canton’s existing asset base. Self-reinforcing adoption flywheel.
+
+**Why not CBTC alone:**
+
+CBTC serves BTC custody and holding. It does not support programmable lending, vault strategies, or capital markets integration. CBTC requires 6 Bitcoin confirmations (~60 minutes) for issuance/redemption, creating a collateral enforcement bottleneck. Arch’s 300ms execution eliminates this. CBTC and aBTC are complementary — CBTC for custody, aBTC for capital markets.
+
+**Daml development partnership:**
+
+Arch aims to engage IntellectEU or Obsidian Systems as specialist Daml development partner. Both are recognized Canton ecosystem developers with production experience.
+
+**Existing ecosystem partnerships providing day-one demand:**
+
+- Institutional custodian integrations: Anchorage, Ceffu, Utila
+- HoneyB: Active asset management partnership for BTC private credit yield strategies
+- Institutional liquidity providers: Galaxy, Pantera — committed to seeding initial vault liquidity
+- DAT partners: Digital Asset Trusts going live with $10–20M BTC yield pilots
+

--- a/proposals/arch-bitcoin-capital-markets-stack.md
+++ b/proposals/arch-bitcoin-capital-markets-stack.md
@@ -109,9 +109,9 @@ No backward compatibility impact. All components are additive:
   - Integration tests — End-to-end tests (Arch deposit → Canton mint, Canton burn → Arch unlock). Minimum 50 test cases covering normal and failure paths. Test suite published.
   - Documentation — Developer guide for bridge integration. aBTC token specification. Published on GitHub with README and quickstart.
 
-### Milestone 2: Vault Standard + Bridge Production (Q3 2026)
+### Milestone 2: Vault Standard + Bridge Production (Q2 2026)
 
-- **Estimated Delivery:** Q3 2026 (July–September)
+- **Estimated Delivery:** Q2 2026 (April–June)
 - **Focus:** Canton Vault Standard specification and reference implementations, bridge security audit, mainnet deployment, aBTC mainnet launch
 - **Deliverables / Value Metrics:**
   - Canton Vault Standard specification — Published standard with Daml interface definitions, deposit/withdraw flows, share accounting, compliance integration. Formally submitted as a Canton Improvement Proposal (CIP).
@@ -122,9 +122,9 @@ No backward compatibility impact. All components are additive:
   - aBTC mainnet launch — aBTC live on Canton mainnet, mintable via bridge. At least one institutional participant has minted aBTC.
   - Documentation — Vault standard developer guide, bridge operational runbook, aBTC integration guide. All published on GitHub.
 
-### Milestone 3: BTC Capital Markets Integration + Ecosystem Launch (Q4 2026)
+### Milestone 3: BTC Capital Markets Integration + Ecosystem Launch (Q3 2026)
 
-- **Estimated Delivery:** Q4 2026 (October–December)
+- **Estimated Delivery:** Q3 2026 (July–September)
 - **Focus:** DA Tokenization Utility integration, aBTC subscription interfaces, BTC settlement pairs, ecosystem launch
 - **Deliverables / Value Metrics:**
   - aBTC Subscription Interface — CIP-56 Daml contract enabling atomic DvP subscriptions denominated in aBTC into DA Tokenization Utility-issued assets. Tested end-to-end on Canton testnet.

--- a/proposals/arch-bitcoin-capital-markets-stack.md
+++ b/proposals/arch-bitcoin-capital-markets-stack.md
@@ -1,173 +1,185 @@
 # Development Fund Proposal
 
-**Author:** Arch Network (Matt Mudano)
-**Status:** Draft
-**Created:** 2026-04-01
+## Arch-Canton Bridge and Canton Vault Standard
+
+Author: Arch Network (Matt Mudano)
+
+Daml Development Partner: IntellectEU
+
+Status: Draft
+
+Created: 2026-04-01
+
+Total Funding Request: $150,000 USD (payable in CC equivalent)
 
 ## Abstract
 
-Arch and Canton are structurally complementary institutions. Canton provides the institutional compliance layer, sub-transaction privacy, and atomic DvP settlement that capital markets require. Arch provides Bitcoin-native execution and settlement infrastructure — 300ms blocks, ~1,000 TPS, validator-secured collateral enforcement, and native Bitcoin settlement. Together, they can create the capital markets corridor between Bitcoin's $2T+ and Canton's $9T+ institutional asset ecosystem.
+This proposal requests $150,000 to build two public good infrastructure components that connect Bitcoin to Canton Network:
 
-Bitcoin is a $2T+ asset with no scalable form of native yield. The most viable strategy for making BTC productive — for institutions, family offices, and sophisticated investors — is the credit carry trade: borrow against BTC collateral, deploy stablecoins into yield-generating strategies (private credit, yield ETFs, money market instruments), collect yield, repay the loan, keep the spread as net BTC yield. This strategy requires fast execution, deterministic collateral enforcement, and deep liquidity — exactly what Arch's infrastructure provides.
+- Arch-Canton Bridge - a bidirectional, fee-free, open source bridge that mints CIP-56-compliant aBTC on Canton, enabling BTC holders to access Canton’s institutional ecosystem and Canton participants to access Bitcoin liquidity.
+- Canton Vault Standard - a standardized, composable vault interface written in Daml (analogous to Ethereum’s ERC-4626), submitted as a formal Canton Improvement Proposal (CIP) for community adoption.
 
-All five of the infrastructure primitives described below are already fully built and deployed on Arch Network. This proposal does not request funding to build these products from scratch — it requests funding to build the Daml contracts and integration layer that connect Arch's existing, production-tested infrastructure to Canton Network. The $250K budget covers Canton-side Daml contract development, bridge relayer integration, testing, security audits, and documentation — executed by IntellectEU, a specialist Daml development firm with Canton production experience.
+Both components are open, permissionless infrastructure available to any Canton participant at no cost. The $150K budget covers Canton-side Daml contract development, bridge relayer integration, testing, security audit, and documentation. All work will be executed by IntellectEU, a specialist Daml development firm with Canton production experience.
 
-This proposal describes five infrastructure components that deliver a full Bitcoin financial services stack for Canton to facilitate this:
-
-1. **Arch–Canton Bridge** — Foundational interoperability infrastructure connecting native BTC to Canton Network. Also serves as the connectivity layer for Arch's financial services (DEX, lending, vaults) to Canton participants. Institutions interact through existing custody relationships (Anchorage, Ceffu, Utila) — no new custody required.
-
-2. **BTC Financial Services Access (DEX + Lending)** — Canton participants gain access to Arch Swap (deep BTC/stablecoin liquidity) and Arch Lend (stablecoin loans against BTC collateral) through the bridge. These are the financial primitives that make BTC productive — without them, BTC on Canton is a holding asset, not a working one.
-
-3. **Canton Vault Standard** — A standardized, composable vault interface written in Daml (analogous to Ethereum's ERC-4626) that enables institutional yield strategies on Canton. Once credit infrastructure exists, vaults become the vehicle for deploying it — private credit strategies, yield ETFs, debt tranches, corporate bonds, subscription agreements with fund asset managers, and other tradfi yield strategies, all accessible through a standard interface.
-
-4. **BTC Capital Markets Integration for DA's Tokenization Utility** — An integration layer connecting Arch's financial services to DA's existing issuance infrastructure, enabling aBTC as a native subscription and settlement asset for tokenized securities on Canton.
-
-5. **Compliant Tokenization Service** — A compliant securities issuance service that enables the tokenization of yield instruments, fund shares, structured products, and other securities on top of the BTC infrastructure with proper regulatory compliance. This is a public good for Canton's ecosystem: any issuer can use it to create compliant tokenized securities backed by or denominated in BTC.
-
-Together, these components deliver a complete Bitcoin capital markets stack for Canton: bridge access, deep swaps, institutional lending, tradfi yield infrastructure, compliant securities tokenization — and the capital markets integration that connects all of it to Canton's existing $9T+ tokenized asset base.
+The underlying Arch-side infrastructure (consensus, execution, settlement) is already built and deployed. This proposal funds only the Canton integration layer.
 
 ## Specification
 
 ### 1. Objective
 
-Connect Bitcoin's $2T+ asset class to Canton's $9T+ institutional ecosystem through purpose-built financial infrastructure. Specifically: enable institutional BTC holders to earn yield on their Bitcoin without leaving the Canton compliance framework, and enable Canton-native asset issuers to access BTC-denominated capital for the first time.
+Connect Bitcoin’s $2T+ asset class to Canton’s $9T+ institutional ecosystem through two foundational infrastructure primitives. Specifically:
 
-The five infrastructure components solve three problems that Canton cannot solve internally:
+- Bridge a gap in programmable BTC access. Canton has CBTC for custodial BTC holding, but no programmable bridge with execution capabilities. The Arch-Canton Bridge provides bidirectional BTC movement with 300ms execution, enabling BTC capital to flow into Canton’s DvP settlement, lending, and yield infrastructure, and Canton participants to access Bitcoin-native liquidity.
+- Fill a missing Daml primitive. Ethereum’s ERC-4626 vault standard has enabled billions in composable yield strategies. Canton has no equivalent. The Canton Vault Standard creates this primitive, enabling any Canton developer to build composable vaults for any underlying asset.
 
-- **No programmable BTC bridge with execution capabilities.** Canton has CBTC (custodial holding), but no mechanism for BTC capital to flow into lending, trading, or yield strategies. The Arch–Canton Bridge solves this.
-- **No standardized vault primitive.** Ethereum's ERC-4626 has enabled billions in composable DeFi strategies. Canton has no equivalent. The Canton Vault Standard fills this gap.
-- **No BTC capital onramp for tokenized assets.** DA's Tokenization Utility provides world-class issuance infrastructure, but there is no mechanism for BTC capital to subscribe to Canton-issued securities. The BTC Capital Markets Integration builds that connection.
-### 2. Implementation Mechanics
+### 2. Component 1: Arch-Canton Bridge
 
-**Arch–Canton Bridge**
+The bridge uses a relayer-based architecture with FROST threshold signatures for security.
 
-The bridge uses a relayer-based architecture with FROST threshold signatures for security:
+Bridge mechanics:
 
-- Arch → Canton: User locks BTC on Arch → validators produce signed attestation → relayer transmits to Canton → Canton bridge contract verifies and mints CIP-56 aBTC token via Offer-Accept protocol.
-- Canton → Arch: User transfers aBTC to bridge contract → bridge burns aBTC and emits withdrawal attestation → relayer transmits to Arch → validators construct and sign Bitcoin unlock transaction → user receives native BTC.
+- Arch to Canton: User locks BTC on Arch. Validators produce a signed attestation. Relayer transmits to Canton. Canton bridge contract verifies and mints CIP-56 aBTC via Offer-Accept protocol.
+- Canton to Arch: User transfers aBTC to bridge contract. Bridge burns aBTC and emits withdrawal attestation. Relayer transmits to Arch. Validators construct and sign Bitcoin unlock transaction. User receives native BTC.
 - Security: (⌈2N/3⌉ + 1)-of-N FROST threshold signatures, per-epoch volume caps, emergency pause, reorg handling via DAG-based transaction tracking and UTXO anchoring.
-- Relayer model: Permissionless — any party can relay valid attestations. Minimum 3 independent operators recommended.
+- Relayer model: Permissionless. Any party can relay valid attestations. Minimum 3 independent operators recommended.
 
-**aBTC Token (CIP-56)**
+aBTC token (CIP-56):
 
-- Standard: CIP-56 compliant, 8 decimals (matching BTC), mint authority restricted to bridge contract only.
-- Compliance: Configurable transfer restrictions (KYC, jurisdictional, accredited investor checks), regulatory observer support.
-- Oracle: Dual-oracle design (RedStone primary, Chainlink secondary), 5-minute staleness threshold, 2% divergence handling, 10-minute TWAP, circuit breaker.
+- CIP-56 compliant, 8 decimals (matching BTC), mint authority restricted to bridge contract only.
+- Configurable transfer restrictions (KYC, jurisdictional, accredited investor checks), regulatory observer support.
+- Dual-oracle design (RedStone primary, Chainlink secondary), 5-minute staleness threshold, 2% divergence handling, 10-minute TWAP, circuit breaker.
 
-**Canton Vault Standard**
+Public good characteristics:
 
-- Daml-based interface analogous to ERC-4626: deposit/withdraw via CIP-56 Offer-Accept, share token accounting, compliance-gated deposits.
+- Free and open source. Arch does not charge fees for bridging, minting, or burning aBTC.
+- Reusable reference architecture. Other networks can adapt the bridge design to build their own Canton bridges.
+- Bidirectional value flow. BTC holders gain access to Canton’s tokenized asset ecosystem; Canton participants gain access to Bitcoin liquidity.
+
+### 3. Component 2: Canton Vault Standard
+
+A Daml-based vault interface specification analogous to Ethereum’s ERC-4626, providing a standardized primitive for composable yield strategies on Canton.
+
+Interface:
+
+- Deposit/withdraw via CIP-56 Offer-Accept, share token accounting, compliance-gated deposits.
 - View functions: totalAssets, totalShares, convertToShares, convertToAssets, maxDeposit, maxWithdraw.
-- Composability: Vault shares usable as collateral in Acme/Palladium, settleable via DvP, nestable in other vaults.
-- Reference implementations: HoneyB vault (private credit yield via Simplify, $13B AUM ETF platform), delta-neutral vault (funding rate capture).
-**BTC Capital Markets Integration**
+- Composability: vault shares usable as collateral in existing Canton applications, settleable via DvP, nestable in other vaults.
 
-- aBTC Subscription Interface: Enables atomic DvP subscriptions denominated in aBTC into DA Tokenization Utility-issued assets.
-- Vault Share Composability: Vault share tokens registered as eligible collateral and subscription assets within DA's credential layer.
-- BTC Settlement Pairs: aBTC/tokenized-treasury, aBTC/money-market-fund, aBTC/private-credit DvP settlement pairs.
-- Open source integration guides, Daml templates, and TypeScript examples for issuers.
+Reference implementation:
 
-**Compliant Tokenization Service**
+- A reference vault using aBTC as the underlying asset, demonstrating the full deposit/withdraw/redeem lifecycle.
+- The standard itself is asset-agnostic. Any CIP-56 token can serve as a vault underlying.
 
-- Compliant issuance of securities as tokens on Canton — open, permissionless infrastructure.
-- Supports yield instruments, fund shares, structured products, and other securities with proper regulatory compliance.
-- KYC/AML, accreditation, and jurisdictional controls enforced at issuance level.
+Public good characteristics:
 
-### 3. Architectural Alignment
+- Submitted as a formal Canton Improvement Proposal (CIP) for community adoption.
+- Open standard. Any Canton developer can build vaults using this interface for any asset class.
+- Fills a documented gap in Canton’s smart contract primitives.
 
-This proposal aligns with Canton's architecture and ecosystem priorities:
+### 4. Architectural Alignment
 
-- **CIP-56 compliance:** aBTC is a native CIP-56 token, fully compatible with Canton's Offer-Accept transfer model, sub-transaction privacy, and regulatory observer framework.
-- **DvP settlement:** All components support Canton's atomic DvP settlement — aBTC subscriptions, vault share trades, and BTC settlement pairs all settle atomically via the Global Synchronizer.
-- **Daml-native:** Bridge contracts, vault standard, and tokenization protocol are implemented in Daml, leveraging Canton's smart contract model and benefiting from its privacy and composability guarantees.
-- **Canton Improvement Proposal:** The Canton Vault Standard will be submitted as a formal CIP for community adoption, contributing to Canton's standards ecosystem.
-- **DA Tokenization Utility integration:** The BTC Capital Markets Integration builds on top of DA's existing issuance infrastructure rather than replacing it — aBTC becomes a new payment and collateral leg for assets already issued via DA's Tokenization Utility.
-- **Institutional compliance model:** Vault-level compliance gating (KYC, accreditation, jurisdictional rules) enforced at deposit, aligned with Canton's institutional-grade compliance framework.
-### 4. Backward Compatibility
+Both components align with Canton’s architecture and ecosystem priorities:
 
-No backward compatibility impact. All components are additive:
+- CIP-56 compliance: aBTC is a native CIP-56 token, fully compatible with Canton’s Offer-Accept transfer model, sub-transaction privacy, and regulatory observer framework.
+- DvP settlement: aBTC and vault shares settle atomically via the Global Synchronizer.
+- Daml-native: Bridge contracts and vault standard are implemented in Daml, leveraging Canton’s smart contract model and privacy guarantees.
+- Credential Utility compatible: aBTC holder requirements and vault deposit gates integrate with DA’s existing Credential Utility for KYC/AML enforcement.
+- Registry Utility compatible: Once minted, aBTC participates in DA’s Registry Utility workflows (transfer, allocation, settlement) with no custom integration required.
 
-- aBTC is a new CIP-56 token — does not modify existing token contracts or standards.
-- The Canton Vault Standard is a new primitive — does not change existing Daml contracts.
+### 5. Backward Compatibility
+
+No backward compatibility impact. Both components are additive:
+
+- aBTC is a new CIP-56 token. Does not modify existing token contracts or standards.
+- The Canton Vault Standard is a new primitive. Does not change existing Daml contracts.
 - The bridge introduces new contracts (BridgeController, DepositAttestation, MintAuthority, WithdrawalRequest) that interact with Canton via standard CIP-56 mechanics.
-- BTC Capital Markets Integration adds subscription and settlement interfaces on top of DA's existing Tokenization Utility — no modifications to DA's contracts required.
-- Compliant Tokenization Service is independent infrastructure, available to any Canton participant.
+
+## Ecosystem Benefits
+
+Once the bridge and vault standard are live, they enable a broader set of use cases for the Canton ecosystem. These are not funded deliverables but represent the downstream value of the public good infrastructure:
+
+- BTC financial services access. Canton participants can bridge aBTC and access BTC/stablecoin liquidity (via Arch Swap) and stablecoin loans against BTC collateral (via Arch Lend). These services are operated and funded by Arch Network independently.
+- Composable yield strategies. The vault standard enables institutional yield strategies on Canton: private credit, yield ETFs, debt tranches, and other tradfi yield products, all through a standardized interface.
+- BTC-denominated capital markets. aBTC as a CIP-56 token can participate in DA’s existing Registry Utility workflows, enabling BTC-denominated subscriptions into tokenized securities issued via DA’s Registry App. No additional integration infrastructure is needed beyond the bridge itself.
+- BTC as collateral. aBTC can be used in DA’s Collateral Utility for margin agreements and collateral settlement, bringing Bitcoin into Canton’s existing institutional collateral framework.
 
 ## Milestones and Deliverables
 
-All milestones below cover Canton-side Daml integration work only. The underlying Arch primitives (bridge logic, DEX, lending protocol, vault infrastructure, tokenization service) are already built and deployed. IntellectEU will lead Daml contract development across all milestones.
+All milestones cover Canton-side Daml integration work only. The underlying Arch primitives (consensus, execution, settlement) are already built and deployed. IntellectEU will lead Daml contract development across all milestones.
 
-### Milestone 1A: Bridge Testnet Delivery (Q2 2026)
+### Milestone 1A: Bridge Testnet Delivery
 
-- **Estimated Delivery:** Q2 2026 (April–May)
-- **Funding:** $50,000
-- **Focus:** Bridge design, Daml contract development, aBTC token deployment on testnet, relayer prototype
-- **Deliverables / Value Metrics:**
-  - Bridge design specification — published technical document covering architecture, security model, message format, and failure modes. Reviewed by at least one independent Daml ecosystem developer.
-  - Daml bridge contracts — BridgeController, DepositAttestation, MintAuthority, WithdrawalRequest implemented with >90% unit test coverage. Source code published on GitHub. Reviewed by IntellectEU.
-  - Arch-side lock/burn contracts — UTXO-based contracts deployed on Arch testnet with passing integration tests.
-  - aBTC CIP-56 token — Compliant token contract with compliance hooks, transfer restrictions, and DvP support. Deployed on Canton testnet. Passes Canton token standard conformance tests.
-  - Relayer prototype — Functional relayer transmitting attestations between Arch testnet and Canton testnet. At least 100 successful cross-chain transfers demonstrated.
-  - Integration tests — End-to-end tests (Arch deposit → Canton mint, Canton burn → Arch unlock). Minimum 50 test cases covering normal and failure paths. Test suite published.
-  - Documentation — Developer guide for bridge integration. aBTC token specification. Published on GitHub with README and quickstart.
-### Milestone 1B: Bridge Mainnet Readiness (Q2–Q3 2026)
+| | |
+|---|---|
+| **Delivery** | Q2 2026 (April–May) |
+| **Funding** | $50,000 |
+| **Focus** | Bridge design, Daml contract development, aBTC token deployment on testnet, relayer prototype |
 
-- **Estimated Delivery:** Q2–Q3 2026 (June–July)
-- **Funding:** $50,000
-- **Focus:** Bridge security audit, mainnet deployment, aBTC mainnet launch
-- **Deliverables / Value Metrics:**
-  - Bridge security audit — Third-party audit by a recognized firm (Certora, Trail of Bits, or equivalent). 0 critical findings, 0 unresolved high findings. Audit report published publicly.
-  - Bridge mainnet deployment — Contracts deployed on Arch mainnet and Canton mainnet. Relayer operational with uptime monitoring and alerting. At least 10 mainnet bridge transfers processed.
-  - aBTC mainnet launch — aBTC live on Canton mainnet, mintable via bridge. At least one institutional participant has minted aBTC.
-  - Documentation — Bridge operational runbook, aBTC integration guide. Published on GitHub.
+Deliverables:
 
-### Milestone 2: Vault Standard + Financial Services Integration (Q3 2026)
+- Bridge design specification. Published technical document covering architecture, security model, message format, and failure modes. Reviewed by at least one independent Daml ecosystem developer.
+- Daml bridge contracts. BridgeController, DepositAttestation, MintAuthority, WithdrawalRequest implemented with >90% unit test coverage. Source code published on GitHub. Reviewed by IntellectEU.
+- Arch-side lock/burn contracts. UTXO-based contracts deployed on Arch testnet with passing integration tests.
+- aBTC CIP-56 token. Compliant token contract with compliance hooks, transfer restrictions, and DvP support. Deployed on Canton testnet. Passes Canton token standard conformance tests.
+- Relayer prototype. Functional relayer transmitting attestations between Arch testnet and Canton testnet. At least 100 successful cross-chain transfers demonstrated.
+- Integration tests. End-to-end tests (Arch deposit to Canton mint, Canton burn to Arch unlock). Minimum 50 test cases covering normal and failure paths. Test suite published.
+- Documentation. Developer guide for bridge integration. aBTC token specification. Published on GitHub with README and quickstart.
 
-- **Estimated Delivery:** Q3 2026 (August–September)
-- **Funding:** $75,000
-- **Focus:** Canton Vault Standard specification and reference implementations, financial services integration
-- **Deliverables / Value Metrics:**
-  - Canton Vault Standard specification — Published standard with Daml interface definitions, deposit/withdraw flows, share accounting, compliance integration. Formally submitted as a Canton Improvement Proposal (CIP).
-  - Reference vault implementation — Daml vault contract using aBTC as underlying. Deposit, withdraw, redeem, share accounting functional on Canton testnet with >90% unit test coverage. Reviewed by IntellectEU.
-  - Vault composability demonstration — Vault shares used as collateral in an atomic DvP settlement with another CIP-56 asset on Canton testnet. Documented with transaction logs.
-  - Documentation — Vault standard developer guide. Published on GitHub.
-### Milestone 3: BTC Capital Markets Integration + Ecosystem Launch (Q4 2026)
+### Milestone 1B: Bridge Mainnet Readiness
 
-- **Estimated Delivery:** Q4 2026 (October–December)
-- **Funding:** $75,000
-- **Focus:** DA Tokenization Utility integration, aBTC subscription interfaces, BTC settlement pairs, compliant tokenization service integration, ecosystem launch
-- **Deliverables / Value Metrics:**
-  - aBTC Subscription Interface — CIP-56 Daml contract enabling atomic DvP subscriptions denominated in aBTC into DA Tokenization Utility-issued assets. Tested end-to-end on Canton testnet.
-  - Vault Share Composability — Canton Vault Standard share tokens registered as eligible collateral and subscription assets within DA's credential layer. Demonstrated on Canton testnet.
-  - BTC Settlement Pairs — aBTC/tokenized-treasury and aBTC/money-market-fund DvP settlement pairs live on Canton mainnet. At least 2 atomic DvP settlements using aBTC executed and documented.
-  - Compliant Tokenization Service — Canton-side Daml integration for compliant securities issuance. Functional on Canton testnet with documentation.
-  - Integration documentation & templates — Open source guides, Daml templates, and TypeScript examples. Published on GitHub. Validated by at least one external developer.
-  - Live demonstration — At least one end-to-end aBTC subscription into a Canton-issued asset on mainnet. Documented with transaction logs and participant attestation.
-  - Full documentation suite — Complete user guides, API reference, and integration guides for all five components. Published on GitHub.
+| | |
+|---|---|
+| **Delivery** | Q2–Q3 2026 (June–July) |
+| **Funding** | $50,000 |
+| **Focus** | Bridge security audit, mainnet deployment, aBTC mainnet launch |
+
+Deliverables:
+
+- Bridge security audit. Third-party audit by a recognized firm (Certora, Trail of Bits, or equivalent). 0 critical findings, 0 unresolved high findings. Audit report published publicly.
+- Bridge mainnet deployment. Contracts deployed on Arch mainnet and Canton mainnet. Relayer operational with uptime monitoring and alerting. At least 10 mainnet bridge transfers processed.
+- aBTC mainnet launch. aBTC live on Canton mainnet, mintable via bridge. At least one institutional participant has minted aBTC.
+- Documentation. Bridge operational runbook, aBTC integration guide. Published on GitHub.
+
+### Milestone 2: Canton Vault Standard CIP
+
+| | |
+|---|---|
+| **Delivery** | Q3 2026 (August–September) |
+| **Funding** | $50,000 |
+| **Focus** | Vault standard specification, reference implementation, CIP submission |
+
+Deliverables:
+
+- Canton Vault Standard specification. Published standard with Daml interface definitions, deposit/withdraw flows, share accounting, compliance integration. Formally submitted as a Canton Improvement Proposal (CIP).
+- Reference vault implementation. Daml vault contract using aBTC as underlying. Deposit, withdraw, redeem, share accounting functional on Canton testnet with >90% unit test coverage. Reviewed by IntellectEU.
+- Vault composability demonstration. Vault shares used as collateral in an atomic DvP settlement with another CIP-56 asset on Canton testnet. Documented with transaction logs.
+- Documentation. Vault standard developer guide. Published on GitHub.
 
 ## Acceptance Criteria
 
 The Tech & Ops Committee will evaluate completion based on:
 
-- Deliverables completed as specified for each milestone
-- Demonstrated functionality or operational readiness
-- Documentation and knowledge transfer provided
-- Alignment with stated value metrics
-- Security audit results (Milestone 1B) — 0 critical, 0 unresolved high findings
-- Mainnet operational status (Milestones 1B–3) — bridge operational, aBTC mintable, vaults live
-- Adoption evidence (Milestone 3) — minimum TVL thresholds met, at least one institutional participant engaged
+- Deliverables completed as specified for each milestone.
+- Demonstrated functionality or operational readiness.
+- Documentation and knowledge transfer provided.
+- Security audit results (Milestone 1B): 0 critical, 0 unresolved high findings.
+- Mainnet operational status (Milestone 1B): bridge operational, aBTC mintable.
+- CIP submission (Milestone 2): vault standard formally submitted as a Canton Improvement Proposal.
+
 ## Funding
 
-**Total Funding Request:** $250,000 USD (payable in CC equivalent)
+Total Funding Request: $150,000 USD (payable in CC equivalent)
 
-This budget covers Canton-side Daml contract development, bridge relayer integration, security audits, testing, and documentation. All underlying Arch primitives (DEX, lending protocol, vault infrastructure, tokenization service) are already built and funded by Arch Network independently.
+This budget covers Canton-side Daml contract development by IntellectEU, bridge relayer integration, security audit, testing, and documentation. All underlying Arch primitives are already built and funded by Arch Network independently.
 
-### Payment Breakdown by Milestone
+### Payment Breakdown
 
-- **Milestone 1A (Bridge Testnet Delivery):** $50,000 upon committee acceptance
-- **Milestone 1B (Bridge Mainnet Readiness):** $50,000 upon committee acceptance
-- **Milestone 2 (Vault Standard + Financial Services Integration):** $75,000 upon committee acceptance
-- **Milestone 3 (BTC Capital Markets Integration + Ecosystem Launch):** $75,000 upon committee acceptance
+| Milestone | Amount | Timeline |
+|---|---|---|
+| M1A: Bridge Testnet Delivery | $50,000 | Q2 2026 |
+| M1B: Bridge Mainnet Readiness | $50,000 | Q2–Q3 2026 |
+| M2: Canton Vault Standard CIP | $50,000 | Q3 2026 |
+| **Total** | **$150,000** | |
 
 ### Volatility Stipulation
 
@@ -180,57 +192,43 @@ Upon release, Arch Network will collaborate with the Foundation on:
 - Announcement coordination
 - Case study or technical blog
 - Developer or ecosystem promotion
+
 ## Motivation
 
-Canton hosts over $9 trillion in tokenized assets and processes approximately $350 billion in daily volume. Institutional participants — including Goldman Sachs (DAP), Broadridge (DLR), and Versana — use Canton for compliant, privacy-preserving financial operations.
+Canton hosts over $9 trillion in tokenized assets and processes approximately $350 billion in daily volume. Institutional participants, including Goldman Sachs (DAP), Broadridge (DLR), and Versana, use Canton for compliant, privacy-preserving financial operations.
 
-However, Canton's connection to Bitcoin — a $2T+ asset class and the most widely held digital asset among institutions — remains underdeveloped. While CBTC provides custodial wrapped BTC on Canton, there is no programmable bridge to Bitcoin-native infrastructure with execution capabilities (lending, trading, structured products), no standardized vault primitive for composable yield strategies, and no mechanism for BTC capital to subscribe to Canton-issued securities.
+Canton’s connection to Bitcoin, a $2T+ asset class and the most widely held digital asset among institutions, remains underdeveloped. While CBTC provides custodial wrapped BTC on Canton, there is no programmable bridge to Bitcoin-native infrastructure with execution capabilities, and no standardized vault primitive for composable yield strategies.
 
-These gaps mean Canton participants who hold BTC — or whose clients hold BTC — cannot put that capital to work within Canton's compliance framework.
+These gaps mean Canton participants who hold BTC, or whose clients hold BTC, cannot put that capital to work within Canton’s compliance framework.
 
-This proposal directly addresses these gaps by delivering open infrastructure that connects Bitcoin's $2T+ asset class to Canton's institutional ecosystem — creating new utility for existing participants and lowering the barrier for new ones.
+This proposal addresses these gaps with two open infrastructure components:
 
-**Public Good / Ecosystem Value Justification:**
+- The Arch-Canton Bridge is free, open source bridging infrastructure. Arch does not charge fees for bridging, minting, or burning aBTC. The bridge is a reusable reference architecture that other networks can adapt to build their own Canton bridges.
+- The Canton Vault Standard is an open CIP for community adoption. Any Canton developer can build composable vaults using this standard for any asset class, not just aBTC.
 
-Two of the five components are genuine public goods — open, permissionless infrastructure available to any Canton participant at no cost:
+Once these public goods exist, they enable commercially viable use cases that Arch Network will build and maintain at its own cost: BTC/stablecoin trading, BTC-collateralized lending, and institutional yield strategies. Arch’s commercial revenue from these services creates perpetual maintenance incentives for the entire stack, including the public goods layer, that persist long after the grant term ends.
 
-- **Arch–Canton Bridge:** Free, open source bridging infrastructure. Arch does not charge fees for bridging, minting, or burning aBTC. The bridge is a reusable reference architecture — other networks can adapt it to build their own Canton bridges. This is the foundational interoperability layer that makes every other use case possible.
-- **Compliant Tokenization Service:** Open issuance infrastructure for compliant tokenized securities. Any Canton issuer can use it to tokenize securities with proper regulatory compliance on top of the BTC infrastructure. This is classic public good infrastructure that lowers the barrier for all Canton participants.
-
-These two public goods are the critical infrastructure that makes a broader set of commercially viable use cases possible. Arch also offers three commercially operated services that Canton participants gain access to through the public infrastructure:
-
-- **BTC Financial Services Access (DEX + Lending):** Makes Bitcoin productive on Canton — deep BTC/stablecoin swaps and stablecoin loans against BTC collateral.
-- **Canton Vault Standard:** An open CIP for community adoption, enabling composable institutional yield strategies.
-- **BTC Capital Markets Integration:** Connects Canton's $9T+ asset base to BTC capital for the first time.
-
-The commercial revenue Arch generates from these services is Arch's skin in the game. Arch is economically incentivized to maintain, scale, and improve the entire stack — including the public goods layer — precisely because the commercial services depend on it. This makes the ecosystem more durable than grant-funded-only infrastructure, where maintenance incentives disappear when grant funds are exhausted. Canton gains infrastructure with built-in, perpetual maintenance incentives that persist long after the grant term ends.
 ## Rationale
 
-**Why Arch Network is the right team:**
+Why Arch Network:
 
-Arch Network is an $18M-funded Bitcoin infrastructure company with a 20-person team that has been building for over 2.5 years. The team has delivered: a production-grade blockchain with BFT consensus, 300ms blocks, and ~1,000 TPS; a Bitcoin-native DEX (Arch Swap); a credit and lending protocol (Arch Lend); and an institutional portfolio dashboard (Arch Prime).
+Arch Network is an $18M-funded Bitcoin infrastructure company with a 20-person team that has been building for over 2.5 years. The team has delivered a production-grade blockchain with BFT consensus, 300ms blocks, and approximately 1,000 TPS; a Bitcoin-native DEX (Arch Swap); a credit and lending protocol (Arch Lend); and an institutional portfolio dashboard (Arch Prime).
 
-**Why this approach:**
+Why not CBTC alone:
 
-The vertically integrated approach (bridge + financial services + vault standard + capital markets integration + tokenization) is deliberate. Each component's value is amplified by the others — the bridge enables aBTC, aBTC enables lending, lending enables vaults, vaults enable structured products, and the capital markets integration connects all of it to Canton's existing asset base. Delivering these as an integrated stack rather than independent components creates a self-reinforcing adoption flywheel.
+CBTC serves BTC custody and holding on Canton. It does not support programmable lending, vault strategies, or capital markets integration. CBTC requires 6 Bitcoin confirmations (approximately 60 minutes) for issuance or redemption, creating a collateral enforcement bottleneck that constrains safe loan-to-value ratios to 25-30%. Arch’s 300ms execution eliminates this bottleneck, enabling higher LTVs and more capital-efficient credit markets. CBTC and aBTC are complementary: CBTC for custody, aBTC for capital markets.
 
-**Why not CBTC alone:**
+Why a dedicated bridge rather than an existing EVM bridge:
 
-CBTC serves BTC custody and holding on Canton. It does not support programmable lending, vault strategies, or capital markets integration. Critically, CBTC requires 6 Bitcoin confirmations (~60 minutes) for issuance or redemption, creating a collateral enforcement bottleneck that constrains safe LTVs to 25–30% and limits carry trade competitiveness. Arch's 300ms execution eliminates this bottleneck, structurally enabling higher LTVs and more capital-efficient credit markets. CBTC and aBTC are complementary — CBTC for custody, aBTC (and Arch's service stack) for capital markets.
+Canton’s privacy model and CIP-56 standard require native Daml integration. EVM bridges cannot provide sub-transaction privacy or Canton’s Offer-Accept transfer model.
 
-**Alternatives considered:**
+Daml development partner: IntellectEU
 
-- *Build on an existing EVM bridge:* Canton's privacy model and CIP-56 standard require native Daml integration. EVM bridges cannot provide sub-transaction privacy or Canton's Offer-Accept transfer model.
-- *Wait for Canton-native BTC lending:* No Canton-native protocol has the execution speed (300ms) or liquidation infrastructure required for safe BTC-collateralized lending at scale.
-- *Use CBTC as collateral base:* The 6-confirmation bottleneck structurally constrains LTVs and makes downstream carry trades less competitive. A purpose-built execution layer is required.
+Arch has selected IntellectEU as its specialist Daml development partner for Canton-side contract work across all milestones. IntellectEU is a recognized Daml ecosystem developer with Canton production experience.
 
-**Daml development partnership: IntellectEU**
+Existing ecosystem partnerships:
 
-Arch has selected IntellectEU as its specialist Daml development partner for Canton-side contract work across all milestones. IntellectEU is a recognized Daml ecosystem developer with Canton production experience. This converts the Daml learning curve from a team capability risk to a managed vendor relationship with defined deliverables and review gates.
-
-**Existing ecosystem partnerships providing day-one demand:**
-
-- Institutional custodian integrations: Anchorage, Ceffu, Utila — custody partners who will distribute aBTC vault strategies to their client bases.
-- HoneyB: Active asset management partnership for BTC private credit yield strategies. The HoneyB credit carry trade (LP deposits BTC → borrow stables via Arch Lend → deploy into tradfi yield → collect yield → repatriate to BTC via Arch Swap → distribute to LPs) demonstrates the complete service stack in a single workflow.
-- Institutional liquidity providers: Galaxy, Pantera — committed to seeding initial vault liquidity.
-- DAT partners: Digital Asset Trusts going live with $10–20M BTC yield pilots.
+- Institutional custodians: Anchorage, Ceffu, Utila, providing custody and distribution for aBTC vault strategies.
+- HoneyB: Active asset management partnership for BTC private credit yield strategies.
+- Institutional liquidity providers: Galaxy, Pantera, committed to seeding initial vault liquidity.
+- DAT partners: Digital Asset Trusts going live with $10-20M BTC yield pilots.

--- a/proposals/arch-bitcoin-capital-markets-stack.md
+++ b/proposals/arch-bitcoin-capital-markets-stack.md
@@ -213,6 +213,227 @@ CBTC serves BTC custody and holding on Canton. It does not support programmable 
 - *Wait for Canton-native BTC lending:* No Canton-native protocol has the execution speed (300ms) or liquidation infrastructure required for safe BTC-collateralized lending at scale.
 - *Use CBTC as collateral base:* The 6-confirmation bottleneck structurally constrains LTVs and makes downstream carry trades less competitive. A purpose-built execution layer is required.
 
+**Existing ecosystem partnerships providing day-one demand:**
+
+- Institutional custodian integrations: Anchorage, Ceffu, Utila — custody partners who will distribute aBTC vault strategies to their client bases.
+- HoneyB: Active asset management partnership for BTC private credit yield strategies. The HoneyB credit carry trade (LP deposits BTC → borrow stables via Arch Lend → deploy into tradfi yield → collect yield → repatriate to BTC via Arch Swap → distribute to LPs) demonstrates the complete service stack in a single workflow.
+- Institutional liquidity providers: Galaxy, Pantera — committed to seeding initial vault liquidity.
+- DAT partners: Digital Asset Trusts going live with $10–20M BTC yield pilots.
+# Development Fund Proposal
+
+**Author:** Arch Network (Matt Mudano)
+**Status:** Draft
+**Created:** 2026-04-01
+
+## Abstract
+
+Arch and Canton are structurally complementary institutions. Canton provides the institutional compliance layer, sub-transaction privacy, and atomic DvP settlement that capital markets require. Arch provides Bitcoin-native execution and settlement infrastructure — 300ms blocks, ~1,000 TPS, validator-secured collateral enforcement, and native Bitcoin settlement. Together, they can create the capital markets corridor between Bitcoin's $2T+ and Canton's $9T+ institutional asset ecosystem.
+
+Bitcoin is a $2T+ asset with no scalable form of native yield. The most viable strategy for making BTC productive — for institutions, family offices, and sophisticated investors — is the credit carry trade: borrow against BTC collateral, deploy stablecoins into yield-generating strategies (private credit, yield ETFs, money market instruments), collect yield, repay the loan, keep the spread as net BTC yield. This strategy requires fast execution, deterministic collateral enforcement, and deep liquidity — exactly what Arch's infrastructure provides.
+
+This proposal describes five infrastructure components that deliver a full Bitcoin financial services stack for Canton to facilitate this:
+
+1. **Arch–Canton Bridge** — Foundational interoperability infrastructure connecting native BTC to Canton Network. Also serves as the connectivity layer for Arch's financial services (DEX, lending, vaults) to Canton participants. Institutions interact through existing custody relationships (Anchorage, Ceffu, Utila) — no new custody required.
+
+2. **BTC Financial Services Access (DEX + Lending)** — Canton participants gain access to Arch Swap (deep BTC/stablecoin liquidity) and Arch Lend (stablecoin loans against BTC collateral) through the bridge. These are the financial primitives that make BTC productive — without them, BTC on Canton is a holding asset, not a working one.
+
+3. **Canton Vault Standard** — A standardized, composable vault interface written in Daml (analogous to Ethereum's ERC-4626) that enables institutional yield strategies on Canton. Once credit infrastructure exists, vaults become the vehicle for deploying it — private credit strategies, yield ETFs, debt tranches, corporate bonds, subscription agreements with fund asset managers, and other tradfi yield strategies, all accessible through a standard interface.
+
+4. **BTC Capital Markets Integration for DA's Tokenization Utility** — An integration layer connecting Arch's financial services to DA's existing issuance infrastructure, enabling aBTC as a native subscription and settlement asset for tokenized securities on Canton.
+
+5. **Compliant Tokenization Service** — A compliant securities issuance service that enables the tokenization of yield instruments, fund shares, structured products, and other securities on top of the BTC infrastructure with proper regulatory compliance. This is a public good for Canton's ecosystem: any issuer can use it to create compliant tokenized securities backed by or denominated in BTC.
+
+Together, these components deliver a complete Bitcoin capital markets stack for Canton: bridge access, deep swaps, institutional lending, tradfi yield infrastructure, compliant securities tokenization — and the capital markets integration that connects all of it to Canton's existing $9T+ tokenized asset base.
+
+## Specification
+
+### 1. Objective
+
+Connect Bitcoin's $2T+ asset class to Canton's $9T+ institutional ecosystem through purpose-built financial infrastructure. Specifically: enable institutional BTC holders to earn yield on their Bitcoin without leaving the Canton compliance framework, and enable Canton-native asset issuers to access BTC-denominated capital for the first time.
+
+The five infrastructure components solve three problems that Canton cannot solve internally:
+
+- **No programmable BTC bridge with execution capabilities.** Canton has CBTC (custodial holding), but no mechanism for BTC capital to flow into lending, trading, or yield strategies. The Arch–Canton Bridge solves this.
+- **No standardized vault primitive.** Ethereum's ERC-4626 has enabled billions in composable DeFi strategies. Canton has no equivalent. The Canton Vault Standard fills this gap.
+- **No BTC capital onramp for tokenized assets.** DA's Tokenization Utility provides world-class issuance infrastructure, but there is no mechanism for BTC capital to subscribe to Canton-issued securities. The BTC Capital Markets Integration builds that connection.
+
+### 2. Implementation Mechanics
+
+**Arch–Canton Bridge**
+
+The bridge uses a relayer-based architecture with FROST threshold signatures for security:
+
+- Arch → Canton: User locks BTC on Arch → validators produce signed attestation → relayer transmits to Canton → Canton bridge contract verifies and mints CIP-56 aBTC token via Offer-Accept protocol.
+- Canton → Arch: User transfers aBTC to bridge contract → bridge burns aBTC and emits withdrawal attestation → relayer transmits to Arch → validators construct and sign Bitcoin unlock transaction → user receives native BTC.
+- Security: (⌈2N/3⌉ + 1)-of-N FROST threshold signatures, per-epoch volume caps, emergency pause, reorg handling via DAG-based transaction tracking and UTXO anchoring.
+- Relayer model: Permissionless — any party can relay valid attestations. Minimum 3 independent operators recommended.
+
+**aBTC Token (CIP-56)**
+
+- Standard: CIP-56 compliant, 8 decimals (matching BTC), mint authority restricted to bridge contract only.
+- Compliance: Configurable transfer restrictions (KYC, jurisdictional, accredited investor checks), regulatory observer support.
+- Oracle: Dual-oracle design (RedStone primary, Chainlink secondary), 5-minute staleness threshold, 2% divergence handling, 10-minute TWAP, circuit breaker.
+
+**Canton Vault Standard**
+
+- Daml-based interface analogous to ERC-4626: deposit/withdraw via CIP-56 Offer-Accept, share token accounting, compliance-gated deposits.
+- View functions: totalAssets, totalShares, convertToShares, convertToAssets, maxDeposit, maxWithdraw.
+- Composability: Vault shares usable as collateral in Acme/Palladium, settleable via DvP, nestable in other vaults.
+- Reference implementations: HoneyB vault (private credit yield via Simplify, $13B AUM ETF platform), delta-neutral vault (funding rate capture).
+
+**BTC Capital Markets Integration**
+
+- aBTC Subscription Interface: Enables atomic DvP subscriptions denominated in aBTC into DA Tokenization Utility-issued assets.
+- Vault Share Composability: Vault share tokens registered as eligible collateral and subscription assets within DA's credential layer.
+- BTC Settlement Pairs: aBTC/tokenized-treasury, aBTC/money-market-fund, aBTC/private-credit DvP settlement pairs.
+- Open source integration guides, Daml templates, and TypeScript examples for issuers.
+
+**Compliant Tokenization Service**
+
+- Compliant issuance of securities as tokens on Canton — open, permissionless infrastructure.
+- Supports yield instruments, fund shares, structured products, and other securities with proper regulatory compliance.
+- KYC/AML, accreditation, and jurisdictional controls enforced at issuance level.
+
+### 3. Architectural Alignment
+
+This proposal aligns with Canton's architecture and ecosystem priorities:
+
+- **CIP-56 compliance:** aBTC is a native CIP-56 token, fully compatible with Canton's Offer-Accept transfer model, sub-transaction privacy, and regulatory observer framework.
+- **DvP settlement:** All components support Canton's atomic DvP settlement — aBTC subscriptions, vault share trades, and BTC settlement pairs all settle atomically via the Global Synchronizer.
+- **Daml-native:** Bridge contracts, vault standard, and tokenization protocol are implemented in Daml, leveraging Canton's smart contract model and benefiting from its privacy and composability guarantees.
+- **Canton Improvement Proposal:** The Canton Vault Standard will be submitted as a formal CIP for community adoption, contributing to Canton's standards ecosystem.
+- **DA Tokenization Utility integration:** The BTC Capital Markets Integration builds on top of DA's existing issuance infrastructure rather than replacing it — aBTC becomes a new payment and collateral leg for assets already issued via DA's Tokenization Utility.
+- **Institutional compliance model:** Vault-level compliance gating (KYC, accreditation, jurisdictional rules) enforced at deposit, aligned with Canton's institutional-grade compliance framework.
+
+### 4. Backward Compatibility
+
+No backward compatibility impact. All components are additive:
+
+- aBTC is a new CIP-56 token — does not modify existing token contracts or standards.
+- The Canton Vault Standard is a new primitive — does not change existing Daml contracts.
+- The bridge introduces new contracts (BridgeController, DepositAttestation, MintAuthority, WithdrawalRequest) that interact with Canton via standard CIP-56 mechanics.
+- BTC Capital Markets Integration adds subscription and settlement interfaces on top of DA's existing Tokenization Utility — no modifications to DA's contracts required.
+- Compliant Tokenization Service is independent infrastructure, available to any Canton participant.
+
+## Milestones and Deliverables
+
+### Milestone 1: Bridge Architecture + aBTC Token (Q2 2026)
+
+- **Estimated Delivery:** Q2 2026 (April–June)
+- **Focus:** Bridge design, Daml contract development, aBTC token deployment on testnet, relayer prototype
+- **Deliverables / Value Metrics:**
+  - Bridge design specification — published technical document covering architecture, security model, message format, and failure modes. Reviewed by at least one independent Daml ecosystem developer.
+  - Daml bridge contracts — BridgeController, DepositAttestation, MintAuthority, WithdrawalRequest implemented with >90% unit test coverage. Source code published on GitHub. Reviewed by selected Daml development partner.
+  - Arch-side lock/burn contracts — UTXO-based contracts deployed on Arch testnet with passing integration tests.
+  - aBTC CIP-56 token — Compliant token contract with compliance hooks, transfer restrictions, and DvP support. Deployed on Canton testnet. Passes Canton token standard conformance tests.
+  - Relayer prototype — Functional relayer transmitting attestations between Arch testnet and Canton testnet. At least 100 successful cross-chain transfers demonstrated.
+  - Integration tests — End-to-end tests (Arch deposit → Canton mint, Canton burn → Arch unlock). Minimum 50 test cases covering normal and failure paths. Test suite published.
+  - Documentation — Developer guide for bridge integration. aBTC token specification. Published on GitHub with README and quickstart.
+
+### Milestone 2: Vault Standard + Bridge Production (Q2 2026)
+
+- **Estimated Delivery:** Q2 2026 (April–June)
+- **Focus:** Canton Vault Standard specification and reference implementations, bridge security audit, mainnet deployment, aBTC mainnet launch
+- **Deliverables / Value Metrics:**
+  - Canton Vault Standard specification — Published standard with Daml interface definitions, deposit/withdraw flows, share accounting, compliance integration. Formally submitted as a Canton Improvement Proposal (CIP).
+  - Reference vault implementation — Daml vault contract using aBTC as underlying. Deposit, withdraw, redeem, share accounting functional on Canton testnet with >90% unit test coverage. Reviewed by Daml development partner.
+  - Vault composability demonstration — Vault shares used as collateral in an atomic DvP settlement with another CIP-56 asset on Canton testnet. Documented with transaction logs.
+  - Bridge security audit — Third-party audit by a recognized firm (Certora, Trail of Bits, or equivalent). 0 critical findings, 0 unresolved high findings. Audit report published publicly.
+  - Bridge mainnet deployment — Contracts deployed on Arch mainnet and Canton mainnet. Relayer operational with uptime monitoring and alerting. At least 10 mainnet bridge transfers processed.
+  - aBTC mainnet launch — aBTC live on Canton mainnet, mintable via bridge. At least one institutional participant has minted aBTC.
+  - Documentation — Vault standard developer guide, bridge operational runbook, aBTC integration guide. All published on GitHub.
+
+### Milestone 3: BTC Capital Markets Integration + Ecosystem Launch (Q3 2026)
+
+- **Estimated Delivery:** Q3 2026 (July–September)
+- **Focus:** DA Tokenization Utility integration, aBTC subscription interfaces, BTC settlement pairs, ecosystem launch
+- **Deliverables / Value Metrics:**
+  - aBTC Subscription Interface — CIP-56 Daml contract enabling atomic DvP subscriptions denominated in aBTC into DA Tokenization Utility-issued assets. Tested end-to-end on Canton testnet.
+  - Vault Share Composability — Canton Vault Standard share tokens registered as eligible collateral and subscription assets within DA's credential layer. Demonstrated on Canton testnet.
+  - BTC Settlement Pairs — aBTC/tokenized-treasury and aBTC/money-market-fund DvP settlement pairs live on Canton mainnet. At least 2 atomic DvP settlements using aBTC executed and documented.
+  - Integration documentation & templates — Open source guides, Daml templates, and TypeScript examples. Published on GitHub. Validated by at least one external developer.
+  - Live demonstration — At least one end-to-end aBTC subscription into a Canton-issued asset on mainnet. Documented with transaction logs and participant attestation.
+  - Full documentation suite — Complete user guides, API reference, and integration guides for all five components. Published on GitHub.
+
+## Acceptance Criteria
+
+The Tech & Ops Committee will evaluate completion based on:
+
+- Deliverables completed as specified for each milestone
+- Demonstrated functionality or operational readiness
+- Documentation and knowledge transfer provided
+- Alignment with stated value metrics
+- Security audit results (Milestone 2) — 0 critical, 0 unresolved high findings
+- Mainnet operational status (Milestones 2–3) — bridge operational, aBTC mintable, vaults live
+- Adoption evidence (Milestone 3) — minimum TVL thresholds met, at least one institutional participant engaged
+
+## Funding
+
+**Total Funding Request:** $250,000 USD (payable in CC at prevailing rate)
+
+### Payment Breakdown by Milestone
+
+- **Milestone 1 (Bridge Architecture + aBTC Token):** $100,000 upon committee acceptance
+- **Milestone 2 (Vault Standard + Bridge Production):** $87,500 upon committee acceptance
+- **Milestone 3 (BTC Capital Markets Integration + Ecosystem Launch):** $62,500 upon committee acceptance
+
+### Volatility Stipulation
+
+Should the project timeline extend beyond 6 months due to Committee-requested scope changes, any remaining milestones must be renegotiated to account for significant USD/CC price volatility.
+
+## Co-Marketing
+
+Upon release, Arch Network will collaborate with the Foundation on:
+
+- Announcement coordination
+- Joint case study or technical blog highlighting the Arch-Canton integration
+- Developer or ecosystem promotion
+
+**Economic Design Audit & Bitcoin Credit Markets Study:** Arch is currently underway on a comprehensive economic design audit and case study of Bitcoin credit markets that supports the thesis behind this proposal. The study demonstrates that Arch’s architecture is structurally more efficient for scaling Bitcoin lending than existing alternatives. We would welcome the opportunity to include Canton in this study — examining how Canton’s institutional settlement layer combined with Arch’s execution infrastructure creates a uniquely efficient credit market design for institutional BTC participants. This joint research could serve as a powerful co-marketing asset for both ecosystems.
+
+## Motivation
+
+Canton hosts over $9 trillion in tokenized assets and processes approximately $350 billion in daily volume. Institutional participants — including Goldman Sachs (DAP), Broadridge (DLR), and Versana — use Canton for compliant, privacy-preserving financial operations.
+
+However, Canton's connection to Bitcoin — a $2T+ asset class and the most widely held digital asset among institutions — remains underdeveloped. While CBTC provides custodial wrapped BTC on Canton, there is no programmable bridge to Bitcoin-native infrastructure with execution capabilities (lending, trading, structured products), no standardized vault primitive for composable yield strategies, and no mechanism for BTC capital to subscribe to Canton-issued securities.
+
+These gaps limit Canton's ability to attract Bitcoin-denominated capital, restrict the yield strategies available to institutional participants, and raise the barrier to entry for new issuers.
+
+This proposal directly addresses these gaps by delivering open infrastructure that connects Bitcoin's $2T+ asset class to Canton's institutional ecosystem — creating new utility, new capital flows, and new reasons for institutional participants to build on Canton.
+
+**Public Good / Ecosystem Value Justification:**
+
+Two of the five components are genuine public goods — open, permissionless infrastructure available to any Canton participant:
+
+- **Arch–Canton Bridge:** Free, open source bridging infrastructure. Arch does not charge fees for bridging, minting, or burning aBTC. Reusable pattern for other networks to build Canton bridges.
+- **Compliant Tokenization Service:** Open issuance infrastructure for compliant tokenized securities. Any Canton issuer can use it.
+
+The remaining three components generate ecosystem value with built-in maintenance incentives — Arch's revenue depends on their functioning, ensuring durable maintenance:
+
+- **BTC Financial Services Access (DEX + Lending):** Makes Bitcoin productive on Canton. More activity drives Arch Lend and Arch Swap revenue, ensuring continued investment.
+- **Canton Vault Standard:** Open CIP for community adoption. More vault activity drives more lending and trading on Arch infrastructure.
+- **BTC Capital Markets Integration:** Connects Canton's $9T+ asset base to BTC capital. More integrations drive more volume.
+
+## Rationale
+
+**Why Arch Network is the right team:**
+
+Arch Network is an $18M-funded Bitcoin infrastructure company with a 20-person team that has been building for over 2.5 years. Our funding rounds were led by Multicoin Capital and Pantera Capital — two of the most respected institutional crypto investors — reflecting deep conviction in Arch’s technical approach and market positioning. The team has delivered: a production-grade blockchain with BFT consensus, 300ms blocks, and ~1,000 TPS; a Bitcoin-native DEX (Arch Swap); a credit and lending protocol (Arch Lend); and an institutional portfolio dashboard (Arch Prime).
+
+**Why this approach:**
+
+The vertically integrated approach (bridge + financial services + vault standard + capital markets integration + tokenization) is deliberate. Each component's value is amplified by the others — the bridge enables aBTC, aBTC enables lending, lending enables vaults, vaults enable structured products, and the capital markets integration connects all of it to Canton's existing asset base. Delivering these as an integrated stack rather than independent components creates a self-reinforcing adoption flywheel.
+
+**Why not CBTC alone:**
+
+CBTC serves BTC custody and holding on Canton. It does not support programmable lending, vault strategies, or capital markets integration. Critically, CBTC requires 6 Bitcoin confirmations (~60 minutes) for issuance or redemption, creating a collateral enforcement bottleneck that constrains safe LTVs to 25–30% and limits carry trade competitiveness. Arch's 300ms execution eliminates this bottleneck, structurally enabling higher LTVs and more capital-efficient credit markets. CBTC and aBTC are complementary — CBTC for custody, aBTC (and Arch's service stack) for capital markets.
+
+**Alternatives considered:**
+
+- *Build on an existing EVM bridge:* Canton's privacy model and CIP-56 standard require native Daml integration. EVM bridges cannot provide sub-transaction privacy or Canton's Offer-Accept transfer model.
+- *Wait for Canton-native BTC lending:* No Canton-native protocol has the execution speed (300ms) or liquidation infrastructure required for safe BTC-collateralized lending at scale.
+- *Use CBTC as collateral base:* The 6-confirmation bottleneck structurally constrains LTVs and makes downstream carry trades less competitive. A purpose-built execution layer is required.
+
 **Daml development partnership:**
 
 Arch aims to engage IntellectEU or Obsidian Systems as a specialist Daml development partner for Canton-side contract work. Both are recognized Daml ecosystem developers with Canton production experience. This converts the Daml learning curve from a team capability risk to a managed vendor relationship with defined deliverables and review gates.

--- a/proposals/arch-bitcoin-capital-markets-stack.md
+++ b/proposals/arch-bitcoin-capital-markets-stack.md
@@ -1,0 +1,77 @@
+# Development Fund Proposal
+
+**Author:** Arch Network (Matt Mudano)
+**Status:** Draft
+**Created:** 2026-04-01
+
+## Abstract
+
+[PASTE YOUR FINAL DRAFT CONTENT HERE]
+
+## Specification
+
+### 1. Objective
+
+[Describe the specific problem being solved and the intended outcome.]
+
+### 2. Implementation Mechanics
+
+[Explain how the solution will be implemented. Include technologies, components, workflows, and operational approach.]
+
+### 3. Architectural Alignment
+
+[Describe how this work aligns with Canton architecture, ecosystem priorities, and relevant CIPs.]
+
+### 4. Backward Compatibility
+
+No backward compatibility impact.
+
+## Milestones and Deliverables
+
+### Milestone 1: (Name)
+- **Estimated Delivery:**
+- **Focus:**
+- **Deliverables / Value Metrics:**
+
+### Milestone 2: (Name)
+- **Estimated Delivery:**
+- **Focus:**
+- **Deliverables / Value Metrics:**
+
+## Acceptance Criteria
+
+The Tech & Ops Committee will evaluate completion based on:
+
+- Deliverables completed as specified for each milestone
+- Demonstrated functionality or operational readiness
+- Documentation and knowledge transfer provided
+- Alignment with stated value metrics
+
+## Funding
+
+**Total Funding Request:** [XX CC]
+
+### Payment Breakdown by Milestone
+
+- **Milestone 1 (Name):** XX CC upon committee acceptance
+- **Milestone 2 (Name):** XX CC upon committee acceptance
+
+### Volatility Stipulation
+
+Should the project timeline extend beyond 6 months due to Committee-requested scope changes, any remaining milestones must be renegotiated to account for significant USD/CC price volatility.
+
+## Co-Marketing
+
+Upon release, Arch Network will collaborate with the Foundation on:
+
+- Announcement coordination
+- Case study or technical blog
+- Developer or ecosystem promotion
+
+## Motivation
+
+[Why is this valuable to the Canton ecosystem? Describe the ecosystem impact, expected adoption, or strategic importance.]
+
+## Rationale
+
+[Why is this the right approach to deliver that value? Explain design decisions, alternatives considered, and why this solution is preferred.]

--- a/proposals/arch-bitcoin-capital-markets-stack.md
+++ b/proposals/arch-bitcoin-capital-markets-stack.md
@@ -6,46 +6,46 @@
 
 ## Abstract
 
-Arch and Canton are structurally complementary institutions. Canton provides the institutional compliance layer, sub-transaction privacy, and atomic DvP settlement that capital markets require. Arch provides Bitcoin-native execution and settlement infrastructure â 300ms blocks, ~1,000 TPS, validator-secured collateral enforcement, and native Bitcoin settlement. Together, they can create the capital markets corridor between Bitcoinâs $2T+ and Cantonâs $9T+ institutional asset ecosystem.
+Arch and Canton are structurally complementary institutions. Canton provides the institutional compliance layer, sub-transaction privacy, and atomic DvP settlement that capital markets require. Arch provides Bitcoin-native execution and settlement infrastructure — 300ms blocks, ~1,000 TPS, validator-secured collateral enforcement, and native Bitcoin settlement. Together, they can create the capital markets corridor between Bitcoin's $2T+ and Canton's $9T+ institutional asset ecosystem.
 
-Bitcoin is a $2T+ asset with no scalable form of native yield. The most viable strategy for making BTC productive â for institutions, family offices, and sophisticated investors â is the credit carry trade: borrow against BTC collateral, deploy stablecoins into yield-generating strategies (private credit, yield ETFs, money market instruments), collect yield, repay the loan, keep the spread as net BTC yield. This strategy requires fast execution, deterministic collateral enforcement, and deep liquidity â exactly what Archâs infrastructure provides.
+Bitcoin is a $2T+ asset with no scalable form of native yield. The most viable strategy for making BTC productive — for institutions, family offices, and sophisticated investors — is the credit carry trade: borrow against BTC collateral, deploy stablecoins into yield-generating strategies (private credit, yield ETFs, money market instruments), collect yield, repay the loan, keep the spread as net BTC yield. This strategy requires fast execution, deterministic collateral enforcement, and deep liquidity — exactly what Arch's infrastructure provides.
 
 This proposal describes five infrastructure components that deliver a full Bitcoin financial services stack for Canton to facilitate this:
 
-1. **ArchâCanton Bridge** â Foundational interoperability infrastructure connecting native BTC to Canton Network. Also serves as the connectivity layer for Archâs financial services (DEX, lending, vaults) to Canton participants. Institutions interact through existing custody relationships (Anchorage, Ceffu, Utila) â no new custody required.
+1. **Arch–Canton Bridge** — Foundational interoperability infrastructure connecting native BTC to Canton Network. Also serves as the connectivity layer for Arch's financial services (DEX, lending, vaults) to Canton participants. Institutions interact through existing custody relationships (Anchorage, Ceffu, Utila) — no new custody required.
 
-2. **BTC Financial Services Access (DEX + Lending)** â Canton participants gain access to Arch Swap (deep BTC/stablecoin liquidity) and Arch Lend (stablecoin loans against BTC collateral) through the bridge. These are the financial primitives that make BTC productive â without them, BTC on Canton is a holding asset, not a working one.
+2. **BTC Financial Services Access (DEX + Lending)** — Canton participants gain access to Arch Swap (deep BTC/stablecoin liquidity) and Arch Lend (stablecoin loans against BTC collateral) through the bridge. These are the financial primitives that make BTC productive — without them, BTC on Canton is a holding asset, not a working one.
 
-3. **Canton Vault Standard** â A standardized, composable vault interface written in Daml (analogous to Ethereumâs ERC-4626) that enables institutional yield strategies on Canton. Once credit infrastructure exists, vaults become the vehicle for deploying it â private credit strategies, yield ETFs, debt tranches, corporate bonds, subscription agreements with fund asset managers, and other tradfi yield strategies, all accessible through a standard interface.
+3. **Canton Vault Standard** — A standardized, composable vault interface written in Daml (analogous to Ethereum's ERC-4626) that enables institutional yield strategies on Canton. Once credit infrastructure exists, vaults become the vehicle for deploying it — private credit strategies, yield ETFs, debt tranches, corporate bonds, subscription agreements with fund asset managers, and other tradfi yield strategies, all accessible through a standard interface.
 
-4. **BTC Capital Markets Integration for DAâs Tokenization Utility** â An integration layer connecting Archâs financial services to DAâs existing issuance infrastructure, enabling aBTC as a native subscription and settlement asset for tokenized securities on Canton.
+4. **BTC Capital Markets Integration for DA's Tokenization Utility** — An integration layer connecting Arch's financial services to DA's existing issuance infrastructure, enabling aBTC as a native subscription and settlement asset for tokenized securities on Canton.
 
-5. **Compliant Tokenization Service** â A compliant securities issuance service that enables the tokenization of yield instruments, fund shares, structured products, and other securities on top of the BTC infrastructure with proper regulatory compliance. This is a public good for Cantonâs ecosystem: any issuer can use it to create compliant tokenized securities backed by or denominated in BTC.
+5. **Compliant Tokenization Service** — A compliant securities issuance service that enables the tokenization of yield instruments, fund shares, structured products, and other securities on top of the BTC infrastructure with proper regulatory compliance. This is a public good for Canton's ecosystem: any issuer can use it to create compliant tokenized securities backed by or denominated in BTC.
 
-Together, these components deliver a complete Bitcoin capital markets stack for Canton: bridge access, deep swaps, institutional lending, tradfi yield infrastructure, compliant securities tokenization â and the capital markets integration that connects all of it to Cantonâs existing $9T+ tokenized asset base.
+Together, these components deliver a complete Bitcoin capital markets stack for Canton: bridge access, deep swaps, institutional lending, tradfi yield infrastructure, compliant securities tokenization — and the capital markets integration that connects all of it to Canton's existing $9T+ tokenized asset base.
 
 ## Specification
 
 ### 1. Objective
 
-Connect Bitcoinâs $2T+ asset class to Cantonâs $9T+ institutional ecosystem through purpose-built financial infrastructure. Specifically: enable institutional BTC holders to earn yield on their Bitcoin without leaving the Canton compliance framework, and enable Canton-native asset issuers to access BTC-denominated capital for the first time.
+Connect Bitcoin's $2T+ asset class to Canton's $9T+ institutional ecosystem through purpose-built financial infrastructure. Specifically: enable institutional BTC holders to earn yield on their Bitcoin without leaving the Canton compliance framework, and enable Canton-native asset issuers to access BTC-denominated capital for the first time.
 
 The five infrastructure components solve three problems that Canton cannot solve internally:
 
-- **No programmable BTC bridge with execution capabilities.** Canton has CBTC (custodial holding), but no mechanism for BTC capital to flow into lending, trading, or yield strategies. The ArchâCanton Bridge solves this.
-- **No standardized vault primitive.** Ethereumâs ERC-4626 has enabled billions in composable DeFi strategies. Canton has no equivalent. The Canton Vault Standard fills this gap.
-- **No BTC capital onramp for tokenized assets.** DAâs Tokenization Utility provides world-class issuance infrastructure, but there is no mechanism for BTC capital to subscribe to Canton-issued securities. The BTC Capital Markets Integration builds that connection.
+- **No programmable BTC bridge with execution capabilities.** Canton has CBTC (custodial holding), but no mechanism for BTC capital to flow into lending, trading, or yield strategies. The Arch–Canton Bridge solves this.
+- **No standardized vault primitive.** Ethereum's ERC-4626 has enabled billions in composable DeFi strategies. Canton has no equivalent. The Canton Vault Standard fills this gap.
+- **No BTC capital onramp for tokenized assets.** DA's Tokenization Utility provides world-class issuance infrastructure, but there is no mechanism for BTC capital to subscribe to Canton-issued securities. The BTC Capital Markets Integration builds that connection.
 
 ### 2. Implementation Mechanics
 
-**ArchâCanton Bridge**
+**Arch–Canton Bridge**
 
 The bridge uses a relayer-based architecture with FROST threshold signatures for security:
 
-- Arch to Canton: User locks BTC on Arch, validators produce signed attestation, relayer transmits to Canton, Canton bridge contract verifies and mints CIP-56 aBTC token via Offer-Accept protocol.
-- Canton to Arch: User transfers aBTC to bridge contract, bridge burns aBTC and emits withdrawal attestation, relayer transmits to Arch, validators construct and sign Bitcoin unlock transaction, user receives native BTC.
-- Security: FROST threshold signatures, per-epoch volume caps, emergency pause, reorg handling via DAG-based transaction tracking and UTXO anchoring.
-- Relayer model: Permissionless â any party can relay valid attestations. Minimum 3 independent operators recommended.
+- Arch → Canton: User locks BTC on Arch → validators produce signed attestation → relayer transmits to Canton → Canton bridge contract verifies and mints CIP-56 aBTC token via Offer-Accept protocol.
+- Canton → Arch: User transfers aBTC to bridge contract → bridge burns aBTC and emits withdrawal attestation → relayer transmits to Arch → validators construct and sign Bitcoin unlock transaction → user receives native BTC.
+- Security: (⌈2N/3⌉ + 1)-of-N FROST threshold signatures, per-epoch volume caps, emergency pause, reorg handling via DAG-based transaction tracking and UTXO anchoring.
+- Relayer model: Permissionless — any party can relay valid attestations. Minimum 3 independent operators recommended.
 
 **aBTC Token (CIP-56)**
 
@@ -63,76 +63,76 @@ The bridge uses a relayer-based architecture with FROST threshold signatures for
 **BTC Capital Markets Integration**
 
 - aBTC Subscription Interface: Enables atomic DvP subscriptions denominated in aBTC into DA Tokenization Utility-issued assets.
-- Vault Share Composability: Vault share tokens registered as eligible collateral and subscription assets within DAâs credential layer.
+- Vault Share Composability: Vault share tokens registered as eligible collateral and subscription assets within DA's credential layer.
 - BTC Settlement Pairs: aBTC/tokenized-treasury, aBTC/money-market-fund, aBTC/private-credit DvP settlement pairs.
 - Open source integration guides, Daml templates, and TypeScript examples for issuers.
 
 **Compliant Tokenization Service**
 
-- Compliant issuance of securities as tokens on Canton â open, permissionless infrastructure.
+- Compliant issuance of securities as tokens on Canton — open, permissionless infrastructure.
 - Supports yield instruments, fund shares, structured products, and other securities with proper regulatory compliance.
 - KYC/AML, accreditation, and jurisdictional controls enforced at issuance level.
 
 ### 3. Architectural Alignment
 
-This proposal aligns with Cantonâs architecture and ecosystem priorities:
+This proposal aligns with Canton's architecture and ecosystem priorities:
 
-- **CIP-56 compliance:** aBTC is a native CIP-56 token, fully compatible with Cantonâs Offer-Accept transfer model, sub-transaction privacy, and regulatory observer framework.
-- **DvP settlement:** All components support Cantonâs atomic DvP settlement â aBTC subscriptions, vault share trades, and BTC settlement pairs all settle atomically via the Global Synchronizer.
-- **Daml-native:** Bridge contracts, vault standard, and tokenization protocol are implemented in Daml, leveraging Cantonâs smart contract model and benefiting from its privacy and composability guarantees.
-- **Canton Improvement Proposal:** The Canton Vault Standard will be submitted as a formal CIP for community adoption, contributing to Cantonâs standards ecosystem.
-- **DA Tokenization Utility integration:** The BTC Capital Markets Integration builds on top of DAâs existing issuance infrastructure rather than replacing it â aBTC becomes a new payment and collateral leg for assets already issued via DAâs Tokenization Utility.
-- **Institutional compliance model:** Vault-level compliance gating (KYC, accreditation, jurisdictional rules) enforced at deposit, aligned with Cantonâs institutional-grade compliance framework.
+- **CIP-56 compliance:** aBTC is a native CIP-56 token, fully compatible with Canton's Offer-Accept transfer model, sub-transaction privacy, and regulatory observer framework.
+- **DvP settlement:** All components support Canton's atomic DvP settlement — aBTC subscriptions, vault share trades, and BTC settlement pairs all settle atomically via the Global Synchronizer.
+- **Daml-native:** Bridge contracts, vault standard, and tokenization protocol are implemented in Daml, leveraging Canton's smart contract model and benefiting from its privacy and composability guarantees.
+- **Canton Improvement Proposal:** The Canton Vault Standard will be submitted as a formal CIP for community adoption, contributing to Canton's standards ecosystem.
+- **DA Tokenization Utility integration:** The BTC Capital Markets Integration builds on top of DA's existing issuance infrastructure rather than replacing it — aBTC becomes a new payment and collateral leg for assets already issued via DA's Tokenization Utility.
+- **Institutional compliance model:** Vault-level compliance gating (KYC, accreditation, jurisdictional rules) enforced at deposit, aligned with Canton's institutional-grade compliance framework.
 
 ### 4. Backward Compatibility
 
 No backward compatibility impact. All components are additive:
 
-- aBTC is a new CIP-56 token â does not modify existing token contracts or standards.
-- The Canton Vault Standard is a new primitive â does not change existing Daml contracts.
+- aBTC is a new CIP-56 token — does not modify existing token contracts or standards.
+- The Canton Vault Standard is a new primitive — does not change existing Daml contracts.
 - The bridge introduces new contracts (BridgeController, DepositAttestation, MintAuthority, WithdrawalRequest) that interact with Canton via standard CIP-56 mechanics.
-- BTC Capital Markets Integration adds subscription and settlement interfaces on top of DAâs existing Tokenization Utility â no modifications to DAâs contracts required.
+- BTC Capital Markets Integration adds subscription and settlement interfaces on top of DA's existing Tokenization Utility — no modifications to DA's contracts required.
 - Compliant Tokenization Service is independent infrastructure, available to any Canton participant.
 
 ## Milestones and Deliverables
 
 ### Milestone 1: Bridge Architecture + aBTC Token (Q2 2026)
 
-- **Estimated Delivery:** Q2 2026 (AprilâJune)
+- **Estimated Delivery:** Q2 2026 (April–June)
 - **Focus:** Bridge design, Daml contract development, aBTC token deployment on testnet, relayer prototype
 - **Deliverables / Value Metrics:**
-  - Bridge design specification â published technical document covering architecture, security model, message format, and failure modes.
-  - Daml bridge contracts â BridgeController, DepositAttestation, MintAuthority, WithdrawalRequest implemented with >90% unit test coverage.
-  - Arch-side lock/burn contracts â UTXO-based contracts deployed on Arch testnet with passing integration tests.
-  - aBTC CIP-56 token â Compliant token contract with compliance hooks, transfer restrictions, and DvP support. Deployed on Canton testnet.
-  - Relayer prototype â Functional relayer with at least 100 successful cross-chain transfers demonstrated.
-  - Integration tests â End-to-end tests. Minimum 50 test cases covering normal and failure paths.
-  - Documentation â Developer guide for bridge integration. aBTC token specification. Published on GitHub.
+  - Bridge design specification — published technical document covering architecture, security model, message format, and failure modes. Reviewed by at least one independent Daml ecosystem developer.
+  - Daml bridge contracts — BridgeController, DepositAttestation, MintAuthority, WithdrawalRequest implemented with >90% unit test coverage. Source code published on GitHub. Reviewed by selected Daml development partner.
+  - Arch-side lock/burn contracts — UTXO-based contracts deployed on Arch testnet with passing integration tests.
+  - aBTC CIP-56 token — Compliant token contract with compliance hooks, transfer restrictions, and DvP support. Deployed on Canton testnet. Passes Canton token standard conformance tests.
+  - Relayer prototype — Functional relayer transmitting attestations between Arch testnet and Canton testnet. At least 100 successful cross-chain transfers demonstrated.
+  - Integration tests — End-to-end tests (Arch deposit → Canton mint, Canton burn → Arch unlock). Minimum 50 test cases covering normal and failure paths. Test suite published.
+  - Documentation — Developer guide for bridge integration. aBTC token specification. Published on GitHub with README and quickstart.
 
 ### Milestone 2: Vault Standard + Bridge Production (Q3 2026)
 
-- **Estimated Delivery:** Q3 2026 (JulyâSeptember)
-- **Focus:** Canton Vault Standard specification, reference implementations, bridge security audit, mainnet deployment
+- **Estimated Delivery:** Q3 2026 (July–September)
+- **Focus:** Canton Vault Standard specification and reference implementations, bridge security audit, mainnet deployment, aBTC mainnet launch
 - **Deliverables / Value Metrics:**
-  - Canton Vault Standard specification â Published standard. Formally submitted as a Canton Improvement Proposal (CIP).
-  - Reference vault implementation â Daml vault contract using aBTC as underlying with >90% unit test coverage.
-  - Vault composability demonstration â Vault shares used as collateral in an atomic DvP settlement.
-  - Bridge security audit â Third-party audit. 0 critical findings, 0 unresolved high findings. Audit report published publicly.
-  - Bridge mainnet deployment â Contracts deployed on Arch mainnet and Canton mainnet. At least 10 mainnet bridge transfers.
-  - aBTC mainnet launch â aBTC live on Canton mainnet, mintable via bridge.
-  - Documentation â Vault standard developer guide, bridge operational runbook, aBTC integration guide.
+  - Canton Vault Standard specification — Published standard with Daml interface definitions, deposit/withdraw flows, share accounting, compliance integration. Formally submitted as a Canton Improvement Proposal (CIP).
+  - Reference vault implementation — Daml vault contract using aBTC as underlying. Deposit, withdraw, redeem, share accounting functional on Canton testnet with >90% unit test coverage. Reviewed by Daml development partner.
+  - Vault composability demonstration — Vault shares used as collateral in an atomic DvP settlement with another CIP-56 asset on Canton testnet. Documented with transaction logs.
+  - Bridge security audit — Third-party audit by a recognized firm (Certora, Trail of Bits, or equivalent). 0 critical findings, 0 unresolved high findings. Audit report published publicly.
+  - Bridge mainnet deployment — Contracts deployed on Arch mainnet and Canton mainnet. Relayer operational with uptime monitoring and alerting. At least 10 mainnet bridge transfers processed.
+  - aBTC mainnet launch — aBTC live on Canton mainnet, mintable via bridge. At least one institutional participant has minted aBTC.
+  - Documentation — Vault standard developer guide, bridge operational runbook, aBTC integration guide. All published on GitHub.
 
 ### Milestone 3: BTC Capital Markets Integration + Ecosystem Launch (Q4 2026)
 
-- **Estimated Delivery:** Q4 2026 (OctoberâDecember)
+- **Estimated Delivery:** Q4 2026 (October–December)
 - **Focus:** DA Tokenization Utility integration, aBTC subscription interfaces, BTC settlement pairs, ecosystem launch
 - **Deliverables / Value Metrics:**
-  - aBTC Subscription Interface â CIP-56 Daml contract enabling atomic DvP subscriptions into DA Tokenization Utility-issued assets.
-  - Vault Share Composability â Share tokens registered as eligible collateral within DAâs credential layer.
-  - BTC Settlement Pairs â aBTC/tokenized-treasury and aBTC/money-market-fund DvP settlement pairs live on Canton mainnet.
-  - Integration documentation and templates â Open source guides, Daml templates, and TypeScript examples.
-  - Live demonstration â At least one end-to-end aBTC subscription into a Canton-issued asset on mainnet.
-  - Full documentation suite â Complete user guides, API reference, and integration guides for all five components.
+  - aBTC Subscription Interface — CIP-56 Daml contract enabling atomic DvP subscriptions denominated in aBTC into DA Tokenization Utility-issued assets. Tested end-to-end on Canton testnet.
+  - Vault Share Composability — Canton Vault Standard share tokens registered as eligible collateral and subscription assets within DA's credential layer. Demonstrated on Canton testnet.
+  - BTC Settlement Pairs — aBTC/tokenized-treasury and aBTC/money-market-fund DvP settlement pairs live on Canton mainnet. At least 2 atomic DvP settlements using aBTC executed and documented.
+  - Integration documentation & templates — Open source guides, Daml templates, and TypeScript examples. Published on GitHub. Validated by at least one external developer.
+  - Live demonstration — At least one end-to-end aBTC subscription into a Canton-issued asset on mainnet. Documented with transaction logs and participant attestation.
+  - Full documentation suite — Complete user guides, API reference, and integration guides for all five components. Published on GitHub.
 
 ## Acceptance Criteria
 
@@ -142,9 +142,9 @@ The Tech & Ops Committee will evaluate completion based on:
 - Demonstrated functionality or operational readiness
 - Documentation and knowledge transfer provided
 - Alignment with stated value metrics
-- Security audit results (Milestone 2) â 0 critical, 0 unresolved high findings
-- Mainnet operational status (Milestones 2â3) â bridge operational, aBTC mintable, vaults live
-- Adoption evidence (Milestone 3) â minimum TVL thresholds met, at least one institutional participant engaged
+- Security audit results (Milestone 2) — 0 critical, 0 unresolved high findings
+- Mainnet operational status (Milestones 2–3) — bridge operational, aBTC mintable, vaults live
+- Adoption evidence (Milestone 3) — minimum TVL thresholds met, at least one institutional participant engaged
 
 ## Funding
 
@@ -168,54 +168,58 @@ Upon release, Arch Network will collaborate with the Foundation on:
 - Joint case study or technical blog highlighting the Arch-Canton integration
 - Developer or ecosystem promotion
 
-**Economic Design Audit & Bitcoin Credit Markets Study:** Arch is currently underway on a comprehensive economic design audit and case study of Bitcoin credit markets that supports the thesis behind this proposal. The study demonstrates that Arch's architecture is structurally more efficient for scaling Bitcoin lending than existing alternatives. We would welcome the opportunity to include Canton in this study — examining how Canton's institutional settlement layer combined with Arch's execution infrastructure creates a uniquely efficient credit market design for institutional BTC participants. This joint research could serve as a powerful co-marketing asset for both ecosystems.
+**Economic Design Audit & Bitcoin Credit Markets Study:** Arch is currently underway on a comprehensive economic design audit and case study of Bitcoin credit markets that supports the thesis behind this proposal. The study demonstrates that Arch’s architecture is structurally more efficient for scaling Bitcoin lending than existing alternatives. We would welcome the opportunity to include Canton in this study — examining how Canton’s institutional settlement layer combined with Arch’s execution infrastructure creates a uniquely efficient credit market design for institutional BTC participants. This joint research could serve as a powerful co-marketing asset for both ecosystems.
 
 ## Motivation
 
-Canton hosts over $9 trillion in tokenized assets and processes approximately $350 billion in daily volume. Institutional participants â including Goldman Sachs (DAP), Broadridge (DLR), and Versana â use Canton for compliant, privacy-preserving financial operations.
+Canton hosts over $9 trillion in tokenized assets and processes approximately $350 billion in daily volume. Institutional participants — including Goldman Sachs (DAP), Broadridge (DLR), and Versana — use Canton for compliant, privacy-preserving financial operations.
 
-However, Cantonâs connection to Bitcoin â a $2T+ asset class and the most widely held digital asset among institutions â remains underdeveloped. While CBTC provides custodial wrapped BTC on Canton, there is no programmable bridge to Bitcoin-native infrastructure with execution capabilities, no standardized vault primitive for composable yield strategies, and no mechanism for BTC capital to subscribe to Canton-issued securities.
+However, Canton's connection to Bitcoin — a $2T+ asset class and the most widely held digital asset among institutions — remains underdeveloped. While CBTC provides custodial wrapped BTC on Canton, there is no programmable bridge to Bitcoin-native infrastructure with execution capabilities (lending, trading, structured products), no standardized vault primitive for composable yield strategies, and no mechanism for BTC capital to subscribe to Canton-issued securities.
 
-These gaps limit Cantonâs ability to attract Bitcoin-denominated capital, restrict yield strategies available to institutional participants, and raise the barrier to entry for new issuers.
+These gaps limit Canton's ability to attract Bitcoin-denominated capital, restrict the yield strategies available to institutional participants, and raise the barrier to entry for new issuers.
 
-This proposal directly addresses these gaps by delivering open infrastructure that connects Bitcoinâs $2T+ asset class to Cantonâs institutional ecosystem â creating new utility, new capital flows, and new reasons for institutional participants to build on Canton.
+This proposal directly addresses these gaps by delivering open infrastructure that connects Bitcoin's $2T+ asset class to Canton's institutional ecosystem — creating new utility, new capital flows, and new reasons for institutional participants to build on Canton.
 
 **Public Good / Ecosystem Value Justification:**
 
-Two of the five components are genuine public goods â open, permissionless infrastructure available to any Canton participant:
+Two of the five components are genuine public goods — open, permissionless infrastructure available to any Canton participant:
 
-- **ArchâCanton Bridge:** Free, open source bridging infrastructure. Arch does not charge fees for bridging, minting, or burning aBTC.
+- **Arch–Canton Bridge:** Free, open source bridging infrastructure. Arch does not charge fees for bridging, minting, or burning aBTC. Reusable pattern for other networks to build Canton bridges.
 - **Compliant Tokenization Service:** Open issuance infrastructure for compliant tokenized securities. Any Canton issuer can use it.
 
-The remaining three generate ecosystem value with built-in maintenance incentives:
+The remaining three components generate ecosystem value with built-in maintenance incentives — Arch's revenue depends on their functioning, ensuring durable maintenance:
 
-- **BTC Financial Services Access (DEX + Lending):** Makes Bitcoin productive on Canton.
-- **Canton Vault Standard:** Open CIP for community adoption.
-- **BTC Capital Markets Integration:** Connects Cantonâs $9T+ asset base to BTC capital.
+- **BTC Financial Services Access (DEX + Lending):** Makes Bitcoin productive on Canton. More activity drives Arch Lend and Arch Swap revenue, ensuring continued investment.
+- **Canton Vault Standard:** Open CIP for community adoption. More vault activity drives more lending and trading on Arch infrastructure.
+- **BTC Capital Markets Integration:** Connects Canton's $9T+ asset base to BTC capital. More integrations drive more volume.
 
 ## Rationale
 
 **Why Arch Network is the right team:**
 
-Arch Network is an $18M-funded Bitcoin infrastructure company with a 20-person team building for over 2.5 years. Our funding rounds were led by Multicoin Capital and Pantera Capital — two of the most respected institutional crypto investors — reflecting deep conviction in Arch's technical approach and market positioning. Delivered: production-grade blockchain with BFT consensus, 300ms blocks, ~1,000 TPS; Bitcoin-native DEX (Arch Swap); credit and lending protocol (Arch Lend); institutional portfolio dashboard (Arch Prime).
+Arch Network is an $18M-funded Bitcoin infrastructure company with a 20-person team that has been building for over 2.5 years. Our funding rounds were led by Multicoin Capital and Pantera Capital — two of the most respected institutional crypto investors — reflecting deep conviction in Arch’s technical approach and market positioning. The team has delivered: a production-grade blockchain with BFT consensus, 300ms blocks, and ~1,000 TPS; a Bitcoin-native DEX (Arch Swap); a credit and lending protocol (Arch Lend); and an institutional portfolio dashboard (Arch Prime).
 
 **Why this approach:**
 
-The vertically integrated approach is deliberate. Each componentâs value is amplified by the others â bridge enables aBTC, aBTC enables lending, lending enables vaults, vaults enable structured products, capital markets integration connects all of it to Cantonâs existing asset base. Self-reinforcing adoption flywheel.
+The vertically integrated approach (bridge + financial services + vault standard + capital markets integration + tokenization) is deliberate. Each component's value is amplified by the others — the bridge enables aBTC, aBTC enables lending, lending enables vaults, vaults enable structured products, and the capital markets integration connects all of it to Canton's existing asset base. Delivering these as an integrated stack rather than independent components creates a self-reinforcing adoption flywheel.
 
 **Why not CBTC alone:**
 
-CBTC serves BTC custody and holding. It does not support programmable lending, vault strategies, or capital markets integration. CBTC requires 6 Bitcoin confirmations (~60 minutes) for issuance/redemption, creating a collateral enforcement bottleneck. Archâs 300ms execution eliminates this. CBTC and aBTC are complementary â CBTC for custody, aBTC for capital markets.
+CBTC serves BTC custody and holding on Canton. It does not support programmable lending, vault strategies, or capital markets integration. Critically, CBTC requires 6 Bitcoin confirmations (~60 minutes) for issuance or redemption, creating a collateral enforcement bottleneck that constrains safe LTVs to 25–30% and limits carry trade competitiveness. Arch's 300ms execution eliminates this bottleneck, structurally enabling higher LTVs and more capital-efficient credit markets. CBTC and aBTC are complementary — CBTC for custody, aBTC (and Arch's service stack) for capital markets.
+
+**Alternatives considered:**
+
+- *Build on an existing EVM bridge:* Canton's privacy model and CIP-56 standard require native Daml integration. EVM bridges cannot provide sub-transaction privacy or Canton's Offer-Accept transfer model.
+- *Wait for Canton-native BTC lending:* No Canton-native protocol has the execution speed (300ms) or liquidation infrastructure required for safe BTC-collateralized lending at scale.
+- *Use CBTC as collateral base:* The 6-confirmation bottleneck structurally constrains LTVs and makes downstream carry trades less competitive. A purpose-built execution layer is required.
 
 **Daml development partnership:**
 
-Arch aims to engage IntellectEU or Obsidian Systems as specialist Daml development partner. Both are recognized Canton ecosystem developers with production experience.
+Arch aims to engage IntellectEU or Obsidian Systems as a specialist Daml development partner for Canton-side contract work. Both are recognized Daml ecosystem developers with Canton production experience. This converts the Daml learning curve from a team capability risk to a managed vendor relationship with defined deliverables and review gates.
 
 **Existing ecosystem partnerships providing day-one demand:**
 
-- Institutional custodian integrations: Anchorage, Ceffu, Utila
-- HoneyB: Active asset management partnership for BTC private credit yield strategies
-- Institutional liquidity providers: Galaxy, Pantera â committed to seeding initial vault liquidity
-- DAT partners: Digital Asset Trusts going live with $10â20M BTC yield pilots
-
-
+- Institutional custodian integrations: Anchorage, Ceffu, Utila — custody partners who will distribute aBTC vault strategies to their client bases.
+- HoneyB: Active asset management partnership for BTC private credit yield strategies. The HoneyB credit carry trade (LP deposits BTC → borrow stables via Arch Lend → deploy into tradfi yield → collect yield → repatriate to BTC via Arch Swap → distribute to LPs) demonstrates the complete service stack in a single workflow.
+- Institutional liquidity providers: Galaxy, Pantera — committed to seeding initial vault liquidity.
+- DAT partners: Digital Asset Trusts going live with $10–20M BTC yield pilots.

--- a/proposals/arch-bitcoin-capital-markets-stack.md
+++ b/proposals/arch-bitcoin-capital-markets-stack.md
@@ -1,6 +1,6 @@
 # Development Fund Proposal
 
-## Arch-Canton Bridge and Canton Vault Standard
+## Arch-Canton Bridge and BTC Developer SDK
 
 Author: Arch Network (Matt Mudano)
 
@@ -10,16 +10,21 @@ Status: Draft
 
 Created: 2026-04-01
 
-Total Funding Request: $150,000 USD (payable in CC equivalent)
+Label: dapp-integration
+
+Champion: Canton Foundation
+
+Total Funding Request: $125,000 USD (payable in CC equivalent)
 
 ## Abstract
 
-This proposal requests $150,000 to build two public good infrastructure components that connect Bitcoin to Canton Network:
+This proposal requests $125,000 to build two public good infrastructure components that connect Bitcoin's $2T+ asset class to Canton Network:
 
-- Arch-Canton Bridge - a bidirectional, fee-free, open source bridge that mints CIP-56-compliant aBTC on Canton, enabling BTC holders to access Canton’s institutional ecosystem and Canton participants to access Bitcoin liquidity.
-- Canton Vault Standard - a standardized, composable vault interface written in Daml (analogous to Ethereum’s ERC-4626), submitted as a formal Canton Improvement Proposal (CIP) for community adoption.
+- **Arch-Canton Bridge** - a bidirectional, fee-free, open source bridge that mints CIP-56-compliant aBTC on Canton, enabling BTC holders to access Canton's institutional ecosystem and Canton participants to access Bitcoin liquidity.
 
-Both components are open, permissionless infrastructure available to any Canton participant at no cost. The $150K budget covers Canton-side Daml contract development, bridge relayer integration, testing, security audit, and documentation. All work will be executed by IntellectEU, a specialist Daml development firm with Canton production experience.
+- **BTC Developer SDK** - a Daml integration layer with typed bindings, allowing any Canton developer to access Arch's BTC-native protocols (lending, yield, prime brokerage) directly from Daml contracts without building on the Bitcoin side themselves.
+
+Both components are open, permissionless infrastructure available to any Canton participant at no cost. The $125K budget covers Canton-side Daml contract development, bridge relayer integration, SDK development, testing, security audit, and documentation. All work will be executed by IntellectEU, a specialist Daml development firm with Canton production experience. Grant funding is used exclusively for these two public goods components. Arch Network separately operates commercial products (Arch Swap, Arch Lend, Arch Prime) at its own cost; the SDK provides open access to these protocols but no grant funds are used to build, operate, or market them.
 
 The underlying Arch-side infrastructure (consensus, execution, settlement) is already built and deployed. This proposal funds only the Canton integration layer.
 
@@ -27,81 +32,111 @@ The underlying Arch-side infrastructure (consensus, execution, settlement) is al
 
 ### 1. Objective
 
-Connect Bitcoin’s $2T+ asset class to Canton’s $9T+ institutional ecosystem through two foundational infrastructure primitives. Specifically:
+Connect Bitcoin's $2T+ asset class to Canton's $9T+ institutional ecosystem through two foundational infrastructure primitives, positioning Arch as a BTC infrastructure gateway for Canton. Specifically:
 
-- Bridge a gap in programmable BTC access. Canton has CBTC for custodial BTC holding, but no programmable bridge with execution capabilities. The Arch-Canton Bridge provides bidirectional BTC movement with 300ms execution, enabling BTC capital to flow into Canton’s DvP settlement, lending, and yield infrastructure, and Canton participants to access Bitcoin-native liquidity.
-- Fill a missing Daml primitive. Ethereum’s ERC-4626 vault standard has enabled billions in composable yield strategies. Canton has no equivalent. The Canton Vault Standard creates this primitive, enabling any Canton developer to build composable vaults for any underlying asset.
+- **Bridge a gap in programmable BTC access.** Canton has CBTC for custodial BTC holding, but no programmable bridge with execution capabilities. The Arch-Canton Bridge provides bidirectional BTC movement with 300ms execution, enabling BTC capital to flow into Canton's DvP settlement, lending, and yield infrastructure, and Canton participants to access Bitcoin-native liquidity.
 
-### 2. Component 1: Arch-Canton Bridge
+- **Give Canton developers access to BTC-native protocols.** Canton developers who need BTC-collateralized lending, BTC yield strategies, or Bitcoin prime brokerage in their applications currently have no way to access Bitcoin-native infrastructure from Daml. The BTC Developer SDK provides typed Daml bindings to Arch's protocols, so any Canton participant can integrate BTC primitives without building on the Bitcoin side themselves.
+
+### 2. Implementation Mechanics: Arch-Canton Bridge
 
 The bridge uses a relayer-based architecture with FROST threshold signatures for security.
 
-Bridge mechanics:
+**Bridge mechanics:**
 
-- Arch to Canton: User locks BTC on Arch. Validators produce a signed attestation. Relayer transmits to Canton. Canton bridge contract verifies and mints CIP-56 aBTC via Offer-Accept protocol.
-- Canton to Arch: User transfers aBTC to bridge contract. Bridge burns aBTC and emits withdrawal attestation. Relayer transmits to Arch. Validators construct and sign Bitcoin unlock transaction. User receives native BTC.
-- Security: (⌈2N/3⌉ + 1)-of-N FROST threshold signatures, per-epoch volume caps, emergency pause, reorg handling via DAG-based transaction tracking and UTXO anchoring.
-- Relayer model: Permissionless. Any party can relay valid attestations. Minimum 3 independent operators recommended.
+- **Arch to Canton:** User locks BTC on Arch. Validators produce a signed attestation. Relayer transmits to Canton. Canton bridge contract verifies and mints CIP-56 aBTC via Offer-Accept protocol.
 
-aBTC token (CIP-56):
+- **Canton to Arch:** User transfers aBTC to bridge contract. Bridge burns aBTC and emits withdrawal attestation. Relayer transmits to Arch. Validators construct and sign Bitcoin unlock transaction. User receives native BTC.
+
+- **Security:** (⌈2N/3⌉ + 1)-of-N FROST threshold signatures, per-epoch volume caps, emergency pause, reorg handling via DAG-based transaction tracking and UTXO anchoring.
+
+- **Relayer model:** Permissionless. Any party can relay valid attestations. Minimum 3 independent operators recommended.
+
+**aBTC token (CIP-56):**
 
 - CIP-56 compliant, 8 decimals (matching BTC), mint authority restricted to bridge contract only.
+
 - Configurable transfer restrictions (KYC, jurisdictional, accredited investor checks), regulatory observer support.
+
 - Dual-oracle design (RedStone primary, Chainlink secondary), 5-minute staleness threshold, 2% divergence handling, 10-minute TWAP, circuit breaker.
 
-Public good characteristics:
+**Public good characteristics:**
 
 - Free and open source. Arch does not charge fees for bridging, minting, or burning aBTC.
+
 - Reusable reference architecture. Other networks can adapt the bridge design to build their own Canton bridges.
-- Bidirectional value flow. BTC holders gain access to Canton’s tokenized asset ecosystem; Canton participants gain access to Bitcoin liquidity.
 
-### 3. Component 2: Canton Vault Standard
+- Bidirectional value flow. BTC holders gain access to Canton's tokenized asset ecosystem; Canton participants gain access to Bitcoin liquidity.
 
-A Daml-based vault interface specification analogous to Ethereum’s ERC-4626, providing a standardized primitive for composable yield strategies on Canton.
+### 3. Implementation Mechanics: BTC Developer SDK
 
-Interface:
+A Daml integration layer that gives Canton developers typed access to Arch's BTC-native protocols through the bridge. The SDK turns Arch into a BTC primitives provider for the Canton ecosystem: any participant who needs BTC-collateralized lending, BTC yield, or Bitcoin prime brokerage can call Arch's protocols from Daml contracts via standardized APIs.
 
-- Deposit/withdraw via CIP-56 Offer-Accept, share token accounting, compliance-gated deposits.
-- View functions: totalAssets, totalShares, convertToShares, convertToAssets, maxDeposit, maxWithdraw.
-- Composability: vault shares usable as collateral in existing Canton applications, settleable via DvP, nestable in other vaults.
+**SDK components:**
 
-Reference implementation:
+- Daml bindings for Arch Lend (BTC-collateralized lending), Arch Prime (institutional portfolio and prime brokerage), and bridge operations (mint/burn aBTC).
 
-- A reference vault using aBTC as the underlying asset, demonstrating the full deposit/withdraw/redeem lifecycle.
-- The standard itself is asset-agnostic. Any CIP-56 token can serve as a vault underlying.
+- Typed API wrappers: loan terms, collateral ratios, yield positions, bridge status, aBTC balances.
 
-Public good characteristics:
+- Composability: SDK calls can be embedded in existing Canton workflows, enabling BTC operations within DvP settlement, collateral management, and other Daml-native applications.
 
-- Submitted as a formal Canton Improvement Proposal (CIP) for community adoption.
-- Open standard. Any Canton developer can build vaults using this interface for any asset class.
-- Fills a documented gap in Canton’s smart contract primitives.
+**Reference integration:**
+
+- A reference Canton application demonstrating a BTC-collateralized loan and yield position executed entirely from Daml via the SDK.
+
+- The SDK is protocol-agnostic on the Canton side. Any Daml application can call Arch's BTC primitives through the typed bindings.
+
+**Public good characteristics:**
+
+- Open source SDK published on GitHub with permissive license. Any Canton developer can use it.
+
+- Removes the need for Canton developers to understand Bitcoin infrastructure. BTC primitives become callable from Daml like any other Canton service.
+
+- Positions Canton as a distribution layer for Bitcoin-native financial services, expanding the use cases available to Canton participants.
 
 ### 4. Architectural Alignment
 
-Both components align with Canton’s architecture and ecosystem priorities:
+Both components align with Canton's architecture and ecosystem priorities:
 
-- CIP-56 compliance: aBTC is a native CIP-56 token, fully compatible with Canton’s Offer-Accept transfer model, sub-transaction privacy, and regulatory observer framework.
-- DvP settlement: aBTC and vault shares settle atomically via the Global Synchronizer.
-- Daml-native: Bridge contracts and vault standard are implemented in Daml, leveraging Canton’s smart contract model and privacy guarantees.
-- Credential Utility compatible: aBTC holder requirements and vault deposit gates integrate with DA’s existing Credential Utility for KYC/AML enforcement.
-- Registry Utility compatible: Once minted, aBTC participates in DA’s Registry Utility workflows (transfer, allocation, settlement) with no custom integration required.
+- **CIP-56 compliance:** aBTC is a native CIP-56 token, fully compatible with Canton's Offer-Accept transfer model, sub-transaction privacy, and regulatory observer framework.
+
+- **DvP settlement:** aBTC settles atomically via the Global Synchronizer. SDK-initiated operations (loans, yield positions) settle on Arch with results reflected on Canton through the bridge.
+
+- **Daml-native:** Bridge contracts and SDK bindings are implemented in Daml, leveraging Canton's smart contract model and privacy guarantees.
+
+- **Credential Utility compatible:** aBTC holder requirements and SDK access controls integrate with DA's existing Credential Utility for KYC/AML enforcement.
+
+- **Registry Utility compatible:** Once minted, aBTC participates in DA's Registry Utility workflows (transfer, allocation, settlement) with no custom integration required.
 
 ### 5. Backward Compatibility
 
 No backward compatibility impact. Both components are additive:
 
 - aBTC is a new CIP-56 token. Does not modify existing token contracts or standards.
-- The Canton Vault Standard is a new primitive. Does not change existing Daml contracts.
-- The bridge introduces new contracts (BridgeController, DepositAttestation, MintAuthority, WithdrawalRequest) that interact with Canton via standard CIP-56 mechanics.
 
-## Ecosystem Benefits
+- The BTC Developer SDK is a new integration layer. Does not change existing Daml contracts.
 
-Once the bridge and vault standard are live, they enable a broader set of use cases for the Canton ecosystem. These are not funded deliverables but represent the downstream value of the public good infrastructure:
+- The bridge introduces new contracts (BridgeController, DepositAttestation, MintAuthority, WithdrawalRequest) and the SDK adds typed Daml bindings. Both interact with Canton via standard CIP-56 mechanics.
 
-- BTC financial services access. Canton participants can bridge aBTC and access BTC/stablecoin liquidity (via Arch Swap) and stablecoin loans against BTC collateral (via Arch Lend). These services are operated and funded by Arch Network independently.
-- Composable yield strategies. The vault standard enables institutional yield strategies on Canton: private credit, yield ETFs, debt tranches, and other tradfi yield products, all through a standardized interface.
-- BTC-denominated capital markets. aBTC as a CIP-56 token can participate in DA’s existing Registry Utility workflows, enabling BTC-denominated subscriptions into tokenized securities issued via DA’s Registry App. No additional integration infrastructure is needed beyond the bridge itself.
-- BTC as collateral. aBTC can be used in DA’s Collateral Utility for margin agreements and collateral settlement, bringing Bitcoin into Canton’s existing institutional collateral framework.
+## Ecosystem Benefits (Not Grant-Funded)
+
+The bridge and SDK enable downstream use cases available to builders and participants in the Canton ecosystem which can be accessed via APIs.
+
+- **BTC financial services.** BTC/stablecoin liquidity/swaps (Arch Swap) and BTC-collateralized lending (Arch Lend) accessible to Canton participants via the SDK.
+
+- **Institutional yield.** Existing partnerships (HoneyB, Pantera, DAT partners, Anchorage, Maple with $10–20M pilots) provide ready demand for BTC yield on Canton.
+
+- **BTC capital markets and collateral.** aBTC's CIP-56 compliance makes it eligible for listing in DA's Registry Utility and use in the Collateral Utility, enabling BTC-denominated securities subscriptions and collateral in margin agreements.
+
+## Committed Reference Implementation: HoneyB
+
+HoneyB, a BTC-native asset management firm, has committed to using the Arch-Canton bridge and BTC Developer SDK as the infrastructure layer for bringing Bitcoin yield products to Canton. This is not a hypothetical use case — HoneyB is an active Arch ecosystem partner already building BTC private credit strategies on Arch's lending infrastructure. HoneyB has also established a partnership with a fixed income ETF provider with a 15-year track record and $15 billion in AUM, led by an ex-PIMCO fixed income team, to bring traditional fixed income yield strategies to Bitcoin holders. Their commitment to Canton integration provides an immediate, real-world reference implementation from day one.
+
+**What this means for Canton:** Once the bridge and SDK ship, HoneyB will use them to offer BTC yield strategies — including private credit, structured lending products, and traditional fixed income strategies sourced through their institutional ETF partnership — directly to Canton participants via aBTC. This brings a unique convergence to Canton: institutional-grade tradfi yield expertise (backed by a team with a 15-year track record managing $15B in fixed income) paired with Bitcoin-native infrastructure. Canton's institutional ecosystem gains not just a new asset class (BTC yield), but a bridge between traditional fixed income and digital assets, without any Canton participant needing to interact with Bitcoin infrastructure directly. HoneyB's integration adds a live, revenue-generating application to the Canton ecosystem that would not exist without the grant-funded public goods.
+
+**Why this matters for the proposal:** A committed reference implementation de-risks the grant. The bridge and SDK are not speculative infrastructure waiting for adoption — they have a confirmed first user with an active business ready to deploy on Canton as soon as the integration is live. This accelerates time-to-value for the Canton ecosystem and demonstrates that the public goods funded by this grant will generate immediate, tangible ecosystem activity.
+
+HoneyB's integration is commercially operated and funded entirely by Arch and HoneyB — no grant funds are used. It is listed here because it validates the infrastructure this proposal builds and provides the Canton Foundation with confidence that the grant-funded components will see real usage upon delivery.
 
 ## Milestones and Deliverables
 
@@ -117,13 +152,19 @@ All milestones cover Canton-side Daml integration work only. The underlying Arch
 
 Deliverables:
 
-- Bridge design specification. Published technical document covering architecture, security model, message format, and failure modes. Reviewed by at least one independent Daml ecosystem developer.
-- Daml bridge contracts. BridgeController, DepositAttestation, MintAuthority, WithdrawalRequest implemented with >90% unit test coverage. Source code published on GitHub. Reviewed by IntellectEU.
-- Arch-side lock/burn contracts. UTXO-based contracts deployed on Arch testnet with passing integration tests.
-- aBTC CIP-56 token. Compliant token contract with compliance hooks, transfer restrictions, and DvP support. Deployed on Canton testnet. Passes Canton token standard conformance tests.
-- Relayer prototype. Functional relayer transmitting attestations between Arch testnet and Canton testnet. At least 100 successful cross-chain transfers demonstrated.
-- Integration tests. End-to-end tests (Arch deposit to Canton mint, Canton burn to Arch unlock). Minimum 50 test cases covering normal and failure paths. Test suite published.
-- Documentation. Developer guide for bridge integration. aBTC token specification. Published on GitHub with README and quickstart.
+- **Bridge design specification.** Published technical document covering architecture, security model, message format, and failure modes. Reviewed by at least one independent Daml ecosystem developer.
+
+- **Daml bridge contracts.** BridgeController, DepositAttestation, MintAuthority, WithdrawalRequest implemented with >90% unit test coverage. Source code published on GitHub. Reviewed by IntellectEU.
+
+- **Arch-side lock/burn contracts.** UTXO-based contracts deployed on Arch testnet with passing integration tests.
+
+- **aBTC CIP-56 token.** Compliant token contract with compliance hooks, transfer restrictions, and DvP support. Deployed on Canton testnet. Passes Canton token standard conformance tests.
+
+- **Relayer prototype.** Functional relayer transmitting attestations between Arch testnet and Canton testnet. At least 100 successful cross-chain transfers demonstrated.
+
+- **Integration tests.** End-to-end tests (Arch deposit to Canton mint, Canton burn to Arch unlock). Minimum 50 test cases covering normal and failure paths. Test suite published.
+
+- **Documentation.** Developer guide for bridge integration. aBTC token specification. Published on GitHub with README and quickstart.
 
 ### Milestone 1B: Bridge Mainnet Readiness
 
@@ -135,42 +176,53 @@ Deliverables:
 
 Deliverables:
 
-- Bridge security audit. Third-party audit by a recognized firm (Certora, Trail of Bits, or equivalent). 0 critical findings, 0 unresolved high findings. Audit report published publicly.
-- Bridge mainnet deployment. Contracts deployed on Arch mainnet and Canton mainnet. Relayer operational with uptime monitoring and alerting. At least 10 mainnet bridge transfers processed.
-- aBTC mainnet launch. aBTC live on Canton mainnet, mintable via bridge. At least one institutional participant has minted aBTC.
-- Documentation. Bridge operational runbook, aBTC integration guide. Published on GitHub.
+- **Bridge security audit.** Third-party audit by a recognized firm (Certora, Trail of Bits, or equivalent). 0 critical findings, 0 unresolved high findings. Audit report published publicly.
 
-### Milestone 2: Canton Vault Standard CIP
+- **Bridge mainnet deployment.** Contracts deployed on Arch mainnet and Canton mainnet. Relayer operational with uptime monitoring and alerting. At least 10 mainnet bridge transfers processed.
+
+- **aBTC mainnet launch.** aBTC live on Canton mainnet, mintable via bridge. At least one institutional participant has minted aBTC.
+
+- **Documentation.** Bridge operational runbook, aBTC integration guide. Published on GitHub.
+
+### Milestone 2: BTC Developer SDK
 
 | | |
 |---|---|
-| **Delivery** | Q3 2026 (August–September) |
-| **Funding** | $50,000 |
-| **Focus** | Vault standard specification, reference implementation, CIP submission |
+| **Delivery** | Q3 2026 (July–August) |
+| **Funding** | $25,000 |
+| **Focus** | SDK development, Daml bindings for Arch protocols, reference integration, documentation |
 
 Deliverables:
 
-- Canton Vault Standard specification. Published standard with Daml interface definitions, deposit/withdraw flows, share accounting, compliance integration. Formally submitted as a Canton Improvement Proposal (CIP).
-- Reference vault implementation. Daml vault contract using aBTC as underlying. Deposit, withdraw, redeem, share accounting functional on Canton testnet with >90% unit test coverage. Reviewed by IntellectEU.
-- Vault composability demonstration. Vault shares used as collateral in an atomic DvP settlement with another CIP-56 asset on Canton testnet. Documented with transaction logs.
-- Documentation. Vault standard developer guide. Published on GitHub.
+- **BTC Developer SDK.** Typed Daml bindings for Arch Lend, Arch Prime, and bridge operations. Published on GitHub with permissive open source license. Reviewed by IntellectEU.
+
+- **Reference integration.** Reference Canton application demonstrating a BTC-collateralized loan and yield position via SDK. Functional on Canton testnet with >90% unit test coverage. Reviewed by IntellectEU.
+
+- **End-to-end integration test.** Canton application executes a BTC-collateralized loan and uses proceeds in a DvP settlement with another CIP-56 asset on Canton testnet. Documented with transaction logs.
+
+- **Documentation.** SDK developer guide with API reference and integration examples. Published on GitHub.
 
 ## Acceptance Criteria
 
 The Tech & Ops Committee will evaluate completion based on:
 
 - Deliverables completed as specified for each milestone.
+
 - Demonstrated functionality or operational readiness.
+
 - Documentation and knowledge transfer provided.
+
 - Security audit results (Milestone 1B): 0 critical, 0 unresolved high findings.
+
 - Mainnet operational status (Milestone 1B): bridge operational, aBTC mintable.
-- CIP submission (Milestone 2): vault standard formally submitted as a Canton Improvement Proposal.
+
+- SDK delivery (Milestone 2): BTC Developer SDK published on GitHub with documentation and reference integration.
 
 ## Funding
 
-Total Funding Request: $150,000 USD (payable in CC equivalent)
+**Total Funding Request:** $125,000 USD (payable in CC equivalent)
 
-This budget covers Canton-side Daml contract development by IntellectEU, bridge relayer integration, security audit, testing, and documentation. All underlying Arch primitives are already built and funded by Arch Network independently.
+This budget covers Canton-side Daml contract development by IntellectEU, bridge relayer integration, SDK development, security audit, testing, and documentation. All underlying Arch primitives are already built and funded by Arch Network independently. No grant funds are used to build, operate, or market Arch's commercial products (Arch Swap, Arch Lend, Arch Prime), which Arch develops and maintains at its own cost.
 
 ### Payment Breakdown
 
@@ -178,8 +230,8 @@ This budget covers Canton-side Daml contract development by IntellectEU, bridge 
 |---|---|---|
 | M1A: Bridge Testnet Delivery | $50,000 | Q2 2026 |
 | M1B: Bridge Mainnet Readiness | $50,000 | Q2–Q3 2026 |
-| M2: Canton Vault Standard CIP | $50,000 | Q3 2026 |
-| **Total** | **$150,000** | |
+| M2: BTC Developer SDK | $25,000 | Q3 2026 |
+| **Total** | **$125,000** | |
 
 ### Volatility Stipulation
 
@@ -190,45 +242,51 @@ Should the project timeline extend beyond 6 months due to Committee-requested sc
 Upon release, Arch Network will collaborate with the Foundation on:
 
 - Announcement coordination
+
 - Case study or technical blog
+
 - Developer or ecosystem promotion
 
 ## Motivation
 
 Canton hosts over $9 trillion in tokenized assets and processes approximately $350 billion in daily volume. Institutional participants, including Goldman Sachs (DAP), Broadridge (DLR), and Versana, use Canton for compliant, privacy-preserving financial operations.
 
-Canton’s connection to Bitcoin, a $2T+ asset class and the most widely held digital asset among institutions, remains underdeveloped. While CBTC provides custodial wrapped BTC on Canton, there is no programmable bridge to Bitcoin-native infrastructure with execution capabilities, and no standardized vault primitive for composable yield strategies.
+Canton's connection to Bitcoin, a $2T+ asset class and the most widely held digital asset among institutions, remains underdeveloped. While CBTC provides custodial wrapped BTC on Canton, there is no programmable bridge to Bitcoin-native infrastructure with execution capabilities, and no way for Canton developers to access BTC-native protocols (lending, yield, prime brokerage) from Daml.
 
-These gaps mean Canton participants who hold BTC, or whose clients hold BTC, cannot put that capital to work within Canton’s compliance framework.
+These gaps mean Canton participants who hold BTC, or whose clients hold BTC, cannot put that capital to work within Canton's compliance framework. Arch Network's existing BTC infrastructure (DEX, lending, prime brokerage) already serves this market on the Bitcoin side; this proposal funds the Canton integration that makes those capabilities accessible to Canton participants.
 
 This proposal addresses these gaps with two open infrastructure components:
 
-- The Arch-Canton Bridge is free, open source bridging infrastructure. Arch does not charge fees for bridging, minting, or burning aBTC. The bridge is a reusable reference architecture that other networks can adapt to build their own Canton bridges.
-- The Canton Vault Standard is an open CIP for community adoption. Any Canton developer can build composable vaults using this standard for any asset class, not just aBTC.
+- **The Arch-Canton Bridge** is free, open source bridging infrastructure. Arch does not charge fees for bridging, minting, or burning aBTC. The bridge is a reusable reference architecture that other networks can adapt to build their own Canton bridges.
 
-Once these public goods exist, they enable commercially viable use cases that Arch Network will build and maintain at its own cost: BTC/stablecoin trading, BTC-collateralized lending, and institutional yield strategies. Arch’s commercial revenue from these services creates perpetual maintenance incentives for the entire stack, including the public goods layer, that persist long after the grant term ends.
+- **The BTC Developer SDK** is an open source integration layer. Any Canton developer can access Arch's BTC protocols (lending, yield, prime brokerage) from Daml contracts through typed bindings, without building on the Bitcoin side themselves.
+
+Once these public goods exist, they enable commercially viable use cases that Arch Network already operates at its own cost, with no grant funding: BTC/stablecoin trading (Arch Swap), BTC-collateralized lending (Arch Lend), and institutional yield strategies (HoneyB partnership, Galaxy and Pantera liquidity commitments, $10-20M DAT pilots). These are Arch's commercial products, not public goods. Arch's revenue from operating them creates a direct financial incentive to maintain the public goods layer long after the grant term ends.
 
 ## Rationale
 
-Why Arch Network:
+**Why Arch Network:**
 
 Arch Network is an $18M-funded Bitcoin infrastructure company with a 20-person team that has been building for over 2.5 years. The team has delivered a production-grade blockchain with BFT consensus, 300ms blocks, and approximately 1,000 TPS; a Bitcoin-native DEX (Arch Swap); a credit and lending protocol (Arch Lend); and an institutional portfolio dashboard (Arch Prime).
 
-Why not CBTC alone:
+**Why not CBTC alone:**
 
-CBTC serves BTC custody and holding on Canton. It does not support programmable lending, vault strategies, or capital markets integration. CBTC requires 6 Bitcoin confirmations (approximately 60 minutes) for issuance or redemption, creating a collateral enforcement bottleneck that constrains safe loan-to-value ratios to 25-30%. Arch’s 300ms execution eliminates this bottleneck, enabling higher LTVs and more capital-efficient credit markets. CBTC and aBTC are complementary: CBTC for custody, aBTC for capital markets.
+CBTC serves BTC custody and holding on Canton. It does not support programmable lending, vault strategies, or capital markets integration. CBTC requires 6 Bitcoin confirmations (approximately 60 minutes) for issuance or redemption, creating a collateral enforcement bottleneck that constrains safe loan-to-value ratios to 25-30%. Arch's 300ms execution eliminates this bottleneck, enabling higher LTVs and more capital-efficient credit markets. CBTC and aBTC are complementary: CBTC for custody, aBTC for capital markets.
 
-Why a dedicated bridge rather than an existing EVM bridge:
+**Why a dedicated bridge rather than an existing EVM bridge:**
 
-Canton’s privacy model and CIP-56 standard require native Daml integration. EVM bridges cannot provide sub-transaction privacy or Canton’s Offer-Accept transfer model.
+Canton's privacy model and CIP-56 standard require native Daml integration. EVM bridges cannot provide sub-transaction privacy or Canton's Offer-Accept transfer model.
 
-Daml development partner: IntellectEU
+**Daml development partner: IntellectEU**
 
 Arch has selected IntellectEU as its specialist Daml development partner for Canton-side contract work across all milestones. IntellectEU is a recognized Daml ecosystem developer with Canton production experience.
 
-Existing ecosystem partnerships:
+**Existing ecosystem partnerships:**
 
-- Institutional custodians: Anchorage, Ceffu, Utila, providing custody and distribution for aBTC vault strategies.
-- HoneyB: Active asset management partnership for BTC private credit yield strategies.
-- Institutional liquidity providers: Galaxy, Pantera, committed to seeding initial vault liquidity.
-- DAT partners: Digital Asset Trusts going live with $10-20M BTC yield pilots.
+- **Institutional custodians:** Anchorage, Ceffu, Utila, providing custody and distribution for aBTC strategies on Canton.
+
+- **HoneyB:** Active asset management partnership for BTC private credit yield strategies, with an established partnership with a fixed income ETF provider ($15B AUM, 15-year track record, ex-PIMCO team) bringing tradfi yield to Bitcoin holders.
+
+- **Institutional liquidity providers:** Galaxy, Pantera, committed to seeding initial liquidity.
+
+- **DAT partners:** Digital Asset Trusts going live with $10-20M BTC yield pilots.

--- a/proposals/arch-bitcoin-capital-markets-stack.md
+++ b/proposals/arch-bitcoin-capital-markets-stack.md
@@ -6,46 +6,46 @@
 
 ## Abstract
 
-Arch and Canton are structurally complementary institutions. Canton provides the institutional compliance layer, sub-transaction privacy, and atomic DvP settlement that capital markets require. Arch provides Bitcoin-native execution and settlement infrastructure — 300ms blocks, ~1,000 TPS, validator-secured collateral enforcement, and native Bitcoin settlement. Together, they can create the capital markets corridor between Bitcoin’s $2T+ and Canton’s $9T+ institutional asset ecosystem.
+Arch and Canton are structurally complementary institutions. Canton provides the institutional compliance layer, sub-transaction privacy, and atomic DvP settlement that capital markets require. Arch provides Bitcoin-native execution and settlement infrastructure â 300ms blocks, ~1,000 TPS, validator-secured collateral enforcement, and native Bitcoin settlement. Together, they can create the capital markets corridor between Bitcoinâs $2T+ and Cantonâs $9T+ institutional asset ecosystem.
 
-Bitcoin is a $2T+ asset with no scalable form of native yield. The most viable strategy for making BTC productive — for institutions, family offices, and sophisticated investors — is the credit carry trade: borrow against BTC collateral, deploy stablecoins into yield-generating strategies (private credit, yield ETFs, money market instruments), collect yield, repay the loan, keep the spread as net BTC yield. This strategy requires fast execution, deterministic collateral enforcement, and deep liquidity — exactly what Arch’s infrastructure provides.
+Bitcoin is a $2T+ asset with no scalable form of native yield. The most viable strategy for making BTC productive â for institutions, family offices, and sophisticated investors â is the credit carry trade: borrow against BTC collateral, deploy stablecoins into yield-generating strategies (private credit, yield ETFs, money market instruments), collect yield, repay the loan, keep the spread as net BTC yield. This strategy requires fast execution, deterministic collateral enforcement, and deep liquidity â exactly what Archâs infrastructure provides.
 
 This proposal describes five infrastructure components that deliver a full Bitcoin financial services stack for Canton to facilitate this:
 
-1. **Arch–Canton Bridge** — Foundational interoperability infrastructure connecting native BTC to Canton Network. Also serves as the connectivity layer for Arch’s financial services (DEX, lending, vaults) to Canton participants. Institutions interact through existing custody relationships (Anchorage, Ceffu, Utila) — no new custody required.
+1. **ArchâCanton Bridge** â Foundational interoperability infrastructure connecting native BTC to Canton Network. Also serves as the connectivity layer for Archâs financial services (DEX, lending, vaults) to Canton participants. Institutions interact through existing custody relationships (Anchorage, Ceffu, Utila) â no new custody required.
 
-2. **BTC Financial Services Access (DEX + Lending)** — Canton participants gain access to Arch Swap (deep BTC/stablecoin liquidity) and Arch Lend (stablecoin loans against BTC collateral) through the bridge. These are the financial primitives that make BTC productive — without them, BTC on Canton is a holding asset, not a working one.
+2. **BTC Financial Services Access (DEX + Lending)** â Canton participants gain access to Arch Swap (deep BTC/stablecoin liquidity) and Arch Lend (stablecoin loans against BTC collateral) through the bridge. These are the financial primitives that make BTC productive â without them, BTC on Canton is a holding asset, not a working one.
 
-3. **Canton Vault Standard** — A standardized, composable vault interface written in Daml (analogous to Ethereum’s ERC-4626) that enables institutional yield strategies on Canton. Once credit infrastructure exists, vaults become the vehicle for deploying it — private credit strategies, yield ETFs, debt tranches, corporate bonds, subscription agreements with fund asset managers, and other tradfi yield strategies, all accessible through a standard interface.
+3. **Canton Vault Standard** â A standardized, composable vault interface written in Daml (analogous to Ethereumâs ERC-4626) that enables institutional yield strategies on Canton. Once credit infrastructure exists, vaults become the vehicle for deploying it â private credit strategies, yield ETFs, debt tranches, corporate bonds, subscription agreements with fund asset managers, and other tradfi yield strategies, all accessible through a standard interface.
 
-4. **BTC Capital Markets Integration for DA’s Tokenization Utility** — An integration layer connecting Arch’s financial services to DA’s existing issuance infrastructure, enabling aBTC as a native subscription and settlement asset for tokenized securities on Canton.
+4. **BTC Capital Markets Integration for DAâs Tokenization Utility** â An integration layer connecting Archâs financial services to DAâs existing issuance infrastructure, enabling aBTC as a native subscription and settlement asset for tokenized securities on Canton.
 
-5. **Compliant Tokenization Service** — A compliant securities issuance service that enables the tokenization of yield instruments, fund shares, structured products, and other securities on top of the BTC infrastructure with proper regulatory compliance. This is a public good for Canton’s ecosystem: any issuer can use it to create compliant tokenized securities backed by or denominated in BTC.
+5. **Compliant Tokenization Service** â A compliant securities issuance service that enables the tokenization of yield instruments, fund shares, structured products, and other securities on top of the BTC infrastructure with proper regulatory compliance. This is a public good for Cantonâs ecosystem: any issuer can use it to create compliant tokenized securities backed by or denominated in BTC.
 
-Together, these components deliver a complete Bitcoin capital markets stack for Canton: bridge access, deep swaps, institutional lending, tradfi yield infrastructure, compliant securities tokenization — and the capital markets integration that connects all of it to Canton’s existing $9T+ tokenized asset base.
+Together, these components deliver a complete Bitcoin capital markets stack for Canton: bridge access, deep swaps, institutional lending, tradfi yield infrastructure, compliant securities tokenization â and the capital markets integration that connects all of it to Cantonâs existing $9T+ tokenized asset base.
 
 ## Specification
 
 ### 1. Objective
 
-Connect Bitcoin’s $2T+ asset class to Canton’s $9T+ institutional ecosystem through purpose-built financial infrastructure. Specifically: enable institutional BTC holders to earn yield on their Bitcoin without leaving the Canton compliance framework, and enable Canton-native asset issuers to access BTC-denominated capital for the first time.
+Connect Bitcoinâs $2T+ asset class to Cantonâs $9T+ institutional ecosystem through purpose-built financial infrastructure. Specifically: enable institutional BTC holders to earn yield on their Bitcoin without leaving the Canton compliance framework, and enable Canton-native asset issuers to access BTC-denominated capital for the first time.
 
 The five infrastructure components solve three problems that Canton cannot solve internally:
 
-- **No programmable BTC bridge with execution capabilities.** Canton has CBTC (custodial holding), but no mechanism for BTC capital to flow into lending, trading, or yield strategies. The Arch–Canton Bridge solves this.
-- **No standardized vault primitive.** Ethereum’s ERC-4626 has enabled billions in composable DeFi strategies. Canton has no equivalent. The Canton Vault Standard fills this gap.
-- **No BTC capital onramp for tokenized assets.** DA’s Tokenization Utility provides world-class issuance infrastructure, but there is no mechanism for BTC capital to subscribe to Canton-issued securities. The BTC Capital Markets Integration builds that connection.
+- **No programmable BTC bridge with execution capabilities.** Canton has CBTC (custodial holding), but no mechanism for BTC capital to flow into lending, trading, or yield strategies. The ArchâCanton Bridge solves this.
+- **No standardized vault primitive.** Ethereumâs ERC-4626 has enabled billions in composable DeFi strategies. Canton has no equivalent. The Canton Vault Standard fills this gap.
+- **No BTC capital onramp for tokenized assets.** DAâs Tokenization Utility provides world-class issuance infrastructure, but there is no mechanism for BTC capital to subscribe to Canton-issued securities. The BTC Capital Markets Integration builds that connection.
 
 ### 2. Implementation Mechanics
 
-**Arch–Canton Bridge**
+**ArchâCanton Bridge**
 
 The bridge uses a relayer-based architecture with FROST threshold signatures for security:
 
 - Arch to Canton: User locks BTC on Arch, validators produce signed attestation, relayer transmits to Canton, Canton bridge contract verifies and mints CIP-56 aBTC token via Offer-Accept protocol.
 - Canton to Arch: User transfers aBTC to bridge contract, bridge burns aBTC and emits withdrawal attestation, relayer transmits to Arch, validators construct and sign Bitcoin unlock transaction, user receives native BTC.
 - Security: FROST threshold signatures, per-epoch volume caps, emergency pause, reorg handling via DAG-based transaction tracking and UTXO anchoring.
-- Relayer model: Permissionless — any party can relay valid attestations. Minimum 3 independent operators recommended.
+- Relayer model: Permissionless â any party can relay valid attestations. Minimum 3 independent operators recommended.
 
 **aBTC Token (CIP-56)**
 
@@ -63,76 +63,76 @@ The bridge uses a relayer-based architecture with FROST threshold signatures for
 **BTC Capital Markets Integration**
 
 - aBTC Subscription Interface: Enables atomic DvP subscriptions denominated in aBTC into DA Tokenization Utility-issued assets.
-- Vault Share Composability: Vault share tokens registered as eligible collateral and subscription assets within DA’s credential layer.
+- Vault Share Composability: Vault share tokens registered as eligible collateral and subscription assets within DAâs credential layer.
 - BTC Settlement Pairs: aBTC/tokenized-treasury, aBTC/money-market-fund, aBTC/private-credit DvP settlement pairs.
 - Open source integration guides, Daml templates, and TypeScript examples for issuers.
 
 **Compliant Tokenization Service**
 
-- Compliant issuance of securities as tokens on Canton — open, permissionless infrastructure.
+- Compliant issuance of securities as tokens on Canton â open, permissionless infrastructure.
 - Supports yield instruments, fund shares, structured products, and other securities with proper regulatory compliance.
 - KYC/AML, accreditation, and jurisdictional controls enforced at issuance level.
 
 ### 3. Architectural Alignment
 
-This proposal aligns with Canton’s architecture and ecosystem priorities:
+This proposal aligns with Cantonâs architecture and ecosystem priorities:
 
-- **CIP-56 compliance:** aBTC is a native CIP-56 token, fully compatible with Canton’s Offer-Accept transfer model, sub-transaction privacy, and regulatory observer framework.
-- **DvP settlement:** All components support Canton’s atomic DvP settlement — aBTC subscriptions, vault share trades, and BTC settlement pairs all settle atomically via the Global Synchronizer.
-- **Daml-native:** Bridge contracts, vault standard, and tokenization protocol are implemented in Daml, leveraging Canton’s smart contract model and benefiting from its privacy and composability guarantees.
-- **Canton Improvement Proposal:** The Canton Vault Standard will be submitted as a formal CIP for community adoption, contributing to Canton’s standards ecosystem.
-- **DA Tokenization Utility integration:** The BTC Capital Markets Integration builds on top of DA’s existing issuance infrastructure rather than replacing it — aBTC becomes a new payment and collateral leg for assets already issued via DA’s Tokenization Utility.
-- **Institutional compliance model:** Vault-level compliance gating (KYC, accreditation, jurisdictional rules) enforced at deposit, aligned with Canton’s institutional-grade compliance framework.
+- **CIP-56 compliance:** aBTC is a native CIP-56 token, fully compatible with Cantonâs Offer-Accept transfer model, sub-transaction privacy, and regulatory observer framework.
+- **DvP settlement:** All components support Cantonâs atomic DvP settlement â aBTC subscriptions, vault share trades, and BTC settlement pairs all settle atomically via the Global Synchronizer.
+- **Daml-native:** Bridge contracts, vault standard, and tokenization protocol are implemented in Daml, leveraging Cantonâs smart contract model and benefiting from its privacy and composability guarantees.
+- **Canton Improvement Proposal:** The Canton Vault Standard will be submitted as a formal CIP for community adoption, contributing to Cantonâs standards ecosystem.
+- **DA Tokenization Utility integration:** The BTC Capital Markets Integration builds on top of DAâs existing issuance infrastructure rather than replacing it â aBTC becomes a new payment and collateral leg for assets already issued via DAâs Tokenization Utility.
+- **Institutional compliance model:** Vault-level compliance gating (KYC, accreditation, jurisdictional rules) enforced at deposit, aligned with Cantonâs institutional-grade compliance framework.
 
 ### 4. Backward Compatibility
 
 No backward compatibility impact. All components are additive:
 
-- aBTC is a new CIP-56 token — does not modify existing token contracts or standards.
-- The Canton Vault Standard is a new primitive — does not change existing Daml contracts.
+- aBTC is a new CIP-56 token â does not modify existing token contracts or standards.
+- The Canton Vault Standard is a new primitive â does not change existing Daml contracts.
 - The bridge introduces new contracts (BridgeController, DepositAttestation, MintAuthority, WithdrawalRequest) that interact with Canton via standard CIP-56 mechanics.
-- BTC Capital Markets Integration adds subscription and settlement interfaces on top of DA’s existing Tokenization Utility — no modifications to DA’s contracts required.
+- BTC Capital Markets Integration adds subscription and settlement interfaces on top of DAâs existing Tokenization Utility â no modifications to DAâs contracts required.
 - Compliant Tokenization Service is independent infrastructure, available to any Canton participant.
 
 ## Milestones and Deliverables
 
 ### Milestone 1: Bridge Architecture + aBTC Token (Q2 2026)
 
-- **Estimated Delivery:** Q2 2026 (April–June)
+- **Estimated Delivery:** Q2 2026 (AprilâJune)
 - **Focus:** Bridge design, Daml contract development, aBTC token deployment on testnet, relayer prototype
 - **Deliverables / Value Metrics:**
-  - Bridge design specification — published technical document covering architecture, security model, message format, and failure modes.
-  - Daml bridge contracts — BridgeController, DepositAttestation, MintAuthority, WithdrawalRequest implemented with >90% unit test coverage.
-  - Arch-side lock/burn contracts — UTXO-based contracts deployed on Arch testnet with passing integration tests.
-  - aBTC CIP-56 token — Compliant token contract with compliance hooks, transfer restrictions, and DvP support. Deployed on Canton testnet.
-  - Relayer prototype — Functional relayer with at least 100 successful cross-chain transfers demonstrated.
-  - Integration tests — End-to-end tests. Minimum 50 test cases covering normal and failure paths.
-  - Documentation — Developer guide for bridge integration. aBTC token specification. Published on GitHub.
+  - Bridge design specification â published technical document covering architecture, security model, message format, and failure modes.
+  - Daml bridge contracts â BridgeController, DepositAttestation, MintAuthority, WithdrawalRequest implemented with >90% unit test coverage.
+  - Arch-side lock/burn contracts â UTXO-based contracts deployed on Arch testnet with passing integration tests.
+  - aBTC CIP-56 token â Compliant token contract with compliance hooks, transfer restrictions, and DvP support. Deployed on Canton testnet.
+  - Relayer prototype â Functional relayer with at least 100 successful cross-chain transfers demonstrated.
+  - Integration tests â End-to-end tests. Minimum 50 test cases covering normal and failure paths.
+  - Documentation â Developer guide for bridge integration. aBTC token specification. Published on GitHub.
 
 ### Milestone 2: Vault Standard + Bridge Production (Q3 2026)
 
-- **Estimated Delivery:** Q3 2026 (July–September)
+- **Estimated Delivery:** Q3 2026 (JulyâSeptember)
 - **Focus:** Canton Vault Standard specification, reference implementations, bridge security audit, mainnet deployment
 - **Deliverables / Value Metrics:**
-  - Canton Vault Standard specification — Published standard. Formally submitted as a Canton Improvement Proposal (CIP).
-  - Reference vault implementation — Daml vault contract using aBTC as underlying with >90% unit test coverage.
-  - Vault composability demonstration — Vault shares used as collateral in an atomic DvP settlement.
-  - Bridge security audit — Third-party audit. 0 critical findings, 0 unresolved high findings. Audit report published publicly.
-  - Bridge mainnet deployment — Contracts deployed on Arch mainnet and Canton mainnet. At least 10 mainnet bridge transfers.
-  - aBTC mainnet launch — aBTC live on Canton mainnet, mintable via bridge.
-  - Documentation — Vault standard developer guide, bridge operational runbook, aBTC integration guide.
+  - Canton Vault Standard specification â Published standard. Formally submitted as a Canton Improvement Proposal (CIP).
+  - Reference vault implementation â Daml vault contract using aBTC as underlying with >90% unit test coverage.
+  - Vault composability demonstration â Vault shares used as collateral in an atomic DvP settlement.
+  - Bridge security audit â Third-party audit. 0 critical findings, 0 unresolved high findings. Audit report published publicly.
+  - Bridge mainnet deployment â Contracts deployed on Arch mainnet and Canton mainnet. At least 10 mainnet bridge transfers.
+  - aBTC mainnet launch â aBTC live on Canton mainnet, mintable via bridge.
+  - Documentation â Vault standard developer guide, bridge operational runbook, aBTC integration guide.
 
 ### Milestone 3: BTC Capital Markets Integration + Ecosystem Launch (Q4 2026)
 
-- **Estimated Delivery:** Q4 2026 (October–December)
+- **Estimated Delivery:** Q4 2026 (OctoberâDecember)
 - **Focus:** DA Tokenization Utility integration, aBTC subscription interfaces, BTC settlement pairs, ecosystem launch
 - **Deliverables / Value Metrics:**
-  - aBTC Subscription Interface — CIP-56 Daml contract enabling atomic DvP subscriptions into DA Tokenization Utility-issued assets.
-  - Vault Share Composability — Share tokens registered as eligible collateral within DA’s credential layer.
-  - BTC Settlement Pairs — aBTC/tokenized-treasury and aBTC/money-market-fund DvP settlement pairs live on Canton mainnet.
-  - Integration documentation and templates — Open source guides, Daml templates, and TypeScript examples.
-  - Live demonstration — At least one end-to-end aBTC subscription into a Canton-issued asset on mainnet.
-  - Full documentation suite — Complete user guides, API reference, and integration guides for all five components.
+  - aBTC Subscription Interface â CIP-56 Daml contract enabling atomic DvP subscriptions into DA Tokenization Utility-issued assets.
+  - Vault Share Composability â Share tokens registered as eligible collateral within DAâs credential layer.
+  - BTC Settlement Pairs â aBTC/tokenized-treasury and aBTC/money-market-fund DvP settlement pairs live on Canton mainnet.
+  - Integration documentation and templates â Open source guides, Daml templates, and TypeScript examples.
+  - Live demonstration â At least one end-to-end aBTC subscription into a Canton-issued asset on mainnet.
+  - Full documentation suite â Complete user guides, API reference, and integration guides for all five components.
 
 ## Acceptance Criteria
 
@@ -142,19 +142,19 @@ The Tech & Ops Committee will evaluate completion based on:
 - Demonstrated functionality or operational readiness
 - Documentation and knowledge transfer provided
 - Alignment with stated value metrics
-- Security audit results (Milestone 2) — 0 critical, 0 unresolved high findings
-- Mainnet operational status (Milestones 2–3) — bridge operational, aBTC mintable, vaults live
-- Adoption evidence (Milestone 3) — minimum TVL thresholds met, at least one institutional participant engaged
+- Security audit results (Milestone 2) â 0 critical, 0 unresolved high findings
+- Mainnet operational status (Milestones 2â3) â bridge operational, aBTC mintable, vaults live
+- Adoption evidence (Milestone 3) â minimum TVL thresholds met, at least one institutional participant engaged
 
 ## Funding
 
-**Total Funding Request:** [XX CC]
+**Total Funding Request:** $250,000 USD (payable in CC at prevailing rate)
 
 ### Payment Breakdown by Milestone
 
-- **Milestone 1 (Bridge Architecture + aBTC Token):** XX CC upon committee acceptance
-- **Milestone 2 (Vault Standard + Bridge Production):** XX CC upon committee acceptance
-- **Milestone 3 (BTC Capital Markets Integration + Ecosystem Launch):** XX CC upon committee acceptance
+- **Milestone 1 (Bridge Architecture + aBTC Token):** $100,000 upon committee acceptance
+- **Milestone 2 (Vault Standard + Bridge Production):** $87,500 upon committee acceptance
+- **Milestone 3 (BTC Capital Markets Integration + Ecosystem Launch):** $62,500 upon committee acceptance
 
 ### Volatility Stipulation
 
@@ -165,45 +165,47 @@ Should the project timeline extend beyond 6 months due to Committee-requested sc
 Upon release, Arch Network will collaborate with the Foundation on:
 
 - Announcement coordination
-- Case study or technical blog
+- Joint case study or technical blog highlighting the Arch-Canton integration
 - Developer or ecosystem promotion
+
+**Economic Design Audit & Bitcoin Credit Markets Study:** Arch is currently underway on a comprehensive economic design audit and case study of Bitcoin credit markets that supports the thesis behind this proposal. The study demonstrates that Arch's architecture is structurally more efficient for scaling Bitcoin lending than existing alternatives. We would welcome the opportunity to include Canton in this study — examining how Canton's institutional settlement layer combined with Arch's execution infrastructure creates a uniquely efficient credit market design for institutional BTC participants. This joint research could serve as a powerful co-marketing asset for both ecosystems.
 
 ## Motivation
 
-Canton hosts over $9 trillion in tokenized assets and processes approximately $350 billion in daily volume. Institutional participants — including Goldman Sachs (DAP), Broadridge (DLR), and Versana — use Canton for compliant, privacy-preserving financial operations.
+Canton hosts over $9 trillion in tokenized assets and processes approximately $350 billion in daily volume. Institutional participants â including Goldman Sachs (DAP), Broadridge (DLR), and Versana â use Canton for compliant, privacy-preserving financial operations.
 
-However, Canton’s connection to Bitcoin — a $2T+ asset class and the most widely held digital asset among institutions — remains underdeveloped. While CBTC provides custodial wrapped BTC on Canton, there is no programmable bridge to Bitcoin-native infrastructure with execution capabilities, no standardized vault primitive for composable yield strategies, and no mechanism for BTC capital to subscribe to Canton-issued securities.
+However, Cantonâs connection to Bitcoin â a $2T+ asset class and the most widely held digital asset among institutions â remains underdeveloped. While CBTC provides custodial wrapped BTC on Canton, there is no programmable bridge to Bitcoin-native infrastructure with execution capabilities, no standardized vault primitive for composable yield strategies, and no mechanism for BTC capital to subscribe to Canton-issued securities.
 
-These gaps limit Canton’s ability to attract Bitcoin-denominated capital, restrict yield strategies available to institutional participants, and raise the barrier to entry for new issuers.
+These gaps limit Cantonâs ability to attract Bitcoin-denominated capital, restrict yield strategies available to institutional participants, and raise the barrier to entry for new issuers.
 
-This proposal directly addresses these gaps by delivering open infrastructure that connects Bitcoin’s $2T+ asset class to Canton’s institutional ecosystem — creating new utility, new capital flows, and new reasons for institutional participants to build on Canton.
+This proposal directly addresses these gaps by delivering open infrastructure that connects Bitcoinâs $2T+ asset class to Cantonâs institutional ecosystem â creating new utility, new capital flows, and new reasons for institutional participants to build on Canton.
 
 **Public Good / Ecosystem Value Justification:**
 
-Two of the five components are genuine public goods — open, permissionless infrastructure available to any Canton participant:
+Two of the five components are genuine public goods â open, permissionless infrastructure available to any Canton participant:
 
-- **Arch–Canton Bridge:** Free, open source bridging infrastructure. Arch does not charge fees for bridging, minting, or burning aBTC.
+- **ArchâCanton Bridge:** Free, open source bridging infrastructure. Arch does not charge fees for bridging, minting, or burning aBTC.
 - **Compliant Tokenization Service:** Open issuance infrastructure for compliant tokenized securities. Any Canton issuer can use it.
 
 The remaining three generate ecosystem value with built-in maintenance incentives:
 
 - **BTC Financial Services Access (DEX + Lending):** Makes Bitcoin productive on Canton.
 - **Canton Vault Standard:** Open CIP for community adoption.
-- **BTC Capital Markets Integration:** Connects Canton’s $9T+ asset base to BTC capital.
+- **BTC Capital Markets Integration:** Connects Cantonâs $9T+ asset base to BTC capital.
 
 ## Rationale
 
 **Why Arch Network is the right team:**
 
-Arch Network is an $18M-funded Bitcoin infrastructure company with a 20-person team building for over 2.5 years. Delivered: production-grade blockchain with BFT consensus, 300ms blocks, ~1,000 TPS; Bitcoin-native DEX (Arch Swap); credit and lending protocol (Arch Lend); institutional portfolio dashboard (Arch Prime).
+Arch Network is an $18M-funded Bitcoin infrastructure company with a 20-person team building for over 2.5 years. Our funding rounds were led by Multicoin Capital and Pantera Capital — two of the most respected institutional crypto investors — reflecting deep conviction in Arch's technical approach and market positioning. Delivered: production-grade blockchain with BFT consensus, 300ms blocks, ~1,000 TPS; Bitcoin-native DEX (Arch Swap); credit and lending protocol (Arch Lend); institutional portfolio dashboard (Arch Prime).
 
 **Why this approach:**
 
-The vertically integrated approach is deliberate. Each component’s value is amplified by the others — bridge enables aBTC, aBTC enables lending, lending enables vaults, vaults enable structured products, capital markets integration connects all of it to Canton’s existing asset base. Self-reinforcing adoption flywheel.
+The vertically integrated approach is deliberate. Each componentâs value is amplified by the others â bridge enables aBTC, aBTC enables lending, lending enables vaults, vaults enable structured products, capital markets integration connects all of it to Cantonâs existing asset base. Self-reinforcing adoption flywheel.
 
 **Why not CBTC alone:**
 
-CBTC serves BTC custody and holding. It does not support programmable lending, vault strategies, or capital markets integration. CBTC requires 6 Bitcoin confirmations (~60 minutes) for issuance/redemption, creating a collateral enforcement bottleneck. Arch’s 300ms execution eliminates this. CBTC and aBTC are complementary — CBTC for custody, aBTC for capital markets.
+CBTC serves BTC custody and holding. It does not support programmable lending, vault strategies, or capital markets integration. CBTC requires 6 Bitcoin confirmations (~60 minutes) for issuance/redemption, creating a collateral enforcement bottleneck. Archâs 300ms execution eliminates this. CBTC and aBTC are complementary â CBTC for custody, aBTC for capital markets.
 
 **Daml development partnership:**
 
@@ -213,6 +215,7 @@ Arch aims to engage IntellectEU or Obsidian Systems as specialist Daml developme
 
 - Institutional custodian integrations: Anchorage, Ceffu, Utila
 - HoneyB: Active asset management partnership for BTC private credit yield strategies
-- Institutional liquidity providers: Galaxy, Pantera — committed to seeding initial vault liquidity
-- DAT partners: Digital Asset Trusts going live with $10–20M BTC yield pilots
+- Institutional liquidity providers: Galaxy, Pantera â committed to seeding initial vault liquidity
+- DAT partners: Digital Asset Trusts going live with $10â20M BTC yield pilots
+
 

--- a/proposals/arch-bitcoin-capital-markets-stack.md
+++ b/proposals/arch-bitcoin-capital-markets-stack.md
@@ -1,237 +1,168 @@
 # Development Fund Proposal
 
-## Arch-Canton Bridge and BTC Developer SDK
+## Arch–Canton Bridge: Leverage and Yield Infrastructure for CBTC
 
 Author: Arch Network (Matt Mudano)
 
 Daml Development Partner: IntellectEU
 
+Decentralized Party Management: BitSafe DecParty manager (open source)
+
 Status: Draft
 
 Created: 2026-04-01
 
-Label: dapp-integration
+Last revised: 2026-05-27
 
-Champion: Canton Foundation
-
-Total Funding Request: $125,000 USD (payable in CC equivalent)
+Total Funding Request: $150,000 USD (payable in CC equivalent)
 
 ## Abstract
 
-This proposal requests $125,000 to build two public good infrastructure components that connect Bitcoin's $2T+ asset class to Canton Network:
+This proposal requests $150,000 to build an open-source bridge that connects CBTC — BitSafe's institutional wrapped Bitcoin on Canton — to the Arch Bitcoin capital markets stack.
 
-- **Arch-Canton Bridge** - a bidirectional, fee-free, open source bridge that mints CIP-56-compliant aBTC on Canton, enabling BTC holders to access Canton's institutional ecosystem and Canton participants to access Bitcoin liquidity.
+The bridge lets CBTC route through the same capital markets flow Arch already operates for institutional BTC: a platform of structured carry trades where Bitcoin is levered at the sharpest available rates and deployed into traditional finance vehicles managed by institutional asset managers. Today CBTC is high-quality collateral with no native path to leverage or managed yield. This bridge adds that utility.
 
-- **BTC Developer SDK** - a Daml integration layer with typed bindings, allowing any Canton developer to access Arch's BTC-native protocols (lending, yield, prime brokerage) directly from Daml contracts without building on the Bitcoin side themselves.
+The funded deliverable is the bridge itself — open-source, public-good infrastructure built on Canton in Daml by IntellectEU, with the decentralized party that controls the bridge managed via BitSafe's open-source DecParty manager. The structured-products platform the bridge unlocks, and the Canton-deployed application through which Canton participants access it, are built and maintained by Arch Network at its own cost. The grant funds the public good; Arch funds and operates the commercial layer on top of it.
 
-Both components are open, permissionless infrastructure available to any Canton participant at no cost. The $125K budget covers Canton-side Daml contract development, bridge relayer integration, SDK development, testing, security audit, and documentation. All work will be executed by IntellectEU, a specialist Daml development firm with Canton production experience. Grant funding is used exclusively for these two public goods components. Arch Network separately operates commercial products (Arch Swap, Arch Lend, Arch Prime) at its own cost; the SDK provides open access to these protocols but no grant funds are used to build, operate, or market them.
-
-The underlying Arch-side infrastructure (consensus, execution, settlement) is already built and deployed. This proposal funds only the Canton integration layer.
+The underlying Arch capital markets infrastructure (consensus, execution, settlement, credit, and the carry-trade platform) is already built and deployed. This proposal funds only the Canton-side bridge and integration layer.
 
 ## Specification
 
 ### 1. Objective
 
-Connect Bitcoin's $2T+ asset class to Canton's $9T+ institutional ecosystem through two foundational infrastructure primitives, positioning Arch as a BTC infrastructure gateway for Canton. Specifically:
+Add leverage and yield optionality to CBTC by connecting it to the Arch Bitcoin capital markets stack. Specifically:
 
-- **Bridge a gap in programmable BTC access.** Canton has CBTC for custodial BTC holding, but no programmable bridge with execution capabilities. The Arch-Canton Bridge provides bidirectional BTC movement with 300ms execution, enabling BTC capital to flow into Canton's DvP settlement, lending, and yield infrastructure, and Canton participants to access Bitcoin-native liquidity.
+- Route CBTC into productive capital markets flow. CBTC is a 1:1 Bitcoin-backed, CIP-56 asset built for institutional trading, lending, and settlement. It is excellent collateral, but Canton has no native mechanism to lever it and deploy the proceeds into managed yield. The Arch–Canton Bridge provides that mechanism, letting CBTC flow through Arch's existing structured carry-trade platform and return a net yield position to its holder.
+- Give Canton participants institutional yield optionality on Bitcoin. Through the bridge, a CBTC holder can take a leveraged position against their Bitcoin and deploy it into traditional finance vehicles — on-chain or off-chain — managed by institutional asset managers, while holding a single, transparent structured position with a defined loan-to-value, a net yield, and accrued-income tracking.
 
-- **Give Canton developers access to BTC-native protocols.** Canton developers who need BTC-collateralized lending, BTC yield strategies, or Bitcoin prime brokerage in their applications currently have no way to access Bitcoin-native infrastructure from Daml. The BTC Developer SDK provides typed Daml bindings to Arch's protocols, so any Canton participant can integrate BTC primitives without building on the Bitcoin side themselves.
+### 2. Component: Arch–Canton Bridge (the funded public good)
 
-### 2. Implementation Mechanics: Arch-Canton Bridge
+The funded deliverable is a bidirectional bridge contract connecting CBTC on Canton to the Arch capital markets stack. IntellectEU leads the Canton-side Daml build. BitSafe's open-source DecParty manager controls the decentralized party that governs the bridge's authority on Canton, so no single operator controls bridge custody or attestation.
 
-The bridge uses a relayer-based architecture with FROST threshold signatures for security.
+Bridge characteristics:
 
-**Bridge mechanics:**
+- Bidirectional. CBTC can be committed to the bridge to enter the Arch capital markets flow, and positions, yield, and principal settle back to the holder's CBTC on Canton.
+- Decentralized authority. The bridge's controlling party is a decentralized threshold of parties managed by BitSafe's DecParty manager — the same coordination model that secures CBTC itself — rather than a single custodian.
+- CIP-56 native. The bridge operates on CBTC as a first-class CIP-56 asset, fully compatible with Canton's Offer-Accept transfer model, sub-transaction privacy, and regulatory observer framework.
+- Open source. The bridge contracts and integration interfaces are published openly. Arch charges no fee for bridging itself, and the design is a reusable reference for connecting Canton assets to external capital markets infrastructure.
 
-- **Arch to Canton:** User locks BTC on Arch. Validators produce a signed attestation. Relayer transmits to Canton. Canton bridge contract verifies and mints CIP-56 aBTC via Offer-Accept protocol.
+This proposal deliberately keeps the bridge mechanism at the architectural level. The detailed lock, attestation, and settlement model is finalized during the design milestone (M1) with IntellectEU and BitSafe, reviewed publicly, and audited before mainnet.
 
-- **Canton to Arch:** User transfers aBTC to bridge contract. Bridge burns aBTC and emits withdrawal attestation. Relayer transmits to Arch. Validators construct and sign Bitcoin unlock transaction. User receives native BTC.
+### 3. What the bridge enables: the Arch structured carry-trade platform
 
-- **Security:** (⌈2N/3⌉ + 1)-of-N FROST threshold signatures, per-epoch volume caps, emergency pause, reorg handling via DAG-based transaction tracking and UTXO anchoring.
+Once CBTC can flow to Arch, it accesses the platform Arch already runs for institutional Bitcoin. This platform is built, operated, and maintained by Arch Network at its own cost — it is the commercial layer the bridge unlocks, not a funded deliverable.
 
-- **Relayer model:** Permissionless. Any party can relay valid attestations. Minimum 3 independent operators recommended.
+The mechanism is the credit carry trade. Arch levers the Bitcoin at the sharpest available rates and deploys the proceeds into yield-generating traditional finance vehicles. The assets can be on-chain or off-chain, managed by institutional asset managers such as Fidelity, Wellington, KKR, and Hamilton Lane, as well as negotiated allocations into private credit funds, real estate funds, and reinsurance funds.
 
-**aBTC token (CIP-56):**
+The participant controls the exposure. A liquidity provider can select a single product or build a basket across multiple products and manage the whole allocation as one structured trade — with a defined loan-to-value, a net yield position, and continuous tracking of the income accrued from the deployment. The position is held and managed as a single instrument rather than a set of disconnected legs.
 
-- CIP-56 compliant, 8 decimals (matching BTC), mint authority restricted to bridge contract only.
+### 4. The Canton application
 
-- Configurable transfer restrictions (KYC, jurisdictional, accredited investor checks), regulatory observer support.
+Canton participants access the platform through an application deployed on Canton, built by Arch on top of the IntellectEU bridge. The application is where a CBTC holder commits collateral, selects a product or constructs a basket, sets and monitors loan-to-value, and tracks net yield and accrued income on the position. Like the carry-trade platform, the application is built and maintained by Arch at its own cost.
 
-- Dual-oracle design (RedStone primary, Chainlink secondary), 5-minute staleness threshold, 2% divergence handling, 10-minute TWAP, circuit breaker.
+### 5. Architectural alignment
 
-**Public good characteristics:**
+The bridge aligns with Canton's architecture and with BitSafe's CBTC design:
 
-- Free and open source. Arch does not charge fees for bridging, minting, or burning aBTC.
+- CBTC native. The bridge treats CBTC as the underlying asset and operates entirely through standard CIP-56 mechanics. It introduces no competing Bitcoin representation on Canton.
+- Decentralized party model. By using BitSafe's DecParty manager, the bridge inherits the same FROST-based, decentralized-threshold authority model that secures CBTC, rather than introducing a new trust assumption.
+- DvP settlement. Bridge commitments and returning positions settle atomically via the Global Synchronizer.
+- Daml-native. The bridge and its integration interfaces are implemented in Daml, leveraging Canton's smart-contract model and privacy guarantees.
+- Credential and Registry Utility compatible. Bridge participation respects CBTC's existing KYC/AML and compliance gating, and integrates with DA's Credential and Registry Utilities without custom rework.
 
-- Reusable reference architecture. Other networks can adapt the bridge design to build their own Canton bridges.
+### 6. Backward compatibility
 
-- Bidirectional value flow. BTC holders gain access to Canton's tokenized asset ecosystem; Canton participants gain access to Bitcoin liquidity.
+No backward compatibility impact. The component is additive:
 
-### 3. Implementation Mechanics: BTC Developer SDK
+- It uses the existing CBTC token. It does not modify or replace CBTC, its issuance, or its custody model.
+- It introduces new bridge and integration contracts that interact with CBTC through standard CIP-56 mechanics.
+- It changes no existing Daml contracts or standards on Canton.
 
-A Daml integration layer that gives Canton developers typed access to Arch's BTC-native protocols through the bridge. The SDK turns Arch into a BTC primitives provider for the Canton ecosystem: any participant who needs BTC-collateralized lending, BTC yield, or Bitcoin prime brokerage can call Arch's protocols from Daml contracts via standardized APIs.
+## Ecosystem Benefits
 
-**SDK components:**
+Once the bridge is live, it enables a broader set of use cases for the Canton ecosystem. These are downstream value of the public-good bridge, not funded deliverables:
 
-- Daml bindings for Arch Lend (BTC-collateralized lending), Arch Prime (institutional portfolio and prime brokerage), and bridge operations (mint/burn aBTC).
-
-- Typed API wrappers: loan terms, collateral ratios, yield positions, bridge status, aBTC balances.
-
-- Composability: SDK calls can be embedded in existing Canton workflows, enabling BTC operations within DvP settlement, collateral management, and other Daml-native applications.
-
-**Reference integration:**
-
-- A reference Canton application demonstrating a BTC-collateralized loan and yield position executed entirely from Daml via the SDK.
-
-- The SDK is protocol-agnostic on the Canton side. Any Daml application can call Arch's BTC primitives through the typed bindings.
-
-**Public good characteristics:**
-
-- Open source SDK published on GitHub with permissive license. Any Canton developer can use it.
-
-- Removes the need for Canton developers to understand Bitcoin infrastructure. BTC primitives become callable from Daml like any other Canton service.
-
-- Positions Canton as a distribution layer for Bitcoin-native financial services, expanding the use cases available to Canton participants.
-
-### 4. Architectural Alignment
-
-Both components align with Canton's architecture and ecosystem priorities:
-
-- **CIP-56 compliance:** aBTC is a native CIP-56 token, fully compatible with Canton's Offer-Accept transfer model, sub-transaction privacy, and regulatory observer framework.
-
-- **DvP settlement:** aBTC settles atomically via the Global Synchronizer. SDK-initiated operations (loans, yield positions) settle on Arch with results reflected on Canton through the bridge.
-
-- **Daml-native:** Bridge contracts and SDK bindings are implemented in Daml, leveraging Canton's smart contract model and privacy guarantees.
-
-- **Credential Utility compatible:** aBTC holder requirements and SDK access controls integrate with DA's existing Credential Utility for KYC/AML enforcement.
-
-- **Registry Utility compatible:** Once minted, aBTC participates in DA's Registry Utility workflows (transfer, allocation, settlement) with no custom integration required.
-
-### 5. Backward Compatibility
-
-No backward compatibility impact. Both components are additive:
-
-- aBTC is a new CIP-56 token. Does not modify existing token contracts or standards.
-
-- The BTC Developer SDK is a new integration layer. Does not change existing Daml contracts.
-
-- The bridge introduces new contracts (BridgeController, DepositAttestation, MintAuthority, WithdrawalRequest) and the SDK adds typed Daml bindings. Both interact with Canton via standard CIP-56 mechanics.
-
-## Ecosystem Benefits (Not Grant-Funded)
-
-The bridge and SDK enable downstream use cases available to builders and participants in the Canton ecosystem which can be accessed via APIs.
-
-- **BTC financial services.** BTC/stablecoin liquidity/swaps (Arch Swap) and BTC-collateralized lending (Arch Lend) accessible to Canton participants via the SDK.
-
-- **Institutional yield.** Existing partnerships (HoneyB, Pantera, DAT partners, Anchorage, Maple with $10–20M pilots) provide ready demand for BTC yield on Canton.
-
-- **BTC capital markets and collateral.** aBTC's CIP-56 compliance makes it eligible for listing in DA's Registry Utility and use in the Collateral Utility, enabling BTC-denominated securities subscriptions and collateral in margin agreements.
-
-## Committed Reference Implementation: HoneyB
-
-HoneyB, a BTC-native asset management firm, has committed to using the Arch-Canton bridge and BTC Developer SDK as the infrastructure layer for bringing Bitcoin yield products to Canton. This is not a hypothetical use case — HoneyB is an active Arch ecosystem partner already building BTC private credit strategies on Arch's lending infrastructure. HoneyB has also established a partnership with a fixed income ETF provider with a 15-year track record and $15 billion in AUM, led by an ex-PIMCO fixed income team, to bring traditional fixed income yield strategies to Bitcoin holders. Their commitment to Canton integration provides an immediate, real-world reference implementation from day one.
-
-**What this means for Canton:** Once the bridge and SDK ship, HoneyB will use them to offer BTC yield strategies — including private credit, structured lending products, and traditional fixed income strategies sourced through their institutional ETF partnership — directly to Canton participants via aBTC. This brings a unique convergence to Canton: institutional-grade tradfi yield expertise (backed by a team with a 15-year track record managing $15B in fixed income) paired with Bitcoin-native infrastructure. Canton's institutional ecosystem gains not just a new asset class (BTC yield), but a bridge between traditional fixed income and digital assets, without any Canton participant needing to interact with Bitcoin infrastructure directly. HoneyB's integration adds a live, revenue-generating application to the Canton ecosystem that would not exist without the grant-funded public goods.
-
-**Why this matters for the proposal:** A committed reference implementation de-risks the grant. The bridge and SDK are not speculative infrastructure waiting for adoption — they have a confirmed first user with an active business ready to deploy on Canton as soon as the integration is live. This accelerates time-to-value for the Canton ecosystem and demonstrates that the public goods funded by this grant will generate immediate, tangible ecosystem activity.
-
-HoneyB's integration is commercially operated and funded entirely by Arch and HoneyB — no grant funds are used. It is listed here because it validates the infrastructure this proposal builds and provides the Canton Foundation with confidence that the grant-funded components will see real usage upon delivery.
+- Leverage and managed yield for CBTC. CBTC holders gain a native path to lever their Bitcoin and deploy it into institutional, professionally managed yield — without leaving Canton's compliance framework.
+- Bitcoin-denominated structured products. Canton participants can build and hold structured carry positions denominated in Bitcoin, with transparent loan-to-value and net-yield accounting.
+- Access to traditional finance vehicles. Through the bridge and the platform it unlocks, Canton's Bitcoin liquidity can reach on-chain and off-chain TradFi products managed by major asset managers and specialist funds.
+- Deeper utility for an existing Canton asset. The bridge increases the productive utility of CBTC specifically, strengthening an asset already adopted by institutional desks on Canton rather than fragmenting Bitcoin liquidity across a new wrapper.
 
 ## Milestones and Deliverables
 
-All milestones cover Canton-side Daml integration work only. The underlying Arch primitives (consensus, execution, settlement) are already built and deployed. IntellectEU will lead Daml contract development across all milestones.
+All milestones cover Canton-side bridge and integration work only. The underlying Arch capital markets stack and the structured carry-trade platform are already built, operated, and funded by Arch Network independently. IntellectEU leads Daml contract development across all milestones; BitSafe's open-source DecParty manager is integrated for decentralized party control.
 
-### Milestone 1A: Bridge Testnet Delivery
-
-| | |
-|---|---|
-| **Delivery** | Q2 2026 (April–May) |
-| **Funding** | $50,000 |
-| **Focus** | Bridge design, Daml contract development, aBTC token deployment on testnet, relayer prototype |
-
-Deliverables:
-
-- **Bridge design specification.** Published technical document covering architecture, security model, message format, and failure modes. Reviewed by at least one independent Daml ecosystem developer.
-
-- **Daml bridge contracts.** BridgeController, DepositAttestation, MintAuthority, WithdrawalRequest implemented with >90% unit test coverage. Source code published on GitHub. Reviewed by IntellectEU.
-
-- **Arch-side lock/burn contracts.** UTXO-based contracts deployed on Arch testnet with passing integration tests.
-
-- **aBTC CIP-56 token.** Compliant token contract with compliance hooks, transfer restrictions, and DvP support. Deployed on Canton testnet. Passes Canton token standard conformance tests.
-
-- **Relayer prototype.** Functional relayer transmitting attestations between Arch testnet and Canton testnet. At least 100 successful cross-chain transfers demonstrated.
-
-- **Integration tests.** End-to-end tests (Arch deposit to Canton mint, Canton burn to Arch unlock). Minimum 50 test cases covering normal and failure paths. Test suite published.
-
-- **Documentation.** Developer guide for bridge integration. aBTC token specification. Published on GitHub with README and quickstart.
-
-### Milestone 1B: Bridge Mainnet Readiness
-
-| | |
-|---|---|
-| **Delivery** | Q2–Q3 2026 (June–July) |
-| **Funding** | $50,000 |
-| **Focus** | Bridge security audit, mainnet deployment, aBTC mainnet launch |
-
-Deliverables:
-
-- **Bridge security audit.** Third-party audit by a recognized firm (Certora, Trail of Bits, or equivalent). 0 critical findings, 0 unresolved high findings. Audit report published publicly.
-
-- **Bridge mainnet deployment.** Contracts deployed on Arch mainnet and Canton mainnet. Relayer operational with uptime monitoring and alerting. At least 10 mainnet bridge transfers processed.
-
-- **aBTC mainnet launch.** aBTC live on Canton mainnet, mintable via bridge. At least one institutional participant has minted aBTC.
-
-- **Documentation.** Bridge operational runbook, aBTC integration guide. Published on GitHub.
-
-### Milestone 2: BTC Developer SDK
+### Milestone 1: Bridge Design and Testnet Delivery
 
 | | |
 |---|---|
 | **Delivery** | Q3 2026 (July–August) |
-| **Funding** | $25,000 |
-| **Focus** | SDK development, Daml bindings for Arch protocols, reference integration, documentation |
+| **Funding** | $50,000 |
+| **Focus** | Bridge design specification, Daml contract development, DecParty manager integration, CBTC bridging on testnet |
 
 Deliverables:
 
-- **BTC Developer SDK.** Typed Daml bindings for Arch Lend, Arch Prime, and bridge operations. Published on GitHub with permissive open source license. Reviewed by IntellectEU.
+- Bridge design specification. Published technical document covering architecture, the CBTC commit/settle model, the DecParty-managed authority model, message format, and failure modes. Reviewed by at least one independent Daml ecosystem developer.
+- Daml bridge contracts. Bridge controller, commitment, attestation, and settlement contracts implemented with >90% unit test coverage. Source code published on GitHub. Reviewed by IntellectEU.
+- DecParty manager integration. BitSafe's open-source DecParty manager integrated to control the bridge's decentralized party on Canton testnet, with documented configuration and operator set.
+- CBTC bridging on testnet. CBTC committed to the bridge and routed to the Arch capital markets stack on testnet, with positions settling back to CBTC. At least 100 successful round-trip transfers demonstrated.
+- Integration tests. End-to-end tests (CBTC commit to Arch position, Arch settlement back to CBTC). Minimum 50 test cases covering normal and failure paths. Test suite published.
+- Documentation. Developer guide for bridge integration. Published on GitHub with README and quickstart.
 
-- **Reference integration.** Reference Canton application demonstrating a BTC-collateralized loan and yield position via SDK. Functional on Canton testnet with >90% unit test coverage. Reviewed by IntellectEU.
+### Milestone 2: Security Audit and Mainnet Readiness
 
-- **End-to-end integration test.** Canton application executes a BTC-collateralized loan and uses proceeds in a DvP settlement with another CIP-56 asset on Canton testnet. Documented with transaction logs.
+| | |
+|---|---|
+| **Delivery** | Q3–Q4 2026 (September–October) |
+| **Funding** | $50,000 |
+| **Focus** | Bridge security audit, mainnet deployment, operational readiness |
 
-- **Documentation.** SDK developer guide with API reference and integration examples. Published on GitHub.
+Deliverables:
+
+- Bridge security audit. Third-party audit by a recognized firm (Certora, Trail of Bits, or equivalent). 0 critical findings, 0 unresolved high findings. Audit report published publicly.
+- Bridge mainnet deployment. Bridge contracts deployed on Canton mainnet with the DecParty-managed authority live. Relayer/attestation operational with uptime monitoring and alerting. At least 10 mainnet round-trip transfers processed.
+- Operational readiness. CBTC bridgeable on mainnet via the bridge, with at least one institutional participant completing a round trip.
+- Documentation. Bridge operational runbook and integration guide. Published on GitHub.
+
+### Milestone 3: Capital Markets Integration Layer
+
+| | |
+|---|---|
+| **Delivery** | Q4 2026 (November–December) |
+| **Funding** | $50,000 |
+| **Focus** | Canton-side integration interfaces connecting bridged CBTC to the structured carry-trade flow |
+
+Deliverables:
+
+- Integration interface specification. Published Daml interfaces enabling bridged CBTC positions to express a loan-to-value, a net yield position, and accrued-income tracking that settle back to CBTC on Canton. Reviewed by IntellectEU.
+- Reference integration. A working reference path on Canton testnet demonstrating a CBTC holder taking a single structured position (defined LTV, net yield, accrued income) through the bridge, with results documented and transaction logs published.
+- Composability demonstration. Bridged-position settlement demonstrated in an atomic DvP flow with CBTC on Canton testnet. Documented with transaction logs.
+- Documentation. Integration developer guide for parties building on the bridge. Published on GitHub.
 
 ## Acceptance Criteria
 
 The Tech & Ops Committee will evaluate completion based on:
 
 - Deliverables completed as specified for each milestone.
-
 - Demonstrated functionality or operational readiness.
-
 - Documentation and knowledge transfer provided.
-
-- Security audit results (Milestone 1B): 0 critical, 0 unresolved high findings.
-
-- Mainnet operational status (Milestone 1B): bridge operational, aBTC mintable.
-
-- SDK delivery (Milestone 2): BTC Developer SDK published on GitHub with documentation and reference integration.
+- Security audit results (Milestone 2): 0 critical, 0 unresolved high findings.
+- Mainnet operational status (Milestone 2): bridge operational, CBTC bridgeable.
+- Integration readiness (Milestone 3): reference path demonstrating a single CBTC structured position with LTV, net yield, and accrued-income tracking, settling back to CBTC.
 
 ## Funding
 
-**Total Funding Request:** $125,000 USD (payable in CC equivalent)
+Total Funding Request: $150,000 USD (payable in CC equivalent)
 
-This budget covers Canton-side Daml contract development by IntellectEU, bridge relayer integration, SDK development, security audit, testing, and documentation. All underlying Arch primitives are already built and funded by Arch Network independently. No grant funds are used to build, operate, or market Arch's commercial products (Arch Swap, Arch Lend, Arch Prime), which Arch develops and maintains at its own cost.
+This budget covers Canton-side bridge and integration development by IntellectEU, BitSafe DecParty manager integration, security audit, testing, and documentation. The underlying Arch capital markets stack and the structured carry-trade platform are already built, operated, and funded by Arch Network independently. The Canton application Arch builds on top of the bridge is also funded by Arch.
 
 ### Payment Breakdown
 
 | Milestone | Amount | Timeline |
 |---|---|---|
-| M1A: Bridge Testnet Delivery | $50,000 | Q2 2026 |
-| M1B: Bridge Mainnet Readiness | $50,000 | Q2–Q3 2026 |
-| M2: BTC Developer SDK | $25,000 | Q3 2026 |
-| **Total** | **$125,000** | |
+| M1: Bridge Design and Testnet Delivery | $50,000 | Q3 2026 |
+| M2: Security Audit and Mainnet Readiness | $50,000 | Q3–Q4 2026 |
+| M3: Capital Markets Integration Layer | $50,000 | Q4 2026 |
+| **Total** | **$150,000** | |
 
 ### Volatility Stipulation
 
@@ -239,54 +170,48 @@ Should the project timeline extend beyond 6 months due to Committee-requested sc
 
 ## Co-Marketing
 
-Upon release, Arch Network will collaborate with the Foundation on:
+Upon release, Arch Network will collaborate with the Foundation and BitSafe on:
 
 - Announcement coordination
-
 - Case study or technical blog
-
 - Developer or ecosystem promotion
 
 ## Motivation
 
 Canton hosts over $9 trillion in tokenized assets and processes approximately $350 billion in daily volume. Institutional participants, including Goldman Sachs (DAP), Broadridge (DLR), and Versana, use Canton for compliant, privacy-preserving financial operations.
 
-Canton's connection to Bitcoin, a $2T+ asset class and the most widely held digital asset among institutions, remains underdeveloped. While CBTC provides custodial wrapped BTC on Canton, there is no programmable bridge to Bitcoin-native infrastructure with execution capabilities, and no way for Canton developers to access BTC-native protocols (lending, yield, prime brokerage) from Daml.
+BitSafe's CBTC brought institutional wrapped Bitcoin to Canton: a 1:1 Bitcoin-backed, CIP-56 asset, secured by a FROST-based decentralized custody network, built for institutional trading, lending, and settlement. CBTC has established Bitcoin as first-class collateral on Canton.
 
-These gaps mean Canton participants who hold BTC, or whose clients hold BTC, cannot put that capital to work within Canton's compliance framework. Arch Network's existing BTC infrastructure (DEX, lending, prime brokerage) already serves this market on the Bitcoin side; this proposal funds the Canton integration that makes those capabilities accessible to Canton participants.
+What CBTC does not yet have is a native path to leverage and managed yield. A CBTC holder can hold and settle Bitcoin on Canton, and post it as margin, but cannot lever it and deploy the proceeds into professionally managed traditional finance vehicles from within Canton. That capital sits as collateral rather than working.
 
-This proposal addresses these gaps with two open infrastructure components:
+This proposal closes that gap with one open infrastructure component:
 
-- **The Arch-Canton Bridge** is free, open source bridging infrastructure. Arch does not charge fees for bridging, minting, or burning aBTC. The bridge is a reusable reference architecture that other networks can adapt to build their own Canton bridges.
+- The Arch–Canton Bridge is free, open-source bridging infrastructure connecting CBTC to the Arch capital markets stack. Arch charges no fee for bridging. The bridge uses BitSafe's open-source DecParty manager for decentralized authority and is a reusable reference for connecting Canton assets to external capital markets infrastructure.
 
-- **The BTC Developer SDK** is an open source integration layer. Any Canton developer can access Arch's BTC protocols (lending, yield, prime brokerage) from Daml contracts through typed bindings, without building on the Bitcoin side themselves.
-
-Once these public goods exist, they enable commercially viable use cases that Arch Network already operates at its own cost, with no grant funding: BTC/stablecoin trading (Arch Swap), BTC-collateralized lending (Arch Lend), and institutional yield strategies (HoneyB partnership, Galaxy and Pantera liquidity commitments, $10-20M DAT pilots). These are Arch's commercial products, not public goods. Arch's revenue from operating them creates a direct financial incentive to maintain the public goods layer long after the grant term ends.
+Once the bridge exists, it enables a commercially viable platform that Arch Network builds and maintains at its own cost: a structured carry-trade platform that levers Bitcoin at the sharpest rates and deploys it into managed yield, accessed through a Canton application. Arch's commercial revenue from operating this platform creates perpetual maintenance incentives for the bridge that persist long after the grant term ends.
 
 ## Rationale
 
-**Why Arch Network:**
+Why Arch Network:
 
-Arch Network is an $18M-funded Bitcoin infrastructure company with a 20-person team that has been building for over 2.5 years. The team has delivered a production-grade blockchain with BFT consensus, 300ms blocks, and approximately 1,000 TPS; a Bitcoin-native DEX (Arch Swap); a credit and lending protocol (Arch Lend); and an institutional portfolio dashboard (Arch Prime).
+Arch Network is an $18M-funded Bitcoin infrastructure company with a 20-person team that has been building for over 2.5 years. The team has delivered a production-grade blockchain with BFT consensus, 300ms blocks, and approximately 1,000 TPS; a Bitcoin-native DEX (Arch Swap); a credit and lending protocol (Arch Lend); an institutional portfolio dashboard (Arch Prime); and the structured carry-trade platform this bridge connects CBTC to.
 
-**Why not CBTC alone:**
+Why bridge to CBTC rather than mint a new Bitcoin representation:
 
-CBTC serves BTC custody and holding on Canton. It does not support programmable lending, vault strategies, or capital markets integration. CBTC requires 6 Bitcoin confirmations (approximately 60 minutes) for issuance or redemption, creating a collateral enforcement bottleneck that constrains safe loan-to-value ratios to 25-30%. Arch's 300ms execution eliminates this bottleneck, enabling higher LTVs and more capital-efficient credit markets. CBTC and aBTC are complementary: CBTC for custody, aBTC for capital markets.
+CBTC is already the institutional wrapped Bitcoin on Canton, with established custody, compliance, and institutional adoption. Bridging CBTC into Arch's capital markets flow adds utility to an asset Canton participants already hold and trust, rather than fragmenting Bitcoin liquidity across a competing wrapper. The bridge complements CBTC; it does not duplicate it.
 
-**Why a dedicated bridge rather than an existing EVM bridge:**
+Why Arch for the capital markets layer:
 
-Canton's privacy model and CIP-56 standard require native Daml integration. EVM bridges cannot provide sub-transaction privacy or Canton's Offer-Accept transfer model.
+CBTC's strength is custody, settlement, and margin on Canton. It does not provide leverage at sharp rates or managed deployment into traditional finance vehicles. Arch's 300ms execution and credit infrastructure enable capital-efficient leverage and deterministic collateral enforcement, and Arch's asset-manager relationships provide the deployment venues. CBTC and Arch are complementary: CBTC for institutional Bitcoin on Canton, Arch for putting it to work.
 
-**Daml development partner: IntellectEU**
+Build partners:
 
-Arch has selected IntellectEU as its specialist Daml development partner for Canton-side contract work across all milestones. IntellectEU is a recognized Daml ecosystem developer with Canton production experience.
+- IntellectEU leads the Canton-side Daml development across all milestones. IntellectEU is a recognized Daml ecosystem developer with Canton production experience.
+- BitSafe's open-source DecParty manager controls the bridge's decentralized party, aligning the bridge's trust model with the decentralized-threshold model that already secures CBTC.
 
-**Existing ecosystem partnerships:**
+Existing ecosystem partnerships:
 
-- **Institutional custodians:** Anchorage, Ceffu, Utila, providing custody and distribution for aBTC strategies on Canton.
-
-- **HoneyB:** Active asset management partnership for BTC private credit yield strategies, with an established partnership with a fixed income ETF provider ($15B AUM, 15-year track record, ex-PIMCO team) bringing tradfi yield to Bitcoin holders.
-
-- **Institutional liquidity providers:** Galaxy, Pantera, committed to seeding initial liquidity.
-
-- **DAT partners:** Digital Asset Trusts going live with $10-20M BTC yield pilots.
+- Institutional custodians: Anchorage, Ceffu, Utila, providing custody and distribution for Arch capital markets strategies.
+- HoneyB: Active asset management partnership for BTC private credit yield strategies.
+- Institutional liquidity providers: Galaxy, Pantera, committed to seeding initial liquidity.
+- DAT partners: Digital Asset Trusts going live with $10-20M BTC yield pilots.

--- a/proposals/arch-bitcoin-capital-markets-stack.md
+++ b/proposals/arch-bitcoin-capital-markets-stack.md
@@ -6,13 +6,13 @@ Author: Arch Network (Matt Mudano)
 
 Daml Development Partner: IntellectEU
 
-Decentralized Party Management: BitSafe DecParty manager (open source)
+Decentralized Party Management: Decentralization Manager (BitSafe, open source)
 
 Status: Draft
 
 Created: 2026-04-01
 
-Last revised: 2026-05-27
+Last revised: 2026-06-03
 
 Total Funding Request: $150,000 USD (payable in CC equivalent)
 
@@ -22,7 +22,7 @@ This proposal requests $150,000 to build an open-source bridge that connects CBT
 
 The bridge lets CBTC route through the same capital markets flow Arch already operates for institutional BTC: a platform of structured carry trades where Bitcoin is levered at the sharpest available rates and deployed into traditional finance vehicles managed by institutional asset managers. Today CBTC is high-quality collateral with no native path to leverage or managed yield. This bridge adds that utility.
 
-The funded deliverable is the bridge itself — open-source, public-good infrastructure built on Canton in Daml by IntellectEU, with the decentralized party that controls the bridge managed via BitSafe's open-source DecParty manager. The structured-products platform the bridge unlocks, and the Canton-deployed application through which Canton participants access it, are built and maintained by Arch Network at its own cost. The grant funds the public good; Arch funds and operates the commercial layer on top of it.
+The funded deliverable is the bridge itself — open-source, public-good infrastructure built on Canton in Daml by IntellectEU. The Decentralized Party that controls the bridge is governed by the Decentralization Manager, BitSafe's open-source application for managing Decentralized Parties on Canton. The structured-products platform the bridge unlocks, and the Canton-deployed application through which Canton participants access it, are built and maintained by Arch Network at its own cost. The grant funds the public good; Arch funds and operates the commercial layer on top of it.
 
 The underlying Arch capital markets infrastructure (consensus, execution, settlement, credit, and the carry-trade platform) is already built and deployed. This proposal funds only the Canton-side bridge and integration layer.
 
@@ -37,12 +37,12 @@ Add leverage and yield optionality to CBTC by connecting it to the Arch Bitcoin 
 
 ### 2. Component: Arch–Canton Bridge (the funded public good)
 
-The funded deliverable is a bidirectional bridge contract connecting CBTC on Canton to the Arch capital markets stack. IntellectEU leads the Canton-side Daml build. BitSafe's open-source DecParty manager controls the decentralized party that governs the bridge's authority on Canton, so no single operator controls bridge custody or attestation.
+The funded deliverable is a bidirectional bridge contract connecting CBTC on Canton to the Arch capital markets stack. IntellectEU leads the Canton-side Daml build. The Decentralization Manager controls the Decentralized Party that governs the bridge's authority on Canton, so no single operator controls bridge custody or attestation.
 
 Bridge characteristics:
 
 - Bidirectional. CBTC can be committed to the bridge to enter the Arch capital markets flow, and positions, yield, and principal settle back to the holder's CBTC on Canton.
-- Decentralized authority. The bridge's controlling party is a decentralized threshold of parties managed by BitSafe's DecParty manager — the same coordination model that secures CBTC itself — rather than a single custodian.
+- Decentralized authority. The bridge's controlling party is a Decentralized Party governed by the Decentralization Manager — the same coordination model that secures CBTC itself — rather than a single custodian.
 - CIP-56 native. The bridge operates on CBTC as a first-class CIP-56 asset, fully compatible with Canton's Offer-Accept transfer model, sub-transaction privacy, and regulatory observer framework.
 - Open source. The bridge contracts and integration interfaces are published openly. Arch charges no fee for bridging itself, and the design is a reusable reference for connecting Canton assets to external capital markets infrastructure.
 
@@ -52,23 +52,33 @@ This proposal deliberately keeps the bridge mechanism at the architectural level
 
 Once CBTC can flow to Arch, it accesses the platform Arch already runs for institutional Bitcoin. This platform is built, operated, and maintained by Arch Network at its own cost — it is the commercial layer the bridge unlocks, not a funded deliverable.
 
-The mechanism is the credit carry trade. Arch levers the Bitcoin at the sharpest available rates and deploys the proceeds into yield-generating traditional finance vehicles. The assets can be on-chain or off-chain, managed by institutional asset managers such as Fidelity, Wellington, KKR, and Hamilton Lane, as well as negotiated allocations into private credit funds, real estate funds, and reinsurance funds.
+The mechanism is the credit carry trade. Arch levers the Bitcoin at the sharpest available rates and deploys the proceeds into yield-generating traditional finance vehicles. The assets can be on-chain or off-chain. Representative institutional asset managers in the category Arch deploys into include Fidelity, Wellington, KKR, and Hamilton Lane; these names are illustrative of the type of manager and strategy the platform routes to, not announced partners. Specific manager partnerships will be confirmed and disclosed as the platform onboards strategies, and may also include negotiated allocations into private credit funds, real estate funds, and reinsurance funds.
 
 The participant controls the exposure. A liquidity provider can select a single product or build a basket across multiple products and manage the whole allocation as one structured trade — with a defined loan-to-value, a net yield position, and continuous tracking of the income accrued from the deployment. The position is held and managed as a single instrument rather than a set of disconnected legs.
+
+Position representation on Canton. When a CBTC holder enters a structured carry position through the bridge, a CIP-56 position token is minted on Canton to represent the leveraged, yield-bearing position. This position token tracks the LTV, net yield, and accrued income for the underlying trade, and is burned on settlement back to CBTC. The final ticker for the position token will be aligned with BitSafe before mainnet; this proposal references it descriptively rather than naming it. No unleveraged-Bitcoin wrapper is introduced on Canton — the only Bitcoin-denominated holding outside an active position is CBTC.
+
+Fee model on the carry-trade platform. Arch charges no fee for bridging itself. On the carry-trade platform, Arch's commercial revenue model is a performance fee (carry) on the strategy's net yield, with the exact rate structured per-strategy in coordination with the institutional asset manager and disclosed at the product level. This fee is separate from any management fee charged by the underlying asset manager on the off-chain or on-chain vehicle.
 
 ### 4. The Canton application
 
 Canton participants access the platform through an application deployed on Canton, built by Arch on top of the IntellectEU bridge. The application is where a CBTC holder commits collateral, selects a product or constructs a basket, sets and monitors loan-to-value, and tracks net yield and accrued income on the position. Like the carry-trade platform, the application is built and maintained by Arch at its own cost.
 
+Vault-agnostic by design. The Canton application does not depend on, and does not require, a Canton-side vault standard. The position-management surface is implemented as Daml interfaces that compose with the CIP-56 position token introduced in §3 and that interoperate with whatever vault providers come online on Canton. Where vault providers exist today, the application integrates with them; where they do not, the position is held and managed natively through the position token. Arch already works with Concrete on the Arch side, and the Canton-side interfaces are deliberately specified so a new Canton vault provider can plug in without changes to the bridge or the position-management interfaces. The full interface contract between the bridge and the Canton-side position-management layer is published in M3 as a deliverable, so reviewers can confirm the bridge is not tightly coupled to a single undisclosed implementation.
+
+Audit scope. The bridge contracts and the Decentralization Manager integration are in scope for the M2 third-party security audit. The Canton-side position-management interfaces (M3) are audited in the same engagement or a separately funded follow-on audit, depending on engineering timing; Arch will not deploy a position-management interface to mainnet without third-party audit sign-off.
+
 ### 5. Architectural alignment
 
 The bridge aligns with Canton's architecture and with BitSafe's CBTC design:
 
-- CBTC native. The bridge treats CBTC as the underlying asset and operates entirely through standard CIP-56 mechanics. It introduces no competing Bitcoin representation on Canton.
-- Decentralized party model. By using BitSafe's DecParty manager, the bridge inherits the same FROST-based, decentralized-threshold authority model that secures CBTC, rather than introducing a new trust assumption.
+- CBTC native on Canton. The bridge treats CBTC as the underlying Bitcoin-denominated asset on Canton and operates entirely through standard CIP-56 mechanics. No new wrapper of unleveraged Bitcoin is introduced on Canton.
+- Decentralized party model. By using the Decentralization Manager, the bridge inherits the same FROST-based, decentralized-threshold authority model that secures CBTC, rather than introducing a new trust assumption.
 - DvP settlement. Bridge commitments and returning positions settle atomically via the Global Synchronizer.
 - Daml-native. The bridge and its integration interfaces are implemented in Daml, leveraging Canton's smart-contract model and privacy guarantees.
 - Credential and Registry Utility compatible. Bridge participation respects CBTC's existing KYC/AML and compliance gating, and integrates with DA's Credential and Registry Utilities without custom rework.
+
+Disclosure on aBTC. Arch operates its own Bitcoin representation, aBTC, internally on the Arch chain as part of its native execution and settlement flow. aBTC is not bridged to Canton, is not visible to CBTC holders, and is not the asset participants interact with through the Canton application. On Canton, the only Bitcoin-denominated assets are CBTC and — only while a structured position is open — the CIP-56 position token described in §3, which is burned on settlement back to CBTC. The bridge therefore does not fragment Bitcoin liquidity on Canton: CBTC remains the single Bitcoin asset on Canton, and the position token is a position receipt, not a competing Bitcoin wrapper.
 
 ### 6. Backward compatibility
 
@@ -89,7 +99,7 @@ Once the bridge is live, it enables a broader set of use cases for the Canton ec
 
 ## Milestones and Deliverables
 
-All milestones cover Canton-side bridge and integration work only. The underlying Arch capital markets stack and the structured carry-trade platform are already built, operated, and funded by Arch Network independently. IntellectEU leads Daml contract development across all milestones; BitSafe's open-source DecParty manager is integrated for decentralized party control.
+All milestones cover Canton-side bridge and integration work only. The underlying Arch capital markets stack and the structured carry-trade platform are already built, operated, and funded by Arch Network independently. IntellectEU leads Daml contract development across all milestones; the Decentralization Manager is integrated as the control plane for the bridge's Decentralized Party.
 
 ### Milestone 1: Bridge Design and Testnet Delivery
 
@@ -97,13 +107,13 @@ All milestones cover Canton-side bridge and integration work only. The underlyin
 |---|---|
 | **Delivery** | Q3 2026 (July–August) |
 | **Funding** | $50,000 |
-| **Focus** | Bridge design specification, Daml contract development, DecParty manager integration, CBTC bridging on testnet |
+| **Focus** | Bridge design specification, Daml contract development, Decentralization Manager integration, CBTC bridging on testnet |
 
 Deliverables:
 
-- Bridge design specification. Published technical document covering architecture, the CBTC commit/settle model, the DecParty-managed authority model, message format, and failure modes. Reviewed by at least one independent Daml ecosystem developer.
+- Bridge design specification. Published technical document covering architecture, the CBTC commit/settle model, the Decentralized-Party authority model, message format, and failure modes. Reviewed by at least one independent Daml ecosystem developer.
 - Daml bridge contracts. Bridge controller, commitment, attestation, and settlement contracts implemented with >90% unit test coverage. Source code published on GitHub. Reviewed by IntellectEU.
-- DecParty manager integration. BitSafe's open-source DecParty manager integrated to control the bridge's decentralized party on Canton testnet, with documented configuration and operator set.
+- Decentralization Manager integration. The Decentralization Manager integrated to govern the bridge's Decentralized Party on Canton testnet, with documented configuration and operator set.
 - CBTC bridging on testnet. CBTC committed to the bridge and routed to the Arch capital markets stack on testnet, with positions settling back to CBTC. At least 100 successful round-trip transfers demonstrated.
 - Integration tests. End-to-end tests (CBTC commit to Arch position, Arch settlement back to CBTC). Minimum 50 test cases covering normal and failure paths. Test suite published.
 - Documentation. Developer guide for bridge integration. Published on GitHub with README and quickstart.
@@ -118,25 +128,28 @@ Deliverables:
 
 Deliverables:
 
-- Bridge security audit. Third-party audit by a recognized firm (Certora, Trail of Bits, or equivalent). 0 critical findings, 0 unresolved high findings. Audit report published publicly.
-- Bridge mainnet deployment. Bridge contracts deployed on Canton mainnet with the DecParty-managed authority live. Relayer/attestation operational with uptime monitoring and alerting. At least 10 mainnet round-trip transfers processed.
+- Bridge security audit. Third-party audit by a recognized firm (Certora, Trail of Bits, or equivalent). 0 critical findings, 0 unresolved high findings. Audit report published publicly. Scope covers the bridge contracts and the Decentralization Manager integration.
+- Bridge mainnet deployment. Bridge contracts deployed on Canton mainnet with the Decentralized-Party authority live under the Decentralization Manager. Relayer/attestation operational with uptime monitoring and alerting. At least 10 mainnet round-trip transfers processed.
 - Operational readiness. CBTC bridgeable on mainnet via the bridge, with at least one institutional participant completing a round trip.
 - Documentation. Bridge operational runbook and integration guide. Published on GitHub.
 
-### Milestone 3: Capital Markets Integration Layer
+### Milestone 3: Capital Markets Integration Layer and Adoption
 
 | | |
 |---|---|
 | **Delivery** | Q4 2026 (November–December) |
 | **Funding** | $50,000 |
-| **Focus** | Canton-side integration interfaces connecting bridged CBTC to the structured carry-trade flow |
+| **Focus** | Asset-agnostic Canton-side integration interfaces, position-token implementation, second-asset reference integration, and protocol adoption |
 
 Deliverables:
 
-- Integration interface specification. Published Daml interfaces enabling bridged CBTC positions to express a loan-to-value, a net yield position, and accrued-income tracking that settle back to CBTC on Canton. Reviewed by IntellectEU.
-- Reference integration. A working reference path on Canton testnet demonstrating a CBTC holder taking a single structured position (defined LTV, net yield, accrued income) through the bridge, with results documented and transaction logs published.
-- Composability demonstration. Bridged-position settlement demonstrated in an atomic DvP flow with CBTC on Canton testnet. Documented with transaction logs.
-- Documentation. Integration developer guide for parties building on the bridge. Published on GitHub.
+- Integration interface specification. Published Daml interfaces (asset-agnostic) for the position-management layer: minting and burning the CIP-56 position token, expressing loan-to-value, tracking net yield and accrued income, and settling back to the underlying Canton asset. The interfaces are explicitly specified so they apply to any CIP-56 Canton asset, not just CBTC. Reviewed by IntellectEU.
+- Position token implementation. Daml contracts for the CIP-56 position token (mint, transfer, settle, burn) implemented with >90% unit test coverage. Source code published on GitHub. Reviewed by IntellectEU.
+- CBTC reference integration. End-to-end working path on Canton mainnet demonstrating a CBTC holder taking a structured position (defined LTV, net yield, accrued income) through the bridge, with results documented and transaction logs published.
+- Second-asset reference integration. A documented, worked example of the same integration interfaces applied to a second Canton asset (an additional CIP-56 asset selected with the Foundation and a counterparty during M1–M2). Delivered as a testnet demonstration with code, configuration, and transaction logs published, evidencing that the integration layer is reusable infrastructure, not bespoke CBTC plumbing.
+- Composability demonstration. Bridged-position settlement demonstrated in an atomic DvP flow with CBTC on Canton mainnet. Documented with transaction logs.
+- Adoption demonstration. At least **$10,000,000 in TVL** bridged into the protocol and actively deployed into yield strategies by the close of the milestone. Reported with on-chain evidence.
+- Documentation. Integration developer guide for parties building on the bridge and the position-management layer. Published on GitHub.
 
 ## Acceptance Criteria
 
@@ -147,13 +160,13 @@ The Tech & Ops Committee will evaluate completion based on:
 - Documentation and knowledge transfer provided.
 - Security audit results (Milestone 2): 0 critical, 0 unresolved high findings.
 - Mainnet operational status (Milestone 2): bridge operational, CBTC bridgeable.
-- Integration readiness (Milestone 3): reference path demonstrating a single CBTC structured position with LTV, net yield, and accrued-income tracking, settling back to CBTC.
+- Integration readiness (Milestone 3): asset-agnostic interfaces published, CBTC reference integration on mainnet, second-asset reference integration on testnet, and ≥$10M TVL deployed into yield through the protocol.
 
 ## Funding
 
 Total Funding Request: $150,000 USD (payable in CC equivalent)
 
-This budget covers Canton-side bridge and integration development by IntellectEU, BitSafe DecParty manager integration, security audit, testing, and documentation. The underlying Arch capital markets stack and the structured carry-trade platform are already built, operated, and funded by Arch Network independently. The Canton application Arch builds on top of the bridge is also funded by Arch.
+This budget covers Canton-side bridge and integration development by IntellectEU, Decentralization Manager integration, security audit, testing, the second-asset reference integration, and documentation. The underlying Arch capital markets stack and the structured carry-trade platform are already built, operated, and funded by Arch Network independently. The Canton application Arch builds on top of the bridge is also funded by Arch.
 
 ### Payment Breakdown
 
@@ -161,8 +174,12 @@ This budget covers Canton-side bridge and integration development by IntellectEU
 |---|---|---|
 | M1: Bridge Design and Testnet Delivery | $50,000 | Q3 2026 |
 | M2: Security Audit and Mainnet Readiness | $50,000 | Q3–Q4 2026 |
-| M3: Capital Markets Integration Layer | $50,000 | Q4 2026 |
+| M3: Capital Markets Integration Layer and Adoption | $50,000 | Q4 2026 |
 | **Total** | **$150,000** | |
+
+### Budget rationale
+
+A note on M3 relative to the prior revision of this proposal. In the earlier version, a $25K SDK line item sat alongside a separate vault-standard primitive. In this revision, the vault standard is removed, and the M3 budget consolidates: (a) IntellectEU's Daml build for the asset-agnostic integration interfaces and the CIP-56 position token, (b) Decentralization Manager integration work attributable to M3, and (c) the second-asset reference integration added in response to reviewer feedback to substantiate the public-good claim. IntellectEU's quote for this scope is at minimum the $50K line item; consolidating reduces total proposal complexity without changing the headline budget. The overall $150K request is unchanged from the prior revision.
 
 ### Volatility Stipulation
 
@@ -186,7 +203,7 @@ What CBTC does not yet have is a native path to leverage and managed yield. A CB
 
 This proposal closes that gap with one open infrastructure component:
 
-- The Arch–Canton Bridge is free, open-source bridging infrastructure connecting CBTC to the Arch capital markets stack. Arch charges no fee for bridging. The bridge uses BitSafe's open-source DecParty manager for decentralized authority and is a reusable reference for connecting Canton assets to external capital markets infrastructure.
+- The Arch–Canton Bridge is free, open-source bridging infrastructure connecting CBTC to the Arch capital markets stack. Arch charges no fee for bridging. The bridge uses the Decentralization Manager for decentralized authority and is a reusable reference — with a worked second-asset example delivered in M3 — for connecting Canton assets to external capital markets infrastructure.
 
 Once the bridge exists, it enables a commercially viable platform that Arch Network builds and maintains at its own cost: a structured carry-trade platform that levers Bitcoin at the sharpest rates and deploys it into managed yield, accessed through a Canton application. Arch's commercial revenue from operating this platform creates perpetual maintenance incentives for the bridge that persist long after the grant term ends.
 
@@ -207,7 +224,7 @@ CBTC's strength is custody, settlement, and margin on Canton. It does not provid
 Build partners:
 
 - IntellectEU leads the Canton-side Daml development across all milestones. IntellectEU is a recognized Daml ecosystem developer with Canton production experience.
-- BitSafe's open-source DecParty manager controls the bridge's decentralized party, aligning the bridge's trust model with the decentralized-threshold model that already secures CBTC.
+- The Decentralization Manager (BitSafe, open source) governs the bridge's Decentralized Party, aligning the bridge's trust model with the decentralized-threshold model that already secures CBTC.
 
 Existing ecosystem partnerships:
 


### PR DESCRIPTION
## Development Fund Proposal Submission

**Proposal file:**
[proposals/arch-bitcoin-capital-markets-stack.md](https://github.com/mudman890/canton-dev-fund/blob/proposal/arch-bitcoin-capital-markets-stack/proposals/arch-bitcoin-capital-markets-stack.md)

---

## Summary

This proposal requests $150,000 to build two public good infrastructure components that connect Bitcoin to Canton Network:

1. **Arch-Canton Bridge** — a bidirectional, fee-free, open source bridge that mints CIP-56-compliant aBTC on Canton, enabling BTC holders to access Canton's institutional ecosystem and Canton participants to access Bitcoin liquidity.
2. **Canton Vault Standard** — a standardized, composable vault interface written in Daml (analogous to Ethereum's ERC-4626), submitted as a formal Canton Improvement Proposal (CIP) for community adoption.

Both components are open, permissionless infrastructure available to any Canton participant at no cost. The $150K budget covers Canton-side Daml contract development, bridge relayer integration, testing, security audit, and documentation — executed by IntellectEU, a specialist Daml development firm with Canton production experience.

All underlying Arch-side infrastructure is already built and deployed. This proposal funds only the Canton integration layer.

---

## Key Details

- **Budget:** $150,000 USD (payable in CC equivalent)
- **Scope:** Canton-side Daml integration only — all five underlying primitives already exist on Arch Network
- **Daml development partner:** IntellectEU (confirmed)
- **Milestones:** M1A Bridge Testnet ($50K) → M1B Bridge Mainnet ($50K) → M2 Vault Standard CIP ($50K)

---

## Checklist

- [x] Proposal file included
- [x] Budget and milestones specified
- [x] Daml development partner confirmed (IntellectEU)
- [x] Reviewer feedback addressed

---

## Changes in this revision

- **Narrowed scope from 5 components to 2** — focused on the two genuine public goods (bridge + vault standard). Commercial services (DEX access, lending, capital markets integration) repositioned as unfunded ecosystem benefits that Arch builds and maintains at its own cost.
- **Reduced budget from $250K to $150K** — reflects the tighter scope
- **Reduced milestones from 4 to 3** — M1A (Bridge Testnet), M1B (Bridge Mainnet), M2 (Vault Standard CIP)
- **Cleaner public goods framing** — addresses reviewer concern about commercial benefit positioning
- **Added DA Utility compatibility** — explicit Credential Utility and Registry Utility alignment
- **Added Ecosystem Benefits section** — downstream value of the public goods clearly separated from funded deliverables
