### PR TITLE
Add Askardex to Node Deployment & Operations and Canton APIs SIGs

### DIFF
--- a/sig-directory.md
+++ b/sig-directory.md
@@ -246,6 +246,7 @@ If your expertise does not fit an existing SIG, feel free to submit a Pull Reque
 | Akash Gaurav | Alpend | akashgaurav |
 | Curtis Hrischuk | Digital Asset | hrischuk-da |
 | Daniel Hansley | FTP | denend |
+| Irpan | Askardex | AskardexDev |
 | Marcin Ziolek | Digital Asset | mziolekda |
 | Marton Nagy | Digital Asset | nmarton-da |
 | Matthieu Le Berre | Peaceful Studio | monsieurleberre |
@@ -261,6 +262,7 @@ If your expertise does not fit an existing SIG, feel free to submit a Pull Reque
 | Andrew Pohl | Liquify | Andrew-Pohl |
 | Brandon Young | Send | beezybarg |
 | Caleb Bolden | Blockdaemon | cbolden15 |
+| Irpan | Askardex | AskardexDev |
 | Itai Segall | Digital Asset | isegall-da |
 | Jeremy Alons | Cumberland | jalonsdrw |
 | Lucas Naundorf | FCS | LucasnFCS |


### PR DESCRIPTION
Adding Askardex (validator operator on Canton mainnet) to two SIGs:

- **Node Deployment & Operations** - We operate a Canton validator running Wallet and Bridge services on mainnet since Q4 2025
- **Canton APIs (Ledger API, SQL API, Admin API)** - We consume JSON Ledger API v2 costEstimation, participant admin traffic endpoints, and AmuletRules fee primitives daily in production

Per the contributing instructions in sig-directory.md:
> If you would like to join an existing SIG, please submit a Pull Request updating this file.