### PR TITLE
Proposal: Canton Event Stream — real-time ledger events via WebSocket…

### DIFF
--- a/proposals/canton-event-stream.md
+++ b/proposals/canton-event-stream.md
@@ -2,7 +2,7 @@
 **Status:** Submitted
 **Created:** 2026-05-05
 **Label:** canton-apis
-**Champion:** Parth <parth@canton.foundation>
+**Champion:** Jatin <jatin@canton.foundation>
 
 ---
 

--- a/proposals/canton-event-stream.md
+++ b/proposals/canton-event-stream.md
@@ -1,0 +1,326 @@
+**Author:** Anand <anand@qasara.ai>, Qasara
+**Status:** Submitted
+**Created:** 2026-05-05
+**Label:** canton-apis
+**Champion:** Parth <parth@canton.foundation>
+
+---
+
+# Canton Event Stream — Real-Time Ledger Events via WebSocket & SSE
+
+> Canton Development Fund Proposal
+> Funding request: 300,000 CC across 3 milestones (6 weeks)
+
+---
+
+## Abstract
+
+Canton Event Stream is an open-source, MIT-licensed, self-hostable Node.js service that connects to any Canton participant node and delivers classified, party-routed ledger events to application clients over WebSocket and Server-Sent Events (SSE). It fills the missing push layer in the Canton ecosystem — the infrastructure between the raw JSON Ledger API stream and the live UIs, deposit detectors, and reactive backends that real applications need. The core implementation already exists and runs against Canton DevNet inside Qasara's commercial Canton Gateway; this proposal extracts and open-sources it as a standalone package, complementing PQS (CIP-0100, the pull/SQL layer) on the same validator without overlap.
+
+---
+
+## Specification
+
+### 1. Objective
+
+Provide every Canton application team with a maintained, open-source push layer for ledger events — classified into named application events (`transfer.executed`, `transfer.rejected`, etc.), routed by party, and exposed over WebSocket and SSE so that browsers, mobile apps, and reactive backends can subscribe directly without each team rebuilding the same classification, fanout, and reconnection plumbing from scratch.
+
+The intended outcome: within 12 months of M1 release, building a real-time Canton dApp UI requires running a single Docker container alongside a validator — not designing and operating bespoke event-routing infrastructure.
+
+### 2. Implementation Mechanics
+
+**Architecture:**
+
+```
+Canton Participant Node
+     │
+     │  JSON Ledger API (WebSocket)
+     │  subscribeToUpdates({ interfaceIds: [...Splice CIPs...] })
+     ▼
+┌─────────────────────────────────┐
+│       Ledger Ingester           │
+│  - Splice interface subscription│
+│  - Event classification         │
+│  - Batch pub to Redis pipeline  │
+│  - Exponential backoff reconnect│
+└──────────────┬──────────────────┘
+               │  Redis Pub/Sub
+               │  channel: party:<partyId>
+               │  buffer:  eventbuf:<eventId> (5-min TTL)
+               ▼
+┌─────────────────────────────────┐
+│      Event Stream Server        │
+│  - WebSocket endpoint           │
+│  - SSE endpoint                 │
+│  - Multi-party subscription     │
+│  - Reconnect replay from buffer │
+│  - Token-based auth             │
+└──────────────┬──────────────────┘
+               │
+     ┌─────────┴──────────┐
+     ▼                    ▼
+WebSocket clients     SSE clients
+(browser dApps,    (server backends,
+ mobile apps)       monitoring tools)
+```
+
+**Workflow:**
+
+1. The Ledger Ingester connects to a Canton participant's JSON Ledger API and subscribes to ledger updates using Splice interface IDs (CIP-0056 token holdings + transfer instructions), with fallback to template-based subscription on nodes that do not yet support interface filtering.
+2. Raw DAML contract events are classified by parsing `templateId` and exercised choice names into human-readable typed events (`transfer.pending`, `transfer.executed`, `transfer.accepted`, `transfer.rejected`, `transfer.withdrawn`, `contract.created`, `contract.archived`).
+3. Events are routed by extracting `signatories`, `observers`, `witnessParties`, and `actingParties` across event types, then fanned out to subscribers via per-party Redis Pub/Sub channels.
+4. Events are buffered for 5 minutes to support reconnection replay via `lastEventId` — clients reconnect and request all buffered events since a given event ID without losing data.
+5. Application clients (browsers, mobile, server backends) connect to the Event Stream Server's WebSocket or SSE endpoint with a party-scoped token; they never connect to the participant node directly.
+6. The whole service ships as a single Docker image deployable alongside any Canton node, with Redis as its only persistent dependency.
+
+**Event format** — all events follow a consistent schema regardless of source:
+
+```json
+{
+  "eventId": "1220abc...def-uuid",
+  "partyId": "alice::1220...",
+  "type": "transfer.executed",
+  "timestamp": "2026-04-07T12:00:00.000Z",
+  "data": {
+    "contractId": "00abc...",
+    "templateId": "Splice.Amulet:Amulet",
+    "choice": "Transfer",
+    "consuming": true,
+    "updateId": "1220...",
+    "effectiveAt": "2026-04-07T12:00:00.000Z"
+  }
+}
+```
+
+**Event types:**
+
+| Type | Trigger |
+|---|---|
+| `transfer.pending` | TransferInstruction contract created |
+| `transfer.executed` | Transfer/Execute choice exercised |
+| `transfer.accepted` | Accept choice exercised |
+| `transfer.rejected` | Reject choice exercised |
+| `transfer.withdrawn` | Withdraw choice exercised |
+| `contract.created` | Any non-transfer contract created |
+| `contract.archived` | Any contract archived |
+
+**Splice interface support** — interface-based subscription rather than template-based, making the ingester forward-compatible with new CIP-0056 token implementations without code changes:
+
+- `#splice-api-token-holding-v1:Splice.Api.Token.HoldingV1:Holding`
+- `#splice-api-token-transfer-instruction-v1:Splice.Api.Token.TransferInstructionV1:TransferInstruction`
+
+**Stack:** TypeScript / Node.js, `@canton-network/wallet-sdk` for ledger access, Redis for fanout and replay buffer, single Docker image (~150 MB), Helm chart for Kubernetes deployment.
+
+### 3. Architectural Alignment
+
+**Ecosystem Infrastructure**: Real-time event delivery is foundational. Wallet UIs, exchange deposit detection, DeFi liquidation triggers, RFQ negotiation, and compliance monitoring all depend on reliable push notifications from the ledger.
+
+**Developer Experience**: Today every team solves this independently. A single, well-maintained open-source solution eliminates duplicate engineering and reduces the surface area for subtle bugs in each custom implementation.
+
+**Complementary to PQS (CIP-0100)**: PQS is the pull layer (offset-paged SQL queries against a materialized Postgres ODS). Canton Event Stream is the push layer. Production applications need both. PQS exposes no LISTEN/NOTIFY, no change feed, no subscription primitive — it is exclusively offset-paged query functions. (Detailed comparison in Rationale below.)
+
+**CIP-0056 alignment**: Interface-based subscription means the ingester works with any CIP-0056 compliant token without modification, supporting the Canton multi-asset future.
+
+**Canton 3.5 alignment**: The compatibility matrix (M3) targets Canton 3.5+ explicitly, in line with the mid-June 2026 protocol upgrade.
+
+### 4. Backward Compatibility
+
+No backward compatibility impact. Canton Event Stream is additive infrastructure that subscribes to the existing JSON Ledger API; it does not modify Canton, Splice, or any existing client interface. Validators electing to deploy it run a new sidecar Docker container — no changes to their participant node, no schema migrations, no client breakage.
+
+---
+
+## Milestones and Deliverables
+
+### Milestone 1: Standalone Package + Replay
+- **Estimated Delivery:** Week 2
+- **Focus:** Extract core ingester from Qasara's commercial gateway into a self-contained MIT-licensed package; add reconnection replay.
+- **Deliverables / Value Metrics:**
+  - npm package decoupled from Qasara's auth, API key, and database systems
+  - Standalone configuration via environment variables only (no Prisma, no external DB dependency)
+  - Multi-auth support: sandbox HMAC, DevNet OAuth2 ClientCredentials, configurable per deployment
+  - `lastEventId` replay on reconnect (5-minute buffer window)
+  - Docker image published to GitHub Container Registry
+  - Unit tests (≥80% coverage on ingester and event classification logic)
+  - GitHub Actions CI: lint, test, Docker build on every PR
+
+### Milestone 2: Integration Tests + AsyncAPI Spec
+- **Estimated Delivery:** Week 4
+- **Focus:** Production-grade test coverage and developer-facing API documentation.
+- **Deliverables / Value Metrics:**
+  - End-to-end integration test suite against Canton Quickstart in CI:
+    - WebSocket connect, subscribe, receive events, disconnect
+    - SSE connect, receive events, disconnect
+    - Stream token issue/use-once/reject-second-use
+    - `lastEventId` replay after disconnect
+    - Invalid token rejection
+    - Multi-party subscription routing
+  - AsyncAPI 3.0 specification covering both WebSocket and SSE endpoints, published and rendered as documentation
+  - `docker-compose.yml` for local development (redis + canton-event-stream + Canton Quickstart)
+  - Published developer quickstart guide: zero-to-events in under 10 minutes
+
+### Milestone 3: Production Hardening + Community Onboarding
+- **Estimated Delivery:** Week 6
+- **Focus:** Make the service safely runnable on production validators and ready for community adoption.
+- **Deliverables / Value Metrics:**
+  - Helm chart for Kubernetes deployment with configurable replicas, resource limits, and Redis connection settings
+  - Prometheus metrics endpoint (`/metrics`): active connections, events/sec, Redis publish latency, reconnect count
+  - Grafana dashboard JSON
+  - Structured JSON logging with configurable log level
+  - Compatibility matrix: Canton Quickstart, Canton 3.5+ DevNet, MainNet validator (Canton 3.5+), Splice 0.5.x and 0.6.x
+  - Security checklist: stream token entropy, WebSocket connection limits, Redis ACL configuration guide
+  - Contributor guide and governance documentation
+  - 12-month maintenance commitment: security patches, Splice/SDK version compatibility updates, issue triage
+
+---
+
+## Acceptance Criteria
+
+The Tech & Ops Committee will evaluate completion against ecosystem-value metrics for each milestone, supported by underlying artifact evidence.
+
+### Milestone 1 — Adoption-readiness
+- ≥1 external developer (non-Qasara) successfully connects to Canton Quickstart and receives classified events using only the published README — no Qasara-specific guidance required
+- Reconnection replay verified end-to-end: client disconnects mid-stream and recovers all events within the 5-minute buffer using `lastEventId`
+- Package and Docker image publicly available on npm and GHCR; install from a fresh machine reaches a working event stream in a single `docker compose up`
+- Unit test suite passes in CI
+
+### Milestone 2 — Developer onboarding velocity
+- ≥3 external teams (validators or app builders) confirm successful local setup using the quickstart guide and provide written feedback
+- AsyncAPI spec published and renderable in standard tooling (e.g., AsyncAPI Studio)
+- An external tester with no prior Canton experience reaches a working event stream within 10 minutes of opening the guide
+- Integration test suite passes in CI against Canton Quickstart
+
+### Milestone 3 — Production deployment readiness
+- ≥2 external production-track deployments running canton-event-stream alongside their validator (DevNet or MainNet), OR ≥1 Canton Foundation-recognized reference deployment
+- Helm chart deployed and verified on a real Kubernetes cluster (not a single-node test rig)
+- Compatibility matrix published with passing test results across all listed environments
+- Security checklist reviewed and signed off by a Canton Foundation Tech & Ops Committee member
+- ≥1 external contributor PR successfully merged following the contributor guide
+
+---
+
+## Funding
+
+**Total Funding Request:** 300,000 CC
+
+### Payment Breakdown by Milestone
+- Milestone 1 (Standalone Package + Replay): **120,000 CC** upon committee acceptance
+- Milestone 2 (Integration Tests + AsyncAPI Spec): **100,000 CC** upon committee acceptance
+- Milestone 3 (Production Hardening + Community Onboarding): **80,000 CC** upon final release and acceptance
+
+### Volatility Stipulation
+
+Project duration is **under 6 months** (6 weeks planned). Should the project timeline extend beyond 6 months due to Committee-requested scope changes, any remaining milestones must be renegotiated to account for significant USD/CC price volatility.
+
+---
+
+## Co-Marketing
+
+Upon release, Qasara will collaborate with the Canton Foundation on:
+
+- **Announcement coordination** — joint blog post and Canton Foundation channel announcements at M1 (npm release) and M3 (production-ready release)
+- **Technical case study** — a published deep-dive on the architecture, the PQS-vs-push-layer design rationale, and lessons from running this in production at Qasara
+- **Reference integration** — make Qasara's Canton Gateway integration with canton-event-stream a public reference example for other dApp builders
+
+---
+
+## Motivation
+
+Real-time event delivery is foundational infrastructure for the Canton dApp ecosystem. Wallet UIs, exchange deposit detection, DeFi liquidation triggers, RFQ negotiation, and compliance monitoring all depend on reliable push notifications from the ledger. Today every team solves this independently — duplicating engineering effort, multiplying the surface area for subtle bugs, and slowing dApp time-to-market.
+
+**The raw JSON Ledger API is not the answer for application clients.** It exposes a WebSocket stream — but what that stream delivers is raw DAML contract events:
+
+```json
+{
+  "update": {
+    "value": {
+      "updateId": "1220abc...",
+      "effectiveAt": "2026-04-08T...",
+      "events": [
+        {
+          "contractId": "00abc...",
+          "templateId": "#splice-amulet-0.1.9:Splice.Amulet:Amulet",
+          "signatories": ["alice::1220..."],
+          "observers": [],
+          "createdAt": "2026-04-08T...",
+          "createdEventBlob": "CgYI..."
+        }
+      ]
+    }
+  }
+}
+```
+
+To turn this into something an application can act on, every team must build event classification, party routing, multi-subscriber fanout, reconnection-with-replay, and a client-facing WebSocket/SSE server (so browsers and mobile apps don't connect to the participant node directly). This abstraction layer does not exist as a shared, maintained open-source component anywhere in the Canton ecosystem.
+
+**Ecosystem portion benefited:** We estimate **~70% of new Canton dApp development happens on Node.js / TypeScript stacks** — the Canton Wallet SDK is TypeScript-native, and the dApp/fintech developer mainstream is Node.js. Of those teams, **all that need real-time event delivery are addressable** — every wallet UI, every exchange integration, every reactive backend. We conservatively expect **≥10 production integrations within 12 months** of M3 release, and a measurable reduction in time-to-first-event for new Canton applications. The remaining ~30% (JVM-stack teams) can still consume the WebSocket/SSE endpoints from any language; they simply gain less from the TypeScript-native implementation.
+
+**Strategic importance:** Approving PQS (CIP-0100) without a complementary push layer leaves every Canton application team to rebuild that push layer independently — exactly the duplication a foundational push component eliminates. PQS makes ledger state queryable and historically auditable; Canton Event Stream makes ledger events deliverable to live UIs and reactive backends. Production applications need both layers.
+
+---
+
+## Rationale
+
+### Why a new component, not an extension of PQS
+
+CIP-0100 (PR #67, merged 2026-04-23) approved Digital Asset's grant to open-source PQS — the Participant Query Store — under Apache 2.0. PQS and Canton Event Stream serve different layers of the same stack and cannot be folded into one another:
+
+| Dimension | PQS (offset-paged SQL ODS) | Canton Event Stream (push) |
+|---|---|---|
+| **Consumer-facing interface** | SQL API: `active()`, `creates()`, `archives()`, `exercises()` | WebSocket and Server-Sent Events |
+| **Wire protocol** | PostgreSQL JDBC | WebSocket / HTTP SSE |
+| **Client topology** | Server-side only (browsers cannot speak Postgres) | Browser, mobile, and server clients |
+| **Authentication** | PostgreSQL roles | App-layer party-scoped tokens |
+| **Event shape** | Decoded contracts in JSONB; clients implement classification | Pre-classified app events (`transfer.executed`, `transfer.rejected`, etc.) |
+| **Hot-path latency** | Ledger API → PQS write → Postgres → poll | Ledger API → Redis pub/sub → WebSocket push (no DB write in the hot path) |
+| **Reconnection model** | Client tracks Postgres offset; bespoke replay logic | `lastEventId` against a 5-minute event buffer, designed for browser reconnect |
+| **Footprint** | JVM (4 GB / 4 cores min.) plus Postgres (8 GB / 8 cores min.) | Node.js (~150 MB image), Redis only |
+
+The [PQS SQL API documentation](https://docs.digitalasset.com/build/3.5/component-howtos/pqs/references/sql-api.html) confirms the consumer-facing interface is exclusively offset-paged query functions — no LISTEN/NOTIFY, no change feed, no subscription primitive. Adding push to PQS would require building exactly this proposal inside a JVM project, which forces a JVM dependency on every dApp consumer (the very dependency many builders are trying to avoid).
+
+### Why TypeScript / Node.js
+
+Existing Canton event indexing work in the ecosystem is JVM-based (Scala). The Canton SDK itself is TypeScript-native (`@canton-network/wallet-sdk`). For teams already running a Node.js application stack — the majority of dApp and fintech developers — a TypeScript implementation:
+
+- Eliminates a JVM dependency from their infrastructure
+- Uses the same SDK they are already familiar with
+- Produces a smaller Docker image (~150 MB vs ~400 MB+ JVM)
+- Shares package ecosystem with the Canton Wallet SDK
+
+JVM-stack consumers are not excluded — the WebSocket and SSE endpoints are language-neutral wire protocols, so any client (Java, Python, Rust, Go) connects without a Node.js runtime on its side.
+
+### Why interface-based subscription
+
+Building this on top of template-based subscription would lock the ecosystem into per-token rewrites every time a new asset launches; building on Splice interfaces (CIP-0056) means the ingester works with any compliant token without modification, supporting the Canton multi-asset future. The fallback to empty-template subscription preserves compatibility with nodes that do not yet support interface filtering.
+
+### Coexistence on the same validator
+
+PQS and Canton Event Stream are independent of one another and can run on the same validator without interaction. Canton Event Stream subscribes to the Canton Ledger API directly and uses Redis as its only persistent state — it does not depend on Postgres or share any infrastructure with PQS. Validators electing to run both gain queryable historical state from PQS and live event delivery from Canton Event Stream without integration work between the two.
+
+### Alternatives considered
+
+- **Recommend each team builds their own push layer over the JSON Ledger API.** Status quo; results in fragmented, inconsistent event semantics, duplicated bugs in classification and reconnection logic, and slow dApp time-to-market. Rejected as the explicit problem this proposal solves.
+- **Add push to PQS.** Forces a JVM dependency on every consumer and changes PQS's architectural identity from a query store into a hybrid push+query system. Better served by an independent, lightweight push component.
+- **Standardize on the gRPC streaming Ledger API.** gRPC streaming is excellent for server-to-server but not consumable by browsers or mobile clients without a translation proxy — exactly the proxy this proposal builds, only the WebSocket/SSE-facing version of it is broadly consumable.
+
+---
+
+## Maintenance Plan
+
+- MIT license, hosted at `github.com/qasara/canton-event-stream`
+- 12-month post-launch maintenance: security patches, Splice/SDK version compatibility updates
+- Semantic versioning with a documented breaking-change policy
+- Issues triaged weekly; critical fixes within 48 hours
+- Compatibility tested against each major Splice and Canton release
+- After 12 months: proposal to transfer stewardship to Canton Foundation or a community SIG if formation is possible
+
+---
+
+## Notes for Reviewers
+
+1. **Core implementation exists today.** This is not a design proposal. The ledger ingester (Splice interface subscription, exponential backoff reconnect), Redis Pub/Sub fanout with batch pipeline, WebSocket endpoint, and SSE endpoint are all implemented and running in our DevNet environment as part of the Qasara Canton Gateway. The milestones deliver: extracting this into a standalone open-source package, decoupling it from Qasara's auth and API key system, adding the `lastEventId` replay query on reconnect, and adding production hardening (Helm chart, metrics, standalone Docker image). The hard engineering is done — what remains is packaging, decoupling, and documentation.
+
+2. **TypeScript choice is intentional.** The Canton Wallet SDK is TypeScript-native. Most dApp developers are TypeScript-first. A JVM-free event stream reduces the operational complexity for the majority of Canton builders, while the language-neutral wire protocols (WebSocket + SSE) keep JVM consumers fully supported.
+
+3. **Commercial relationship.** Qasara operates a hosted version of this infrastructure as part of our commercial Canton Gateway API. The open-source version does not include our API key management, rate limiting, or billing tier logic — those remain part of the commercial product. This is analogous to Uniswap publishing open-source contracts while running a commercial interface.
+
+4. **Champion endorsement.** Endorsed by Parth (parth@canton.foundation), Canton Foundation.

--- a/proposals/canton-event-stream.md
+++ b/proposals/canton-event-stream.md
@@ -2,7 +2,7 @@
 **Status:** Submitted
 **Created:** 2026-05-05
 **Label:** canton-apis
-**Champion:** Jatin <jatin@canton.foundation>
+**Champion:** 
 
 ---
 

--- a/proposals/canton-event-stream.md
+++ b/proposals/canton-event-stream.md
@@ -373,9 +373,10 @@ PQS and Canton Event Stream are independent of one another and can run on the sa
    | Per-party authorization re-enforced at the edge | ✅ | uses OSS |
    | Fanout, WebSocket/SSE serving, `lastEventId` replay | ✅ | uses OSS |
    | Connection authentication (validate client JWT/token → identity) | ✅ (bring-your-own IdP) | Qasara IdP + accounts |
+   | Credential issuance for self-hosting (stream tokens / BYO-IdP) | ✅ | uses OSS |
    | Basic connection / backpressure limits | ✅ | uses OSS |
    | AsyncAPI spec, Helm chart, metrics, Docker image | ✅ | uses OSS |
-   | API-key issuance & management for third-party customers | ❌ | ✅ |
+   | Multi-tenant customer key management (issue/rotate/meter keys for paying third-party customers) | ❌ | ✅ |
    | Per-plan tiered rate limits | ❌ | ✅ |
    | Usage metering & billing | ❌ | ✅ |
 

--- a/proposals/canton-event-stream.md
+++ b/proposals/canton-event-stream.md
@@ -9,14 +9,14 @@
 # Canton Event Stream — Real-Time Ledger Events via WebSocket & SSE
 
 > Canton Development Fund Proposal
-> Phase 1 funding request: 300,000 CC across 3 milestones (12 weeks).
+> Phase 1 funding request: 300,000 CC across 3 milestones. Build (M1, M2, and the M3 release) is ~12 weeks; the M3 external-adoption window runs up to 6 months. The final milestone is 50% of the grant, released when the service is adopted by at least 3 independent teams on MainNet.
 > Phase 2 (multi-hosted HA + multi-synchronizer reassignment) is scoped as a follow-on grant requiring a multi-participant / multi-synchronizer testbed — see **Phasing**.
 
 ---
 
 ## Abstract
 
-Canton Event Stream is an open-source, MIT-licensed, self-hostable Node.js service that connects to any Canton participant node and delivers classified, party-authorized ledger events to application clients over WebSocket and Server-Sent Events (SSE). Canton already provides a native push *transport* (the JSON Ledger API WebSocket channels and gRPC `UpdateService.GetUpdates`); Canton Event Stream is the **application-edge layer above it** — it takes one upstream subscription, re-enforces Canton's per-party visibility at the streaming edge, classifies raw events into a stable application vocabulary, and fans them out to many clients without each client connecting to the participant or holding a ledger token. The transport and event-classification core already run against Canton DevNet inside Qasara's commercial Canton Gateway; this proposal open-sources that core as a standalone package and builds the net-new pieces the ecosystem needs — per-party authorization at the streaming edge, RecordTime ordering, and configurable subscriptions — complementing PQS (CIP-0100, the pull/SQL layer) on the same validator without overlap.
+Canton Event Stream is an open-source, Apache 2, self-hostable Node.js service that connects to any Canton participant node and delivers classified, party-authorized ledger events to application clients over WebSocket and Server-Sent Events (SSE). Canton already provides a native push *transport* (the JSON Ledger API WebSocket channels and gRPC `UpdateService.GetUpdates`); Canton Event Stream is the **application-edge layer above it** — it takes one upstream subscription, re-enforces Canton's per-party visibility at the streaming edge, classifies raw events into a stable application vocabulary, and fans them out to many clients without each client connecting to the participant or holding a ledger token. The transport and event-classification core already run against Canton DevNet inside Qasara's commercial Canton Gateway; this proposal open-sources that core as a standalone package and builds the net-new pieces the ecosystem needs — per-party authorization at the streaming edge, RecordTime ordering, and configurable subscriptions — complementing PQS (CIP-0100, the pull/SQL layer) on the same validator without overlap. Qasara's commercial offering is a hosted infrastructure service that runs this same open-source code: the grant funds the OSS package, and the hosted product consumes it as-is rather than maintaining a private fork, so every improvement made here reaches self-hosters and the hosted service alike.
 
 ---
 
@@ -26,13 +26,45 @@ Canton Event Stream is an open-source, MIT-licensed, self-hostable Node.js servi
 
 Provide every Canton application team with a maintained, open-source application-edge layer over Canton's native push transport — classifying ledger events into named application events (`transfer.executed`, `transfer.rejected`, etc.), re-enforcing per-party authorization at the streaming edge, ordering and resuming by RecordTime, and exposing the result over WebSocket and SSE so that browsers, mobile apps, and reactive backends can subscribe without each team rebuilding the same classification, authorization, ordering, fanout, and reconnection plumbing from scratch — and without each client connecting directly to the participant. The set of events subscribed to is operator-configurable, not fixed to one asset family.
 
-The intended outcome: within 12 months of M1 release, building a real-time Canton dApp UI requires running a single Docker container alongside a validator — not designing and operating bespoke event-routing infrastructure.
+The intended outcome: from M1 release, a team building a real-time Canton dApp UI can get classified, party-authorized ledger events by running a single Docker container alongside their validator, instead of designing and operating bespoke event-routing infrastructure themselves. Whether it becomes the default choice across the ecosystem is a matter of adoption; what the grant delivers and demonstrates is that the capability exists, is maintained, and works on infrastructure available today.
 
 This proposal funds **Phase 1** — the application-edge layer that is fully demonstrable on infrastructure available today (a single participant). **Phase 2** — multi-hosted high availability (failover across participant LAPI endpoints) and multi-synchronizer reassignment events — is scoped as a follow-on grant because it can only be built and demonstrated against a multi-participant / multi-synchronizer testbed. The Phase-1 architecture is designed so Phase 2 is additive, not a rewrite: RecordTime ordering (Phase 1) is the participant-independent key that multi-hosted failover and dedup (Phase 2) depend on.
 
 ### 2. Implementation Mechanics
 
 **Architecture:**
+
+```mermaid
+flowchart TD
+    subgraph NODE["Canton participant node(s)"]
+      LAPI["JSON Ledger API (WebSocket updates)<br/>Phase 1: one endpoint<br/>Phase 2: several participants host the same parties"]
+    end
+
+    PROF["Profile (operator config, loaded at startup)<br/>subscribe / classify / payload<br/>default = token standard V1 + V2"]
+
+    subgraph CES["Canton Event Stream: single Docker image (Redis is the only dependency)"]
+      ING["Ledger Ingester<br/>one upstream subscription<br/>classify to named events + token payload<br/>RecordTime ordering, backoff reconnect<br/>Phase 2: multi-host failover + dedup"]
+      REDIS[("Redis<br/>per-party channels (party:&lt;id&gt;)<br/>RecordTime replay buffer (minutes to hours)")]
+      SRV["Event Stream Server<br/>token auth + per-party authorization<br/>WebSocket + SSE, RecordTime resume"]
+      ING -->|"publish party:&lt;id&gt;"| REDIS
+      REDIS --> SRV
+    end
+
+    subgraph CLIENTS["Application clients (party-scoped token, never touch the node)"]
+      DAPP["Browser dApp"]
+      MOB["Mobile app"]
+      BE["Server backend / monitor"]
+    end
+
+    LAPI -->|"one WS subscription"| ING
+    PROF -.->|"config"| ING
+    SRV -->|"classified events (WS/SSE)"| DAPP
+    SRV --> MOB
+    SRV --> BE
+    DAPP -.->|"subscribe / unsubscribe partyIds"| SRV
+```
+
+<details><summary>Same architecture as ASCII (for raw-markdown viewers)</summary>
 
 ```
 Canton Participant Node(s)
@@ -46,12 +78,12 @@ Canton Participant Node(s)
 ┌──────────────────────────────────────┐
 │       Ledger Ingester                │
 │  - Configurable subscription         │
-│  - Event classification              │
+│  - Event classification + payload    │
 │  - RecordTime ordering               │
 │  - Batch pub to Redis pipeline       │
 │  - Exponential-backoff reconnect     │
 │  - Phase 2: multi-host failover +    │
-│             reassignment events      │
+│             dedup + reassignment     │
 └──────────────┬───────────────────────┘
                │  Redis Pub/Sub
                │  channel: party:<partyId>
@@ -59,37 +91,60 @@ Canton Participant Node(s)
                ▼
 ┌─────────────────────────────────┐
 │      Event Stream Server        │
-│  - WebSocket endpoint           │
-│  - SSE endpoint                 │
+│  - WebSocket + SSE endpoints    │
+│  - subscribe / unsubscribe      │
+│      (client chooses partyIds)  │
 │  - Per-party authorization      │
 │  - RecordTime resume            │
 │  - Token-based auth             │
-└──────────────┬──────────────────┘
-               │
-     ┌─────────┴──────────┐
-     ▼                    ▼
-WebSocket clients     SSE clients
-(browser dApps,    (server backends,
- mobile apps)       monitoring tools)
+└───────▲───────────────┬─────────┘
+        │               │
+  subscribe/        classified
+  unsubscribe         events
+  (partyIds)            │
+        │               ▼
+     ┌──┴────────────────────┐
+     ▼                       ▼
+WebSocket clients        SSE clients
+(browser dApps)        (server backends,
+ subscribe [alice],     monitoring tools)
+ later +[bob] −[alice]   partyIds set at connect
 ```
+
+</details>
 
 **Workflow:**
 
-1. The Ledger Ingester connects to a Canton participant's JSON Ledger API and subscribes to a **configurable set of interfaces/templates** — operators declare what to subscribe to, with a pluggable classification mapping. The CIP-0056 token interfaces (holdings + transfer instructions) ship as the **default profile**, with fallback to template-based subscription on nodes that do not yet support interface filtering; the mechanism is general-purpose, not fixed to token assets.
+1. The Ledger Ingester connects to a Canton participant's JSON Ledger API and subscribes to a **configurable set of interfaces/templates** — operators declare what to subscribe to, with a pluggable classification mapping. The CIP-0056 (Token Standard V1) token interfaces (holdings + transfer instructions) ship as the **default profile**, alongside CIP-0112 (Token Standard V2, now live on DevNet) — whose dedicated transfer-events surface (holdings-change events) lets the ingester read transfer events directly instead of inferring them from exercised choices. Both fall back to template-based subscription on nodes that do not yet support interface filtering, and the mechanism is general-purpose, not fixed to token assets.
 2. Raw DAML contract events are classified into human-readable typed events (`transfer.pending`, `transfer.executed`, `transfer.accepted`, `transfer.rejected`, `transfer.withdrawn`, `contract.created`, `contract.archived`) via the configured mapping.
-3. Events are routed by extracting `signatories`, `observers`, `witnessParties`, and `actingParties` across event types, then fanned out to subscribers via per-party Redis Pub/Sub channels. Subscribers are authorized per party at subscribe time — a client may only stream parties its credential is entitled to, re-establishing at the edge the per-party visibility boundary the participant enforces natively (and that is otherwise lost once clients are decoupled from the node for fanout).
+3. Events are routed by extracting `signatories`, `observers`, `witnessParties`, and `actingParties` across event types, then fanned out to subscribers via per-party Redis Pub/Sub channels. Subscribers are authorized per party at subscribe time — a client may only stream parties its credential is entitled to, re-establishing at the edge the per-party visibility boundary the participant enforces natively (and that is otherwise lost once clients are decoupled from the node for fanout). The token-based mechanism is detailed under **Authorization model** below.
 4. Events are ordered by **RecordTime** — Canton's participant-independent record timestamp, present on every update. Subscribers resume from a requested RecordTime ("send me everything since T") within a **configurable recent retention window** — a live-reconnect aid on the order of minutes to hours, **not a historical store**; deep historical replay is PQS's role, not this service's. The service maintains a RecordTime→offset index over that window to translate a requested time into a participant offset to resume from. (Choosing RecordTime over a participant-local offset is also what makes Phase-2 multi-hosted failover and dedup correct — see Phasing.)
 5. Application clients (browsers, mobile, server backends) connect to the Event Stream Server's WebSocket or SSE endpoint with a party-scoped token; they never connect to the participant node directly.
 6. The whole service ships as a single Docker image deployable alongside any Canton node, with Redis as its only persistent dependency.
+
+**Authorization model** — the server re-creates the node's per-party visibility boundary at the streaming edge using short-lived, party-scoped tokens:
+
+- *Who issues tokens.* The operator running the service, or their existing identity system: whoever already knows which user maps to which Canton party (for example, an exchange that knows "this logged-in user = party alice"). The server does not decide party ownership; it only accepts tokens signed by an issuer it is configured to trust (a shared key or a JWKS URL). This is the same trust model the participant already uses for `actAs` claims in an IdP-signed JWT, applied one hop further out.
+- *Two deployment shapes.* (a) the service authenticates the client, looks up its parties from an operator-supplied mapping, and issues the token itself; or (b) the operator's identity system issues the token and the service only verifies it. Making that verify step pluggable, so any operator can use their own identity system, is the net-new open-source work. (Qasara's commercial gateway uses shape (a) today, tied to its API-key system.)
+- *Token contents.* An explicit list of the party IDs the holder may stream, plus standard `iss`/`aud`/`exp` and a single-use id. The allowed-party list is written into the signed token by the issuer; the server never infers it. Tokens are short-lived (around 60 seconds) and single-use.
+- *Subscribe-time check.* Before opening any channel, the server (1) verifies the token (signature, audience, not expired, not already used), (2) reads the allowed-party list, and (3) confirms every requested party is on that list. If any requested party is not, the subscribe is rejected and no channel opens. This is exactly what the Milestone 1 acceptance test demonstrates: request a party the token does not include, and the subscribe is rejected.
+- *Optional node-side check.* Configurably, the service can also confirm with the participant that the token's issuer actually holds read rights for the party, so even a mis-issued token cannot grant more than the node itself would allow.
 
 **Event format** — all events follow a consistent schema regardless of source:
 
 ```json
 {
-  "eventId": "1220abc...def-uuid",
+  "eventId": "1220upd...abc:00ctr...def",
   "partyId": "alice::1220...",
   "type": "transfer.executed",
   "recordTime": "2026-04-07T12:00:00.123456Z",
+  "payload": {
+    "instrumentId": { "admin": "dso::1220...", "id": "Amulet" },
+    "amount": "100.0000000000",
+    "sender": "alice::1220...",
+    "receiver": "bob::1220...",
+    "holdingCid": "00hold..."
+  },
   "data": {
     "contractId": "00abc...",
     "templateId": "Splice.Amulet:Amulet",
@@ -101,6 +156,10 @@ WebSocket clients     SSE clients
   }
 }
 ```
+
+`eventId` is derived deterministically from the update, not randomly: it combines the `updateId` with the contract event's node identity (its `contractId`), so the same ledger event produces the same `eventId` on every participant that sees it and on any re-ingest after a restart.
+
+For token events, `payload` carries the Token Standard semantic fields a consumer actually needs — instrument, amount, sender, receiver, and holding — populated from CIP-0056 (V1) holdings / transfer-instruction data or CIP-0112 (V2) holdings-change events, so a dApp reads "Alice sent Bob 100 Amulet" without decoding the raw contract itself. `data` keeps the raw ledger metadata (contractId, templateId, choice, updateId, synchronizerId) for consumers that need to go deeper. Non-token event types carry their own typed `payload` under the same envelope; the classification mapping defines each type's payload shape.
 
 **Event types:**
 
@@ -118,12 +177,29 @@ WebSocket clients     SSE clients
 
 The event vocabulary above is the default profile; because the subscription set and classification mapping are configurable, operators can extend it to their own templates. The `unassigned`/`assigned` (reassignment) events matter for multi-synchronizer apps — without them, a contract moving between synchronizers is misread downstream as archive-then-create. They require ≥2 synchronizers to exercise and are delivered in **Phase 2** (see Phasing).
 
-**Subscription mechanism** — the ingester subscribes by **interface ID where available** (forward-compatible: a new template implementing an existing interface is picked up with no code change) and falls back to **template-based** subscription on nodes that don't yet support interface filtering. The subscription set is **operator-configurable**; the CIP-0056 token-standard interfaces ship as the default profile:
+**Subscription mechanism** — the ingester subscribes by **interface ID where available** (forward-compatible: a new template implementing an existing interface is picked up with no code change) and falls back to **template-based** subscription on nodes that don't yet support interface filtering.
 
-- `#splice-api-token-holding-v1:Splice.Api.Token.HoldingV1:Holding`
-- `#splice-api-token-transfer-instruction-v1:Splice.Api.Token.TransferInstructionV1:TransferInstruction`
+A **profile** is the operator-configurable unit, and it defines three things: (1) the **subscribe set** (which interfaces/templates to pull), (2) the **classification mapping** (which raw event becomes which named type), and (3) the **payload mapping** (which token-standard fields land in `event.payload`). The **default profile** ships the CIP-0056 (V1) and CIP-0112 (V2) token standards:
 
-Operators can add their own interfaces or templates to the set — the mechanism is general-purpose, not token-specific.
+```yaml
+# default profile — token standard (V1 + V2)
+subscribe:                        # (1) interfaces to pull (template fallback per node)
+  - "#splice-api-token-holding-v1:Splice.Api.Token.HoldingV1:Holding"
+  - "#splice-api-token-transfer-instruction-v1:Splice.Api.Token.TransferInstructionV1:TransferInstruction"
+  - "#splice-api-token-transfer-events-v2:...:HoldingsChange"   # CIP-0112 V2 transfer-events
+classify:                         # (2) raw event -> named type
+  TransferInstruction.created:    transfer.pending
+  TransferInstruction.Accept:     transfer.accepted
+  TransferInstruction.Reject:     transfer.rejected
+  TransferInstruction.Withdraw:   transfer.withdrawn
+  HoldingsChange:                 transfer.executed    # V2 read-events surface
+  "*.created":                    contract.created
+  "*.archived":                   contract.archived
+payload:                          # (3) token fields -> event.payload
+  fields: [instrumentId, amount, sender, receiver, holdingCid]
+```
+
+Operators can add interfaces/templates and classification rules to this profile, or ship additional profiles for non-token domains. The mechanism is general-purpose, not token-specific; the token-standard profile is simply the batteries-included default.
 
 **Stack:** TypeScript / Node.js, `@canton-network/wallet-sdk` for ledger access, Redis for fanout and replay buffer, single Docker image (~150 MB), Helm chart for Kubernetes deployment.
 
@@ -135,7 +211,7 @@ Operators can add their own interfaces or templates to the set — the mechanism
 
 **Complementary to PQS (CIP-0100)**: PQS is the pull layer (offset-paged SQL queries against a materialized Postgres ODS). Canton Event Stream is the push layer. Production applications need both. PQS exposes no LISTEN/NOTIFY, no change feed, no subscription primitive — it is exclusively offset-paged query functions. (Detailed comparison in Rationale below.)
 
-**CIP-0056 alignment**: The default subscription profile uses the CIP-0056 token-standard interfaces, so the ingester works with any compliant token without modification; the same interface-based mechanism extends to any other interface an operator configures — supporting the Canton multi-asset future.
+**Token-standard alignment (CIP-0056 + CIP-0112)**: The default profile uses both the CIP-0056 (V1) and CIP-0112 (V2) token-standard interfaces, so the ingester works with any compliant token without modification, and V2's holdings-change transfer-events are read directly rather than inferred from choices. The same interface-based mechanism extends to any other interface an operator configures, supporting the Canton multi-asset future.
 
 **Canton version alignment**: The service targets the current Canton 3.5 protocol line and tracks subsequent releases (see the Maintenance Plan); the M3 compatibility matrix covers Canton 3.5+ across Quickstart, DevNet, and a MainNet validator, plus Splice 0.5.x / 0.6.x.
 
@@ -152,13 +228,13 @@ No backward compatibility impact. Canton Event Stream is additive infrastructure
 This grant funds **Phase 1** (the three milestones below) — everything that is demonstrable today on a single participant. **Phase 2** is a scoped follow-on, deliberately separated because it cannot be built or demonstrated without a multi-participant / multi-synchronizer testbed:
 
 - **Phase 1 (this grant):** standalone package, per-party authorization at the edge, RecordTime ordering + time-based resume, configurable subscriptions + pluggable classification, integration tests, AsyncAPI spec, production hardening, and a **CIP draft** standardizing the event-selection and classified-event model.
-- **Phase 2 (follow-on grant):** multi-hosted high availability (failover across the LAPI endpoints of participants hosting the same party set, with RecordTime-based dedup) and multi-synchronizer **reassignment** (`unassigned`/`assigned`) events. Phase 1's RecordTime ordering is the enabler, so Phase 2 is additive rather than a rewrite. Scoped and costed when a multi-node/multi-synchronizer testbed is available.
+- **Phase 2 (follow-on grant):** multi-hosted high availability (failover across the LAPI endpoints of participants hosting the same party set) and multi-synchronizer **reassignment** (`unassigned`/`assigned`) events. When a party is hosted on more than one participant, each hosting participant emits the same update, so Phase 2 must **deduplicate the same event arriving from multiple participants**. The dedup key is the participant-independent update identity: the same logical update carries the same `updateId` and the same `RecordTime` on every participant that sees it, so the ingester keeps a seen-set of `updateId`s within the RecordTime window and drops repeats. This is why Phase 1 orders and resumes by RecordTime (participant-independent) rather than a participant-local offset, which is what makes Phase-2 cross-participant dedup correct, so Phase 2 is additive rather than a rewrite. Scoped and costed when a multi-node/multi-synchronizer testbed is available.
 
 ## Milestones and Deliverables (Phase 1)
 
 ### Milestone 1: Standalone Package + Edge Authorization + RecordTime Ordering
 - **Estimated Delivery:** Week 4
-- **Focus:** Extract the core ingester from Qasara's commercial gateway into a self-contained MIT-licensed package; build per-subscriber party authorization at the streaming edge; replace the buffer-based replay with RecordTime ordering and time-based resume.
+- **Focus:** Extract the core ingester from Qasara's commercial gateway into a self-contained Apache 2-licensed package; build per-subscriber party authorization at the streaming edge; replace the buffer-based replay with RecordTime ordering and time-based resume.
 - **Deliverables / Value Metrics:**
   - npm package decoupled from Qasara's auth, API key, and database systems; configuration via environment variables only (no Prisma, no external DB)
   - Multi-auth support: sandbox HMAC, DevNet OAuth2 ClientCredentials, configurable per deployment
@@ -176,21 +252,22 @@ This grant funds **Phase 1** (the three milestones below) — everything that is
   - AsyncAPI 3.0 specification for the classified event API (WS and SSE), published and rendered — distinct from Canton's native raw-event AsyncAPI spec; ours documents the classified-event vocabulary and the subscribe/authorize handshake
   - `docker-compose.yml` (redis + canton-event-stream + Canton Quickstart) and a published quickstart guide
 
-### Milestone 3: Production Hardening + CIP Draft + Community Onboarding
-- **Estimated Delivery:** Week 12
-- **Focus:** Make the service safely runnable on production validators, ready for community adoption, and propose the model for ecosystem standardization.
+### Milestone 3: Production Release + CIP Draft + External MainNet Adoption
+- **Estimated Delivery:** production release by Week 12; the external-adoption window runs up to 6 months after the M2 release.
+- **Focus:** Make the service safely runnable on production validators, get it adopted by independent community teams on MainNet, and propose the model for ecosystem standardization.
 - **Deliverables / Value Metrics:**
   - Helm chart (configurable replicas, resource limits, Redis settings); Prometheus `/metrics` (active connections, events/sec, publish latency, reconnect count) + Grafana dashboard JSON; structured JSON logging
   - Compatibility matrix: Canton Quickstart, Canton 3.5+ DevNet, MainNet validator (Canton 3.5+), Splice 0.5.x and 0.6.x
   - Security checklist: stream-token entropy, WebSocket connection limits, Redis ACL configuration guide
   - **CIP draft** standardizing the event-selection model and the classified-event schema, with canton-event-stream as the reference implementation, submitted to the relevant SIG
   - Contributor guide and governance docs; 12-month maintenance commitment (security patches, Splice/SDK compatibility updates, issue triage)
+  - **External MainNet adoption:** at least 3 independent community members deploy the service alongside their own validator on MainNet, evidenced by their live deployment. This is the primary value demonstration and part of Milestone 3 acceptance (see Funding).
 
 ---
 
 ## Acceptance Criteria
 
-Acceptance is evaluated on **value demonstrated to the ecosystem**, per Canton Development Fund guidance — each milestone is judged by a working, usable capability, with artifacts (tests, images, docs) as supporting evidence rather than the criterion itself. Targets are scoped so value can be demonstrated directly — including via Qasara's own Canton Gateway (reference integration) and MainNet validator (reference deployment) — rather than depending on third-party adoption on a fixed schedule.
+Acceptance is evaluated on **value demonstrated to the ecosystem**, per Canton Development Fund guidance — each milestone is judged by a working, usable capability, with artifacts (tests, images, docs) as supporting evidence rather than the criterion itself. M1 and M2 demonstrate value through working capability, with Qasara's own Canton Gateway (reference integration) proving the extraction is real and consumable. **M3 demonstrates value through independent external adoption on MainNet**: the final 50% is released when the service is running in production and adopted by at least 3 teams outside Qasara, on a window of up to 6 months.
 
 ### Milestone 1 — A usable, privacy-correct, correctly-ordered event layer exists
 - A developer outside the core team stands up the service from the published README and receives **classified** events from Canton Quickstart — and a client requesting a party its credential is not authorized for is **rejected at subscribe time**, demonstrated live. *(Supporting evidence: ≥80%-coverage unit suite green in CI; package runs with zero Qasara dependencies; image on npm/GHCR.)*
@@ -199,16 +276,14 @@ Acceptance is evaluated on **value demonstrated to the ecosystem**, per Canton D
 
 ### Milestone 2 — General-purpose and adoptable
 - **A new event type is added via configuration alone** (a template/interface not in the default profile is subscribed and classified) without code changes — demonstrating the subscription surface is general-purpose, not token-specific.
-- An external tester with no prior Canton experience reaches a working event stream by following only the quickstart guide, **unassisted**. *(Design target: ~10 minutes of hands-on time once base images are pulled; the gate is unassisted success, not a stopwatch.)*
+- An external tester with no prior Canton experience reaches a working event stream by following only the quickstart guide, **unassisted**. *(Design target: ~30 minutes of hands-on time once base images are pulled; the gate is unassisted success, not a stopwatch.)*
 - The documented API behaves as specified: the published AsyncAPI spec renders in standard tooling, and the integration suite — WS/SSE lifecycle, stream-token single-use, RecordTime resume, invalid-token and unauthorized-party rejection, multi-party routing — passes in CI as the evidence.
 
-### Milestone 3 — It runs in production, is community-maintainable, and proposes a standard
-- ≥1 production-track deployment running alongside a validator — **Qasara's own MainNet validator as the reference deployment** — verifiable live by the committee.
-- Operational readiness demonstrated: Helm deploy on a real multi-node cluster; Prometheus metrics + Grafana dashboard; and a published compatibility matrix across the listed environments (Canton Quickstart, Canton 3.5+ DevNet, MainNet validator, Splice 0.5.x/0.6.x).
+### Milestone 3 — It runs in production, is externally adopted, and proposes a standard
+- **Production release:** the service runs alongside a validator, with **Qasara's own MainNet validator as the reference deployment**, verifiable live by the committee. Operational readiness demonstrated: Helm deploy on a real multi-node cluster; Prometheus metrics + Grafana dashboard; and a published compatibility matrix across the listed environments (Canton Quickstart, Canton 3.5+ DevNet, MainNet validator, Splice 0.5.x/0.6.x).
+- **External MainNet adoption (the primary value gate):** at least 3 independent community members deploy the service alongside their own validator on MainNet, evidenced by their live deployment. This is the core of the Milestone 3 gate: the full 50% is released once it is met (see Funding).
 - **CIP draft submitted** to the relevant SIG, standardizing the event-selection and classified-event model with this service as the reference implementation.
 - Community-ready: security checklist submitted for committee review; contributor guide published; documented 12-month maintenance commitment (SECURITY.md, release/versioning policy).
-
-Broader external adoption — multiple third-party integrations and production deployments — is the longer-horizon measure of success; it is tracked and reported transparently after M3 (see Motivation for the 12-month projection) and is not a milestone payment gate.
 
 ---
 
@@ -217,15 +292,17 @@ Broader external adoption — multiple third-party integrations and production d
 **Total Phase 1 Funding Request:** 300,000 CC
 
 ### Payment Breakdown by Milestone (Phase 1)
-- Milestone 1 (Standalone Package + Edge Authorization + RecordTime Ordering): **120,000 CC** upon committee acceptance
-- Milestone 2 (Configurable Subscriptions + Integration Tests + AsyncAPI Spec): **100,000 CC** upon committee acceptance
-- Milestone 3 (Production Hardening + CIP Draft + Community Onboarding): **80,000 CC** upon final release and acceptance
+- Milestone 1 (Standalone Package + Edge Authorization + RecordTime Ordering): **90,000 CC (30%)** upon committee acceptance
+- Milestone 2 (Configurable Subscriptions + Integration Tests + AsyncAPI Spec): **60,000 CC (20%)** upon committee acceptance
+- Milestone 3 (Production Release + CIP Draft + External MainNet Adoption): **150,000 CC (50%)** upon committee acceptance of the full Milestone 3 criteria, including **at least 3 independent community deployments on MainNet**.
+
+The final milestone is **50%** of the grant, released when the service is running in production and adopted by at least 3 independent teams on MainNet — the strongest available signal of ecosystem value.
 
 **Phase 2** (multi-hosted HA + multi-synchronizer reassignment) is **not funded by this grant**; it will be scoped and costed as a follow-on once a multi-participant / multi-synchronizer testbed is available.
 
 ### Volatility Stipulation
 
-Phase 1 duration is **under 6 months** (12 weeks planned). Should the timeline extend beyond 6 months due to Committee-requested scope changes, any remaining milestones must be renegotiated to account for significant USD/CC price volatility.
+Phase 1 build is **~12 weeks** (M1, M2, and the M3 release); the M3 external-adoption window then runs up to 6 months, so total Phase 1 duration is **up to ~6 months**. Should the timeline extend beyond that due to Committee-requested scope changes, any remaining milestones must be renegotiated to account for significant USD/CC price volatility.
 
 ---
 
@@ -331,7 +408,7 @@ JVM-stack consumers are not excluded — the WebSocket and SSE endpoints are lan
 
 ### Why interface-based subscription (with a configurable set)
 
-The subscription set is operator-configurable, so the service is not tied to one asset family. Within that, subscribing by interface ID — rather than enumerating individual templates — means a new template implementing an existing interface is picked up with no code change. For the default token profile this matters because any CIP-0056-compliant token works without modification, supporting the Canton multi-asset future; the same mechanism applies to any interface an operator configures. Template-based subscription (and an empty-template fallback) preserves compatibility with nodes that do not yet support interface filtering.
+The subscription set is operator-configurable, so the service is not tied to one asset family. Within that, subscribing by interface ID — rather than enumerating individual templates — means a new template implementing an existing interface is picked up with no code change. For the default token profile this matters because any CIP-0056 (V1) or CIP-0112 (V2) compliant token works without modification, supporting the Canton multi-asset future; the same mechanism applies to any interface an operator configures. Template-based subscription (and an empty-template fallback) preserves compatibility with nodes that do not yet support interface filtering.
 
 ### Coexistence on the same validator
 
@@ -347,7 +424,7 @@ PQS and Canton Event Stream are independent of one another and can run on the sa
 
 ## Maintenance Plan
 
-- MIT license, hosted at `github.com/Qasara-Labs-Pvt-Ltd/canton-event-stream`
+- Apache 2 license, hosted at `github.com/Qasara-Labs-Pvt-Ltd/canton-event-stream`
 - 12-month post-launch maintenance: security patches, Splice/SDK version compatibility updates
 - Semantic versioning with a documented breaking-change policy
 - Issues triaged weekly; critical fixes within 48 hours
@@ -366,7 +443,7 @@ PQS and Canton Event Stream are independent of one another and can run on the sa
 
    **Open-source vs. hosted boundary:**
 
-   | Capability | Open-source (MIT) | Hosted (commercial) |
+   | Capability | Open-source (Apache 2) | Hosted (commercial) |
    |---|---|---|
    | Ledger ingester (single upstream subscription, backoff reconnect) | ✅ | uses OSS |
    | Event classification into the typed vocabulary | ✅ | uses OSS |

--- a/proposals/canton-event-stream.md
+++ b/proposals/canton-event-stream.md
@@ -362,7 +362,24 @@ PQS and Canton Event Stream are independent of one another and can run on the sa
 
 2. **TypeScript choice is intentional.** The Canton Wallet SDK is TypeScript-native. Most dApp developers are TypeScript-first. A JVM-free event stream reduces the operational complexity for the majority of Canton builders, while the language-neutral wire protocols (WebSocket + SSE) keep JVM consumers fully supported.
 
-3. **Commercial relationship.** Qasara operates a hosted version of this infrastructure as part of our commercial Canton Gateway API. The open-source version does not include our API key management, rate limiting, or billing tier logic — those remain part of the commercial product. This is analogous to Uniswap publishing open-source contracts while running a commercial interface.
+3. **Commercial relationship.** Qasara operates a hosted version of this infrastructure as part of our commercial Canton Gateway API. The entire event-streaming engine — including connection authentication and basic per-connection/backpressure limits — is open-source and self-hostable. What remains commercial is only the multi-tenant SaaS layer: issuing and metering API keys for paying customers, per-plan tiered rate limits, and billing. This is the same boundary as Grafana OSS versus Grafana Cloud — the engine is the public good; the multi-tenant billing service is the business. Our incentive is aligned with keeping the engine open: the more teams that can build real-time Canton applications, the larger the market for our hosted API. We also run this component in production ourselves, which is what sustains its maintenance beyond the grant window.
+
+   **Open-source vs. hosted boundary:**
+
+   | Capability | Open-source (MIT) | Hosted (commercial) |
+   |---|---|---|
+   | Ledger ingester (single upstream subscription, backoff reconnect) | ✅ | uses OSS |
+   | Event classification into the typed vocabulary | ✅ | uses OSS |
+   | Per-party authorization re-enforced at the edge | ✅ | uses OSS |
+   | Fanout, WebSocket/SSE serving, `lastEventId` replay | ✅ | uses OSS |
+   | Connection authentication (validate client JWT/token → identity) | ✅ (bring-your-own IdP) | Qasara IdP + accounts |
+   | Basic connection / backpressure limits | ✅ | uses OSS |
+   | AsyncAPI spec, Helm chart, metrics, Docker image | ✅ | uses OSS |
+   | API-key issuance & management for third-party customers | ❌ | ✅ |
+   | Per-plan tiered rate limits | ❌ | ✅ |
+   | Usage metering & billing | ❌ | ✅ |
+
+   The grant funds only the left column; every deliverable and acceptance criterion in the milestones lands in the public repository.
 
 4. **Phasing reflects what can be demonstrated, not appetite.** Multi-hosted HA and multi-synchronizer reassignment (Phase 2) are deliberately separated because they cannot be built or demonstrated on a single participant / single synchronizer — they require a multi-participant, multi-synchronizer testbed. Phase 1's RecordTime ordering is chosen specifically so Phase 2 is additive (RecordTime is the participant-independent key that multi-hosted failover and dedup depend on). We would rather commit Phase 1 to deliverables we can demonstrate on infrastructure available today and scope Phase 2 once a suitable testbed exists, than over-promise both in one grant.
 

--- a/proposals/canton-event-stream.md
+++ b/proposals/canton-event-stream.md
@@ -9,13 +9,13 @@
 # Canton Event Stream — Real-Time Ledger Events via WebSocket & SSE
 
 > Canton Development Fund Proposal
-> Funding request: 300,000 CC across 3 milestones (6 weeks)
+> Funding request: 300,000 CC across 3 milestones (9 weeks)
 
 ---
 
 ## Abstract
 
-Canton Event Stream is an open-source, MIT-licensed, self-hostable Node.js service that connects to any Canton participant node and delivers classified, party-routed ledger events to application clients over WebSocket and Server-Sent Events (SSE). It fills the missing push layer in the Canton ecosystem — the infrastructure between the raw JSON Ledger API stream and the live UIs, deposit detectors, and reactive backends that real applications need. The core implementation already exists and runs against Canton DevNet inside Qasara's commercial Canton Gateway; this proposal extracts and open-sources it as a standalone package, complementing PQS (CIP-0100, the pull/SQL layer) on the same validator without overlap.
+Canton Event Stream is an open-source, MIT-licensed, self-hostable Node.js service that connects to any Canton participant node and delivers classified, party-authorized ledger events to application clients over WebSocket and Server-Sent Events (SSE). Canton already provides a native push *transport* (the JSON Ledger API WebSocket channels and gRPC `UpdateService.GetUpdates`); Canton Event Stream is the **application-edge layer above it** — it takes one upstream subscription, re-enforces Canton's per-party visibility at the streaming edge, classifies raw events into a stable application vocabulary, and fans them out to many clients without each client connecting to the participant or holding a ledger token. The core implementation already exists and runs against Canton DevNet inside Qasara's commercial Canton Gateway; this proposal extracts and open-sources it as a standalone package, complementing PQS (CIP-0100, the pull/SQL layer) on the same validator without overlap.
 
 ---
 
@@ -23,7 +23,7 @@ Canton Event Stream is an open-source, MIT-licensed, self-hostable Node.js servi
 
 ### 1. Objective
 
-Provide every Canton application team with a maintained, open-source push layer for ledger events — classified into named application events (`transfer.executed`, `transfer.rejected`, etc.), routed by party, and exposed over WebSocket and SSE so that browsers, mobile apps, and reactive backends can subscribe directly without each team rebuilding the same classification, fanout, and reconnection plumbing from scratch.
+Provide every Canton application team with a maintained, open-source application-edge layer over Canton's native push transport — classifying ledger events into named application events (`transfer.executed`, `transfer.rejected`, etc.), re-enforcing per-party authorization at the streaming edge, and exposing the result over WebSocket and SSE so that browsers, mobile apps, and reactive backends can subscribe without each team rebuilding the same classification, authorization, fanout, and reconnection plumbing from scratch — and without each client connecting directly to the participant.
 
 The intended outcome: within 12 months of M1 release, building a real-time Canton dApp UI requires running a single Docker container alongside a validator — not designing and operating bespoke event-routing infrastructure.
 
@@ -68,7 +68,7 @@ WebSocket clients     SSE clients
 
 1. The Ledger Ingester connects to a Canton participant's JSON Ledger API and subscribes to ledger updates using Splice interface IDs (CIP-0056 token holdings + transfer instructions), with fallback to template-based subscription on nodes that do not yet support interface filtering.
 2. Raw DAML contract events are classified by parsing `templateId` and exercised choice names into human-readable typed events (`transfer.pending`, `transfer.executed`, `transfer.accepted`, `transfer.rejected`, `transfer.withdrawn`, `contract.created`, `contract.archived`).
-3. Events are routed by extracting `signatories`, `observers`, `witnessParties`, and `actingParties` across event types, then fanned out to subscribers via per-party Redis Pub/Sub channels.
+3. Events are routed by extracting `signatories`, `observers`, `witnessParties`, and `actingParties` across event types, then fanned out to subscribers via per-party Redis Pub/Sub channels. Subscribers are authorized per party at subscribe time — a client may only stream parties its credential is entitled to, re-establishing at the edge the per-party visibility boundary the participant enforces natively (and that is otherwise lost once clients are decoupled from the node for fanout).
 4. Events are buffered for 5 minutes to support reconnection replay via `lastEventId` — clients reconnect and request all buffered events since a given event ID without losing data.
 5. Application clients (browsers, mobile, server backends) connect to the Event Stream Server's WebSocket or SSE endpoint with a party-scoped token; they never connect to the participant node directly.
 6. The whole service ships as a single Docker image deployable alongside any Canton node, with Redis as its only persistent dependency.
@@ -131,20 +131,21 @@ No backward compatibility impact. Canton Event Stream is additive infrastructure
 
 ## Milestones and Deliverables
 
-### Milestone 1: Standalone Package + Replay
-- **Estimated Delivery:** Week 2
-- **Focus:** Extract core ingester from Qasara's commercial gateway into a self-contained MIT-licensed package; add reconnection replay.
+### Milestone 1: Standalone Package + Edge Authorization + Replay
+- **Estimated Delivery:** Week 3
+- **Focus:** Extract core ingester from Qasara's commercial gateway into a self-contained MIT-licensed package; build per-subscriber party authorization at the streaming edge; add reconnection replay.
 - **Deliverables / Value Metrics:**
   - npm package decoupled from Qasara's auth, API key, and database systems
   - Standalone configuration via environment variables only (no Prisma, no external DB dependency)
   - Multi-auth support: sandbox HMAC, DevNet OAuth2 ClientCredentials, configurable per deployment
+  - **Per-subscriber party authorization** — a client may only stream parties its credential is authorized for, enforced at subscribe time; re-establishes the node's per-party visibility boundary at the streaming edge
   - `lastEventId` replay on reconnect (5-minute buffer window)
   - Docker image published to GitHub Container Registry
   - Unit tests (≥80% coverage on ingester and event classification logic)
   - GitHub Actions CI: lint, test, Docker build on every PR
 
 ### Milestone 2: Integration Tests + AsyncAPI Spec
-- **Estimated Delivery:** Week 4
+- **Estimated Delivery:** Week 6
 - **Focus:** Production-grade test coverage and developer-facing API documentation.
 - **Deliverables / Value Metrics:**
   - End-to-end integration test suite against Canton Quickstart in CI:
@@ -154,12 +155,12 @@ No backward compatibility impact. Canton Event Stream is additive infrastructure
     - `lastEventId` replay after disconnect
     - Invalid token rejection
     - Multi-party subscription routing
-  - AsyncAPI 3.0 specification covering both WebSocket and SSE endpoints, published and rendered as documentation
+  - AsyncAPI 3.0 specification for the classified event API (WebSocket and SSE), published and rendered as documentation — distinct from Canton's native AsyncAPI spec, which documents the raw-event transport; ours documents the application-level classified-event vocabulary and the subscribe/authorize handshake
   - `docker-compose.yml` for local development (redis + canton-event-stream + Canton Quickstart)
   - Published developer quickstart guide: zero-to-events in under 10 minutes
 
 ### Milestone 3: Production Hardening + Community Onboarding
-- **Estimated Delivery:** Week 6
+- **Estimated Delivery:** Week 9
 - **Focus:** Make the service safely runnable on production validators and ready for community adoption.
 - **Deliverables / Value Metrics:**
   - Helm chart for Kubernetes deployment with configurable replicas, resource limits, and Redis connection settings
@@ -175,26 +176,22 @@ No backward compatibility impact. Canton Event Stream is additive infrastructure
 
 ## Acceptance Criteria
 
-The Tech & Ops Committee will evaluate completion against ecosystem-value metrics for each milestone, supported by underlying artifact evidence.
+Acceptance is evaluated on **value demonstrated to the ecosystem**, per Canton Development Fund guidance — each milestone is judged by a working, usable capability, with artifacts (tests, images, docs) as supporting evidence rather than the criterion itself. Targets are scoped so value can be demonstrated directly — including via Qasara's own Canton Gateway (reference integration) and MainNet validator (reference deployment) — rather than depending on third-party adoption on a fixed schedule.
 
-### Milestone 1 — Adoption-readiness
-- ≥1 external developer (non-Qasara) successfully connects to Canton Quickstart and receives classified events using only the published README — no Qasara-specific guidance required
-- Reconnection replay verified end-to-end: client disconnects mid-stream and recovers all events within the 5-minute buffer using `lastEventId`
-- Package and Docker image publicly available on npm and GHCR; install from a fresh machine reaches a working event stream in a single `docker compose up`
-- Unit test suite passes in CI
+### Milestone 1 — A usable, privacy-correct event layer exists
+- A developer outside the core team stands up the service from the published README and receives **classified** events from Canton Quickstart — and a client requesting a party its credential is not authorized for is **rejected at subscribe time**, demonstrated live. *(Supporting evidence: ≥80%-coverage unit suite green in CI; package runs with zero Qasara dependencies; image on npm/GHCR.)*
+- Qasara's Canton Gateway runs against the standalone package as the first reference integration, demonstrating the extraction is real and consumable.
 
-### Milestone 2 — Developer onboarding velocity
-- ≥3 external teams (validators or app builders) confirm successful local setup using the quickstart guide and provide written feedback
-- AsyncAPI spec published and renderable in standard tooling (e.g., AsyncAPI Studio)
-- An external tester with no prior Canton experience reaches a working event stream within 10 minutes of opening the guide
-- Integration test suite passes in CI against Canton Quickstart
+### Milestone 2 — A newcomer can adopt it quickly
+- An external tester with no prior Canton experience reaches a working event stream by following only the quickstart guide, **unassisted**. *(Design target: ~10 minutes of hands-on time once base images are pulled; the acceptance gate is unassisted success, not a stopwatch.)*
+- The documented API behaves as specified: the published AsyncAPI spec renders in standard tooling, and the integration suite — WS/SSE lifecycle, stream-token single-use, `lastEventId` replay, invalid-token and unauthorized-party rejection, multi-party routing — passes in CI as the evidence.
 
-### Milestone 3 — Production deployment readiness
-- ≥2 external production-track deployments running canton-event-stream alongside their validator (DevNet or MainNet), OR ≥1 Canton Foundation-recognized reference deployment
-- Helm chart deployed and verified on a real Kubernetes cluster (not a single-node test rig)
-- Compatibility matrix published with passing test results across all listed environments
-- Security checklist reviewed and signed off by a Canton Foundation Tech & Ops Committee member
-- ≥1 external contributor PR successfully merged following the contributor guide
+### Milestone 3 — It runs in production and is community-maintainable
+- ≥1 production-track deployment running alongside a validator — **Qasara's own MainNet validator as the reference deployment** — verifiable live by the committee.
+- Operational readiness demonstrated: Helm deploy on a real multi-node cluster; Prometheus metrics + Grafana dashboard; and a published compatibility matrix across the listed environments (Canton Quickstart, Canton 3.5+ DevNet, MainNet validator, Splice 0.5.x/0.6.x).
+- Community-ready: security checklist submitted for committee review; contributor guide published; documented 12-month maintenance commitment (SECURITY.md, release/versioning policy).
+
+Broader external adoption — multiple third-party integrations and production deployments — is the longer-horizon measure of success; it is tracked and reported transparently after M3 (see Motivation for the 12-month projection) and is not a milestone payment gate.
 
 ---
 
@@ -209,7 +206,7 @@ The Tech & Ops Committee will evaluate completion against ecosystem-value metric
 
 ### Volatility Stipulation
 
-Project duration is **under 6 months** (6 weeks planned). Should the project timeline extend beyond 6 months due to Committee-requested scope changes, any remaining milestones must be renegotiated to account for significant USD/CC price volatility.
+Project duration is **under 6 months** (9 weeks planned). Should the project timeline extend beyond 6 months due to Committee-requested scope changes, any remaining milestones must be renegotiated to account for significant USD/CC price volatility.
 
 ---
 
@@ -250,9 +247,9 @@ Real-time event delivery is foundational infrastructure for the Canton dApp ecos
 }
 ```
 
-To turn this into something an application can act on, every team must build event classification, party routing, multi-subscriber fanout, reconnection-with-replay, and a client-facing WebSocket/SSE server (so browsers and mobile apps don't connect to the participant node directly). This abstraction layer does not exist as a shared, maintained open-source component anywhere in the Canton ecosystem.
+To turn this into something an application can act on, every team must build event classification, per-party authorization at the fanout edge, multi-subscriber fanout, reconnection-with-replay, and a client-facing WebSocket/SSE server (so browsers and mobile apps don't connect to the participant node directly). This application-edge layer — distinct from Canton's native raw-event transport — does not exist as a shared, maintained open-source component anywhere in the Canton ecosystem.
 
-**Ecosystem portion benefited:** We estimate **~70% of new Canton dApp development happens on Node.js / TypeScript stacks** — the Canton Wallet SDK is TypeScript-native, and the dApp/fintech developer mainstream is Node.js. Of those teams, **all that need real-time event delivery are addressable** — every wallet UI, every exchange integration, every reactive backend. We conservatively expect **≥10 production integrations within 12 months** of M3 release, and a measurable reduction in time-to-first-event for new Canton applications. The remaining ~30% (JVM-stack teams) can still consume the WebSocket/SSE endpoints from any language; they simply gain less from the TypeScript-native implementation.
+**Ecosystem portion benefited:** The **majority of new Canton dApp and fintech development happens on Node.js / TypeScript stacks** — the Canton Wallet SDK is TypeScript-native, and the dApp/fintech developer mainstream is Node.js. Every team in that segment that needs real-time event delivery is addressable — wallet UIs, exchange integrations, reactive backends. JVM-stack teams are not excluded: the WebSocket and SSE endpoints are language-neutral wire protocols, so any client (Java, Python, Rust, Go) consumes them without a Node.js runtime; they simply gain less from the TypeScript-native implementation itself. We expect a measurable reduction in time-to-first-event for new Canton applications as adoption grows.
 
 **Strategic importance:** Approving PQS (CIP-0100) without a complementary push layer leaves every Canton application team to rebuild that push layer independently — exactly the duplication a foundational push component eliminates. PQS makes ledger state queryable and historically auditable; Canton Event Stream makes ledger events deliverable to live UIs and reactive backends. Production applications need both layers.
 
@@ -277,6 +274,25 @@ CIP-0100 (PR #67, merged 2026-04-23) approved Digital Asset's grant to open-sour
 
 The [PQS SQL API documentation](https://docs.digitalasset.com/build/3.5/component-howtos/pqs/references/sql-api.html) confirms the consumer-facing interface is exclusively offset-paged query functions — no LISTEN/NOTIFY, no change feed, no subscription primitive. Adding push to PQS would require building exactly this proposal inside a JVM project, which forces a JVM dependency on every dApp consumer (the very dependency many builders are trying to avoid).
 
+### Relationship to Canton's native push layer (JSON WS and gRPC streaming)
+
+Canton already ships a native push *transport* in two forms: the gRPC `UpdateService.GetUpdates` server-stream, and the JSON Ledger API v2 WebSocket channels (`/v2/updates`, `/v2/state/active-contracts`, `/v2/commands/completions`), documented with an AsyncAPI specification. Canton Event Stream does not replace this transport — it consumes the JSON WS channel upstream. It is the application-edge layer on top of it, and the delta is the part the transport intentionally does not provide:
+
+The native transport enforces privacy **at the node**: a subscription's token read-rights bound which parties it may filter for, so a consumer physically cannot subscribe to a party it is not authorized to see. This is correct and robust — but it is a *per-client* model. Every browser, mobile app, or microservice opens its own node subscription, holds a Ledger API token, and receives raw `Created`/`Archived`/`Exercised` primitives it must classify itself.
+
+The moment an application introduces a fanout tier to serve many clients from one upstream subscription — which it must, to avoid exposing the participant to every client and handing every client a ledger token — **the node's per-party authorization boundary is removed from the downstream path.** Something has to re-establish it, or one party's events leak to another. A generic WebSocket fanout (Centrifugo, socket.io + Redis) cannot: it has no concept of a Canton party or of who is entitled to see whose events. Re-enforcing per-party authorization at the streaming edge is the Canton-specific, security-critical work that makes a purpose-built event gateway necessary rather than off-the-shelf pub/sub — and it is an explicit deliverable of this proposal (M1).
+
+| Dimension | Native push (gRPC GetUpdates / JSON WS) | Canton Event Stream (application edge) |
+|---|---|---|
+| **Role** | Raw event transport | Edge gateway consuming that transport |
+| **Privacy enforcement** | At the node, per subscription | Re-enforced at the edge, per subscriber — preserves the node's guarantee across fanout |
+| **Client topology** | One node subscription per client; each holds a ledger token | One upstream subscription; many clients, none touching the node |
+| **Event shape** | Raw `Created`/`Archived`/`Exercised` | Classified CIP-0056 vocabulary (`transfer.executed`, …) |
+| **Participant exposure** | Every client connects to the participant | Only the gateway connects to the participant |
+| **Reconnection** | Client tracks offset / `OffsetCheckpoint`s | `lastEventId` against a 5-minute buffer (no client-side offset persistence) |
+
+In short: the native WS/gRPC layer is the origin transport; Canton Event Stream is the reverse-proxy/edge above it — classification, per-party-authorized fanout, and a participant-shielding boundary. It composes with the native layer the same way it composes with PQS on the pull side. It only ever delivers events for parties an operator is authorized to read; by Canton's authorization model it cannot expose third-party private events.
+
 ### Why TypeScript / Node.js
 
 Existing Canton event indexing work in the ecosystem is JVM-based (Scala). The Canton SDK itself is TypeScript-native (`@canton-network/wallet-sdk`). For teams already running a Node.js application stack — the majority of dApp and fintech developers — a TypeScript implementation:
@@ -300,13 +316,13 @@ PQS and Canton Event Stream are independent of one another and can run on the sa
 
 - **Recommend each team builds their own push layer over the JSON Ledger API.** Status quo; results in fragmented, inconsistent event semantics, duplicated bugs in classification and reconnection logic, and slow dApp time-to-market. Rejected as the explicit problem this proposal solves.
 - **Add push to PQS.** Forces a JVM dependency on every consumer and changes PQS's architectural identity from a query store into a hybrid push+query system. Better served by an independent, lightweight push component.
-- **Standardize on the gRPC streaming Ledger API.** gRPC streaming is excellent for server-to-server but not consumable by browsers or mobile clients without a translation proxy — exactly the proxy this proposal builds, only the WebSocket/SSE-facing version of it is broadly consumable.
+- **Consume the native push transport directly (gRPC streaming or the JSON Ledger API WebSocket).** Both are excellent transports, and Canton Event Stream uses the JSON WS upstream. But consuming them directly means every client opens its own node subscription, holds a Ledger API token, and classifies raw events itself — and any fanout tier added to fix that strips the node's per-party authorization boundary unless it is re-enforced at the edge. This proposal builds exactly that edge layer (classification + per-party-authorized fanout + participant shielding), not a bare protocol translator. See "Relationship to Canton's native push layer" above.
 
 ---
 
 ## Maintenance Plan
 
-- MIT license, hosted at `github.com/qasara/canton-event-stream`
+- MIT license, hosted at `github.com/Qasara-Labs-Pvt-Ltd/canton-event-stream`
 - 12-month post-launch maintenance: security patches, Splice/SDK version compatibility updates
 - Semantic versioning with a documented breaking-change policy
 - Issues triaged weekly; critical fixes within 48 hours
@@ -317,10 +333,10 @@ PQS and Canton Event Stream are independent of one another and can run on the sa
 
 ## Notes for Reviewers
 
-1. **Core implementation exists today.** This is not a design proposal. The ledger ingester (Splice interface subscription, exponential backoff reconnect), Redis Pub/Sub fanout with batch pipeline, WebSocket endpoint, and SSE endpoint are all implemented and running in our DevNet environment as part of the Qasara Canton Gateway. The milestones deliver: extracting this into a standalone open-source package, decoupling it from Qasara's auth and API key system, adding the `lastEventId` replay query on reconnect, and adding production hardening (Helm chart, metrics, standalone Docker image). The hard engineering is done — what remains is packaging, decoupling, and documentation.
+1. **Core transport implementation exists today; edge authorization is the net-new build.** This is not a greenfield design proposal. The ledger ingester (Splice interface subscription, exponential backoff reconnect), Redis Pub/Sub fanout with batch pipeline, WebSocket endpoint, and SSE endpoint are all implemented and running in our DevNet environment as part of the Qasara Canton Gateway. The one piece of genuinely new engineering this grant funds is **per-subscriber party authorization at the streaming edge** (M1) — re-establishing, outside the participant, the per-party visibility boundary the node enforces natively; in the commercial gateway this is currently coupled to Qasara's API-key system, and the open-source version requires a clean, credential-agnostic implementation. The remaining milestone work is packaging, decoupling from Qasara's auth/DB systems, the `lastEventId` replay query, and production hardening (Helm chart, metrics, standalone Docker image). In short: the transport and classification are proven; the authorization layer and the productionization are what the milestones build.
 
 2. **TypeScript choice is intentional.** The Canton Wallet SDK is TypeScript-native. Most dApp developers are TypeScript-first. A JVM-free event stream reduces the operational complexity for the majority of Canton builders, while the language-neutral wire protocols (WebSocket + SSE) keep JVM consumers fully supported.
 
 3. **Commercial relationship.** Qasara operates a hosted version of this infrastructure as part of our commercial Canton Gateway API. The open-source version does not include our API key management, rate limiting, or billing tier logic — those remain part of the commercial product. This is analogous to Uniswap publishing open-source contracts while running a commercial interface.
 
-4. **Champion endorsement.** Endorsed by Parth (parth@canton.foundation), Canton Foundation.
+

--- a/proposals/canton-event-stream.md
+++ b/proposals/canton-event-stream.md
@@ -9,13 +9,14 @@
 # Canton Event Stream — Real-Time Ledger Events via WebSocket & SSE
 
 > Canton Development Fund Proposal
-> Funding request: 300,000 CC across 3 milestones (9 weeks)
+> Phase 1 funding request: 300,000 CC across 3 milestones (12 weeks).
+> Phase 2 (multi-hosted HA + multi-synchronizer reassignment) is scoped as a follow-on grant requiring a multi-participant / multi-synchronizer testbed — see **Phasing**.
 
 ---
 
 ## Abstract
 
-Canton Event Stream is an open-source, MIT-licensed, self-hostable Node.js service that connects to any Canton participant node and delivers classified, party-authorized ledger events to application clients over WebSocket and Server-Sent Events (SSE). Canton already provides a native push *transport* (the JSON Ledger API WebSocket channels and gRPC `UpdateService.GetUpdates`); Canton Event Stream is the **application-edge layer above it** — it takes one upstream subscription, re-enforces Canton's per-party visibility at the streaming edge, classifies raw events into a stable application vocabulary, and fans them out to many clients without each client connecting to the participant or holding a ledger token. The core implementation already exists and runs against Canton DevNet inside Qasara's commercial Canton Gateway; this proposal extracts and open-sources it as a standalone package, complementing PQS (CIP-0100, the pull/SQL layer) on the same validator without overlap.
+Canton Event Stream is an open-source, MIT-licensed, self-hostable Node.js service that connects to any Canton participant node and delivers classified, party-authorized ledger events to application clients over WebSocket and Server-Sent Events (SSE). Canton already provides a native push *transport* (the JSON Ledger API WebSocket channels and gRPC `UpdateService.GetUpdates`); Canton Event Stream is the **application-edge layer above it** — it takes one upstream subscription, re-enforces Canton's per-party visibility at the streaming edge, classifies raw events into a stable application vocabulary, and fans them out to many clients without each client connecting to the participant or holding a ledger token. The transport and event-classification core already run against Canton DevNet inside Qasara's commercial Canton Gateway; this proposal open-sources that core as a standalone package and builds the net-new pieces the ecosystem needs — per-party authorization at the streaming edge, RecordTime ordering, and configurable subscriptions — complementing PQS (CIP-0100, the pull/SQL layer) on the same validator without overlap.
 
 ---
 
@@ -23,37 +24,45 @@ Canton Event Stream is an open-source, MIT-licensed, self-hostable Node.js servi
 
 ### 1. Objective
 
-Provide every Canton application team with a maintained, open-source application-edge layer over Canton's native push transport — classifying ledger events into named application events (`transfer.executed`, `transfer.rejected`, etc.), re-enforcing per-party authorization at the streaming edge, and exposing the result over WebSocket and SSE so that browsers, mobile apps, and reactive backends can subscribe without each team rebuilding the same classification, authorization, fanout, and reconnection plumbing from scratch — and without each client connecting directly to the participant.
+Provide every Canton application team with a maintained, open-source application-edge layer over Canton's native push transport — classifying ledger events into named application events (`transfer.executed`, `transfer.rejected`, etc.), re-enforcing per-party authorization at the streaming edge, ordering and resuming by RecordTime, and exposing the result over WebSocket and SSE so that browsers, mobile apps, and reactive backends can subscribe without each team rebuilding the same classification, authorization, ordering, fanout, and reconnection plumbing from scratch — and without each client connecting directly to the participant. The set of events subscribed to is operator-configurable, not fixed to one asset family.
 
 The intended outcome: within 12 months of M1 release, building a real-time Canton dApp UI requires running a single Docker container alongside a validator — not designing and operating bespoke event-routing infrastructure.
+
+This proposal funds **Phase 1** — the application-edge layer that is fully demonstrable on infrastructure available today (a single participant). **Phase 2** — multi-hosted high availability (failover across participant LAPI endpoints) and multi-synchronizer reassignment events — is scoped as a follow-on grant because it can only be built and demonstrated against a multi-participant / multi-synchronizer testbed. The Phase-1 architecture is designed so Phase 2 is additive, not a rewrite: RecordTime ordering (Phase 1) is the participant-independent key that multi-hosted failover and dedup (Phase 2) depend on.
 
 ### 2. Implementation Mechanics
 
 **Architecture:**
 
 ```
-Canton Participant Node
+Canton Participant Node(s)
+   Phase 1: one LAPI endpoint
+   Phase 2: multiple participants hosting the same party set,
+            RecordTime-based failover + dedup across endpoints
      │
      │  JSON Ledger API (WebSocket)
-     │  subscribeToUpdates({ interfaceIds: [...Splice CIPs...] })
+     │  configurable interface / template subscription
      ▼
-┌─────────────────────────────────┐
-│       Ledger Ingester           │
-│  - Splice interface subscription│
-│  - Event classification         │
-│  - Batch pub to Redis pipeline  │
-│  - Exponential backoff reconnect│
-└──────────────┬──────────────────┘
+┌──────────────────────────────────────┐
+│       Ledger Ingester                │
+│  - Configurable subscription         │
+│  - Event classification              │
+│  - RecordTime ordering               │
+│  - Batch pub to Redis pipeline       │
+│  - Exponential-backoff reconnect     │
+│  - Phase 2: multi-host failover +    │
+│             reassignment events      │
+└──────────────┬───────────────────────┘
                │  Redis Pub/Sub
                │  channel: party:<partyId>
-               │  buffer:  eventbuf:<eventId> (5-min TTL)
+               │  ordering: RecordTime; resume index
                ▼
 ┌─────────────────────────────────┐
 │      Event Stream Server        │
 │  - WebSocket endpoint           │
 │  - SSE endpoint                 │
-│  - Multi-party subscription     │
-│  - Reconnect replay from buffer │
+│  - Per-party authorization      │
+│  - RecordTime resume            │
 │  - Token-based auth             │
 └──────────────┬──────────────────┘
                │
@@ -66,10 +75,10 @@ WebSocket clients     SSE clients
 
 **Workflow:**
 
-1. The Ledger Ingester connects to a Canton participant's JSON Ledger API and subscribes to ledger updates using Splice interface IDs (CIP-0056 token holdings + transfer instructions), with fallback to template-based subscription on nodes that do not yet support interface filtering.
-2. Raw DAML contract events are classified by parsing `templateId` and exercised choice names into human-readable typed events (`transfer.pending`, `transfer.executed`, `transfer.accepted`, `transfer.rejected`, `transfer.withdrawn`, `contract.created`, `contract.archived`).
+1. The Ledger Ingester connects to a Canton participant's JSON Ledger API and subscribes to a **configurable set of interfaces/templates** — operators declare what to subscribe to, with a pluggable classification mapping. The CIP-0056 token interfaces (holdings + transfer instructions) ship as the **default profile**, with fallback to template-based subscription on nodes that do not yet support interface filtering; the mechanism is general-purpose, not fixed to token assets.
+2. Raw DAML contract events are classified into human-readable typed events (`transfer.pending`, `transfer.executed`, `transfer.accepted`, `transfer.rejected`, `transfer.withdrawn`, `contract.created`, `contract.archived`) via the configured mapping.
 3. Events are routed by extracting `signatories`, `observers`, `witnessParties`, and `actingParties` across event types, then fanned out to subscribers via per-party Redis Pub/Sub channels. Subscribers are authorized per party at subscribe time — a client may only stream parties its credential is entitled to, re-establishing at the edge the per-party visibility boundary the participant enforces natively (and that is otherwise lost once clients are decoupled from the node for fanout).
-4. Events are buffered for 5 minutes to support reconnection replay via `lastEventId` — clients reconnect and request all buffered events since a given event ID without losing data.
+4. Events are ordered by **RecordTime** — Canton's participant-independent record timestamp, present on every update. Subscribers resume from a requested RecordTime ("send me everything since T") within a **configurable recent retention window** — a live-reconnect aid on the order of minutes to hours, **not a historical store**; deep historical replay is PQS's role, not this service's. The service maintains a RecordTime→offset index over that window to translate a requested time into a participant offset to resume from. (Choosing RecordTime over a participant-local offset is also what makes Phase-2 multi-hosted failover and dedup correct — see Phasing.)
 5. Application clients (browsers, mobile, server backends) connect to the Event Stream Server's WebSocket or SSE endpoint with a party-scoped token; they never connect to the participant node directly.
 6. The whole service ships as a single Docker image deployable alongside any Canton node, with Redis as its only persistent dependency.
 
@@ -80,13 +89,14 @@ WebSocket clients     SSE clients
   "eventId": "1220abc...def-uuid",
   "partyId": "alice::1220...",
   "type": "transfer.executed",
-  "timestamp": "2026-04-07T12:00:00.000Z",
+  "recordTime": "2026-04-07T12:00:00.123456Z",
   "data": {
     "contractId": "00abc...",
     "templateId": "Splice.Amulet:Amulet",
     "choice": "Transfer",
     "consuming": true,
     "updateId": "1220...",
+    "synchronizerId": "global-domain::1220...",
     "effectiveAt": "2026-04-07T12:00:00.000Z"
   }
 }
@@ -103,11 +113,17 @@ WebSocket clients     SSE clients
 | `transfer.withdrawn` | Withdraw choice exercised |
 | `contract.created` | Any non-transfer contract created |
 | `contract.archived` | Any contract archived |
+| `contract.unassigned` | Contract unassigned from a synchronizer (reassignment out) — *Phase 2* |
+| `contract.assigned` | Contract assigned to a synchronizer (reassignment in) — *Phase 2* |
 
-**Splice interface support** — interface-based subscription rather than template-based, making the ingester forward-compatible with new CIP-0056 token implementations without code changes:
+The event vocabulary above is the default profile; because the subscription set and classification mapping are configurable, operators can extend it to their own templates. The `unassigned`/`assigned` (reassignment) events matter for multi-synchronizer apps — without them, a contract moving between synchronizers is misread downstream as archive-then-create. They require ≥2 synchronizers to exercise and are delivered in **Phase 2** (see Phasing).
+
+**Subscription mechanism** — the ingester subscribes by **interface ID where available** (forward-compatible: a new template implementing an existing interface is picked up with no code change) and falls back to **template-based** subscription on nodes that don't yet support interface filtering. The subscription set is **operator-configurable**; the CIP-0056 token-standard interfaces ship as the default profile:
 
 - `#splice-api-token-holding-v1:Splice.Api.Token.HoldingV1:Holding`
 - `#splice-api-token-transfer-instruction-v1:Splice.Api.Token.TransferInstructionV1:TransferInstruction`
+
+Operators can add their own interfaces or templates to the set — the mechanism is general-purpose, not token-specific.
 
 **Stack:** TypeScript / Node.js, `@canton-network/wallet-sdk` for ledger access, Redis for fanout and replay buffer, single Docker image (~150 MB), Helm chart for Kubernetes deployment.
 
@@ -119,9 +135,11 @@ WebSocket clients     SSE clients
 
 **Complementary to PQS (CIP-0100)**: PQS is the pull layer (offset-paged SQL queries against a materialized Postgres ODS). Canton Event Stream is the push layer. Production applications need both. PQS exposes no LISTEN/NOTIFY, no change feed, no subscription primitive — it is exclusively offset-paged query functions. (Detailed comparison in Rationale below.)
 
-**CIP-0056 alignment**: Interface-based subscription means the ingester works with any CIP-0056 compliant token without modification, supporting the Canton multi-asset future.
+**CIP-0056 alignment**: The default subscription profile uses the CIP-0056 token-standard interfaces, so the ingester works with any compliant token without modification; the same interface-based mechanism extends to any other interface an operator configures — supporting the Canton multi-asset future.
 
-**Canton 3.5 alignment**: The compatibility matrix (M3) targets Canton 3.5+ explicitly, in line with the mid-June 2026 protocol upgrade.
+**Canton version alignment**: The service targets the current Canton 3.5 protocol line and tracks subsequent releases (see the Maintenance Plan); the M3 compatibility matrix covers Canton 3.5+ across Quickstart, DevNet, and a MainNet validator, plus Splice 0.5.x / 0.6.x.
+
+**Multi-hosted parties & multi-synchronizer (Phase 2)**: RecordTime ordering (Phase 1) is chosen precisely so the service is forward-compatible with multi-hosting and multi-synchronizer operation. In Phase 2, RecordTime — being participant-independent — is the key that lets the service fail over across the LAPI endpoints of participants hosting the same party set (party-based HA) and deduplicate events a multi-hosted party observes on more than one host; and the reassignment (`unassigned`/`assigned`) events let multi-synchronizer apps track contracts moving between synchronizers. Both require a multi-participant / multi-synchronizer environment to build and demonstrate.
 
 ### 4. Backward Compatibility
 
@@ -129,48 +147,44 @@ No backward compatibility impact. Canton Event Stream is additive infrastructure
 
 ---
 
-## Milestones and Deliverables
+## Phasing
 
-### Milestone 1: Standalone Package + Edge Authorization + Replay
-- **Estimated Delivery:** Week 3
-- **Focus:** Extract core ingester from Qasara's commercial gateway into a self-contained MIT-licensed package; build per-subscriber party authorization at the streaming edge; add reconnection replay.
+This grant funds **Phase 1** (the three milestones below) — everything that is demonstrable today on a single participant. **Phase 2** is a scoped follow-on, deliberately separated because it cannot be built or demonstrated without a multi-participant / multi-synchronizer testbed:
+
+- **Phase 1 (this grant):** standalone package, per-party authorization at the edge, RecordTime ordering + time-based resume, configurable subscriptions + pluggable classification, integration tests, AsyncAPI spec, production hardening, and a **CIP draft** standardizing the event-selection and classified-event model.
+- **Phase 2 (follow-on grant):** multi-hosted high availability (failover across the LAPI endpoints of participants hosting the same party set, with RecordTime-based dedup) and multi-synchronizer **reassignment** (`unassigned`/`assigned`) events. Phase 1's RecordTime ordering is the enabler, so Phase 2 is additive rather than a rewrite. Scoped and costed when a multi-node/multi-synchronizer testbed is available.
+
+## Milestones and Deliverables (Phase 1)
+
+### Milestone 1: Standalone Package + Edge Authorization + RecordTime Ordering
+- **Estimated Delivery:** Week 4
+- **Focus:** Extract the core ingester from Qasara's commercial gateway into a self-contained MIT-licensed package; build per-subscriber party authorization at the streaming edge; replace the buffer-based replay with RecordTime ordering and time-based resume.
 - **Deliverables / Value Metrics:**
-  - npm package decoupled from Qasara's auth, API key, and database systems
-  - Standalone configuration via environment variables only (no Prisma, no external DB dependency)
+  - npm package decoupled from Qasara's auth, API key, and database systems; configuration via environment variables only (no Prisma, no external DB)
   - Multi-auth support: sandbox HMAC, DevNet OAuth2 ClientCredentials, configurable per deployment
   - **Per-subscriber party authorization** — a client may only stream parties its credential is authorized for, enforced at subscribe time; re-establishes the node's per-party visibility boundary at the streaming edge
-  - `lastEventId` replay on reconnect (5-minute buffer window)
+  - **RecordTime ordering + resume** — events ordered by RecordTime; subscribers resume from a requested RecordTime via a RecordTime→offset index built from offset checkpoints
   - Docker image published to GitHub Container Registry
-  - Unit tests (≥80% coverage on ingester and event classification logic)
-  - GitHub Actions CI: lint, test, Docker build on every PR
+  - Unit tests (≥80% coverage on ingester, classification, ordering, and authorization logic); GitHub Actions CI: lint, test, Docker build on every PR
 
-### Milestone 2: Integration Tests + AsyncAPI Spec
-- **Estimated Delivery:** Week 6
-- **Focus:** Production-grade test coverage and developer-facing API documentation.
+### Milestone 2: Configurable Subscriptions + Integration Tests + AsyncAPI Spec
+- **Estimated Delivery:** Week 8
+- **Focus:** Make the subscription surface general-purpose, then lock behaviour with end-to-end tests and a published API contract.
 - **Deliverables / Value Metrics:**
-  - End-to-end integration test suite against Canton Quickstart in CI:
-    - WebSocket connect, subscribe, receive events, disconnect
-    - SSE connect, receive events, disconnect
-    - Stream token issue/use-once/reject-second-use
-    - `lastEventId` replay after disconnect
-    - Invalid token rejection
-    - Multi-party subscription routing
-  - AsyncAPI 3.0 specification for the classified event API (WebSocket and SSE), published and rendered as documentation — distinct from Canton's native AsyncAPI spec, which documents the raw-event transport; ours documents the application-level classified-event vocabulary and the subscribe/authorize handshake
-  - `docker-compose.yml` for local development (redis + canton-event-stream + Canton Quickstart)
-  - Published developer quickstart guide: zero-to-events in under 10 minutes
+  - **Configurable subscription set + pluggable classification** — operators declare which interfaces/templates to subscribe to and how they map to event types; CIP-0056 token interfaces ship as the default profile
+  - End-to-end integration test suite against Canton Quickstart in CI: WS/SSE connect-subscribe-receive-disconnect; stream-token issue/use-once/reject-reuse; RecordTime resume after disconnect; invalid-token and unauthorized-party rejection; multi-party routing
+  - AsyncAPI 3.0 specification for the classified event API (WS and SSE), published and rendered — distinct from Canton's native raw-event AsyncAPI spec; ours documents the classified-event vocabulary and the subscribe/authorize handshake
+  - `docker-compose.yml` (redis + canton-event-stream + Canton Quickstart) and a published quickstart guide
 
-### Milestone 3: Production Hardening + Community Onboarding
-- **Estimated Delivery:** Week 9
-- **Focus:** Make the service safely runnable on production validators and ready for community adoption.
+### Milestone 3: Production Hardening + CIP Draft + Community Onboarding
+- **Estimated Delivery:** Week 12
+- **Focus:** Make the service safely runnable on production validators, ready for community adoption, and propose the model for ecosystem standardization.
 - **Deliverables / Value Metrics:**
-  - Helm chart for Kubernetes deployment with configurable replicas, resource limits, and Redis connection settings
-  - Prometheus metrics endpoint (`/metrics`): active connections, events/sec, Redis publish latency, reconnect count
-  - Grafana dashboard JSON
-  - Structured JSON logging with configurable log level
+  - Helm chart (configurable replicas, resource limits, Redis settings); Prometheus `/metrics` (active connections, events/sec, publish latency, reconnect count) + Grafana dashboard JSON; structured JSON logging
   - Compatibility matrix: Canton Quickstart, Canton 3.5+ DevNet, MainNet validator (Canton 3.5+), Splice 0.5.x and 0.6.x
-  - Security checklist: stream token entropy, WebSocket connection limits, Redis ACL configuration guide
-  - Contributor guide and governance documentation
-  - 12-month maintenance commitment: security patches, Splice/SDK version compatibility updates, issue triage
+  - Security checklist: stream-token entropy, WebSocket connection limits, Redis ACL configuration guide
+  - **CIP draft** standardizing the event-selection model and the classified-event schema, with canton-event-stream as the reference implementation, submitted to the relevant SIG
+  - Contributor guide and governance docs; 12-month maintenance commitment (security patches, Splice/SDK compatibility updates, issue triage)
 
 ---
 
@@ -178,17 +192,20 @@ No backward compatibility impact. Canton Event Stream is additive infrastructure
 
 Acceptance is evaluated on **value demonstrated to the ecosystem**, per Canton Development Fund guidance — each milestone is judged by a working, usable capability, with artifacts (tests, images, docs) as supporting evidence rather than the criterion itself. Targets are scoped so value can be demonstrated directly — including via Qasara's own Canton Gateway (reference integration) and MainNet validator (reference deployment) — rather than depending on third-party adoption on a fixed schedule.
 
-### Milestone 1 — A usable, privacy-correct event layer exists
+### Milestone 1 — A usable, privacy-correct, correctly-ordered event layer exists
 - A developer outside the core team stands up the service from the published README and receives **classified** events from Canton Quickstart — and a client requesting a party its credential is not authorized for is **rejected at subscribe time**, demonstrated live. *(Supporting evidence: ≥80%-coverage unit suite green in CI; package runs with zero Qasara dependencies; image on npm/GHCR.)*
+- **RecordTime resume demonstrated:** a client reconnects with a requested RecordTime and receives the correctly-ordered events since that time, verified by automated test.
 - Qasara's Canton Gateway runs against the standalone package as the first reference integration, demonstrating the extraction is real and consumable.
 
-### Milestone 2 — A newcomer can adopt it quickly
-- An external tester with no prior Canton experience reaches a working event stream by following only the quickstart guide, **unassisted**. *(Design target: ~10 minutes of hands-on time once base images are pulled; the acceptance gate is unassisted success, not a stopwatch.)*
-- The documented API behaves as specified: the published AsyncAPI spec renders in standard tooling, and the integration suite — WS/SSE lifecycle, stream-token single-use, `lastEventId` replay, invalid-token and unauthorized-party rejection, multi-party routing — passes in CI as the evidence.
+### Milestone 2 — General-purpose and adoptable
+- **A new event type is added via configuration alone** (a template/interface not in the default profile is subscribed and classified) without code changes — demonstrating the subscription surface is general-purpose, not token-specific.
+- An external tester with no prior Canton experience reaches a working event stream by following only the quickstart guide, **unassisted**. *(Design target: ~10 minutes of hands-on time once base images are pulled; the gate is unassisted success, not a stopwatch.)*
+- The documented API behaves as specified: the published AsyncAPI spec renders in standard tooling, and the integration suite — WS/SSE lifecycle, stream-token single-use, RecordTime resume, invalid-token and unauthorized-party rejection, multi-party routing — passes in CI as the evidence.
 
-### Milestone 3 — It runs in production and is community-maintainable
+### Milestone 3 — It runs in production, is community-maintainable, and proposes a standard
 - ≥1 production-track deployment running alongside a validator — **Qasara's own MainNet validator as the reference deployment** — verifiable live by the committee.
 - Operational readiness demonstrated: Helm deploy on a real multi-node cluster; Prometheus metrics + Grafana dashboard; and a published compatibility matrix across the listed environments (Canton Quickstart, Canton 3.5+ DevNet, MainNet validator, Splice 0.5.x/0.6.x).
+- **CIP draft submitted** to the relevant SIG, standardizing the event-selection and classified-event model with this service as the reference implementation.
 - Community-ready: security checklist submitted for committee review; contributor guide published; documented 12-month maintenance commitment (SECURITY.md, release/versioning policy).
 
 Broader external adoption — multiple third-party integrations and production deployments — is the longer-horizon measure of success; it is tracked and reported transparently after M3 (see Motivation for the 12-month projection) and is not a milestone payment gate.
@@ -197,16 +214,18 @@ Broader external adoption — multiple third-party integrations and production d
 
 ## Funding
 
-**Total Funding Request:** 300,000 CC
+**Total Phase 1 Funding Request:** 300,000 CC
 
-### Payment Breakdown by Milestone
-- Milestone 1 (Standalone Package + Replay): **120,000 CC** upon committee acceptance
-- Milestone 2 (Integration Tests + AsyncAPI Spec): **100,000 CC** upon committee acceptance
-- Milestone 3 (Production Hardening + Community Onboarding): **80,000 CC** upon final release and acceptance
+### Payment Breakdown by Milestone (Phase 1)
+- Milestone 1 (Standalone Package + Edge Authorization + RecordTime Ordering): **120,000 CC** upon committee acceptance
+- Milestone 2 (Configurable Subscriptions + Integration Tests + AsyncAPI Spec): **100,000 CC** upon committee acceptance
+- Milestone 3 (Production Hardening + CIP Draft + Community Onboarding): **80,000 CC** upon final release and acceptance
+
+**Phase 2** (multi-hosted HA + multi-synchronizer reassignment) is **not funded by this grant**; it will be scoped and costed as a follow-on once a multi-participant / multi-synchronizer testbed is available.
 
 ### Volatility Stipulation
 
-Project duration is **under 6 months** (9 weeks planned). Should the project timeline extend beyond 6 months due to Committee-requested scope changes, any remaining milestones must be renegotiated to account for significant USD/CC price volatility.
+Phase 1 duration is **under 6 months** (12 weeks planned). Should the timeline extend beyond 6 months due to Committee-requested scope changes, any remaining milestones must be renegotiated to account for significant USD/CC price volatility.
 
 ---
 
@@ -269,7 +288,7 @@ CIP-0100 (PR #67, merged 2026-04-23) approved Digital Asset's grant to open-sour
 | **Authentication** | PostgreSQL roles | App-layer party-scoped tokens |
 | **Event shape** | Decoded contracts in JSONB; clients implement classification | Pre-classified app events (`transfer.executed`, `transfer.rejected`, etc.) |
 | **Hot-path latency** | Ledger API → PQS write → Postgres → poll | Ledger API → Redis pub/sub → WebSocket push (no DB write in the hot path) |
-| **Reconnection model** | Client tracks Postgres offset; bespoke replay logic | `lastEventId` against a 5-minute event buffer, designed for browser reconnect |
+| **Reconnection model** | Client tracks Postgres offset; bespoke replay logic | Resume from a requested **RecordTime** within a recent window (participant-independent); deep history via PQS, not this service |
 | **Footprint** | JVM (4 GB / 4 cores min.) plus Postgres (8 GB / 8 cores min.) | Node.js (~150 MB image), Redis only |
 
 The [PQS SQL API documentation](https://docs.digitalasset.com/build/3.5/component-howtos/pqs/references/sql-api.html) confirms the consumer-facing interface is exclusively offset-paged query functions — no LISTEN/NOTIFY, no change feed, no subscription primitive. Adding push to PQS would require building exactly this proposal inside a JVM project, which forces a JVM dependency on every dApp consumer (the very dependency many builders are trying to avoid).
@@ -289,13 +308,19 @@ The moment an application introduces a fanout tier to serve many clients from on
 | **Client topology** | One node subscription per client; each holds a ledger token | One upstream subscription; many clients, none touching the node |
 | **Event shape** | Raw `Created`/`Archived`/`Exercised` | Classified CIP-0056 vocabulary (`transfer.executed`, …) |
 | **Participant exposure** | Every client connects to the participant | Only the gateway connects to the participant |
-| **Reconnection** | Client tracks offset / `OffsetCheckpoint`s | `lastEventId` against a 5-minute buffer (no client-side offset persistence) |
+| **Reconnection** | Client tracks per-participant offset / `OffsetCheckpoint`s | Resume from a requested **RecordTime** (no client-side offset persistence; participant-independent) |
 
-In short: the native WS/gRPC layer is the origin transport; Canton Event Stream is the reverse-proxy/edge above it — classification, per-party-authorized fanout, and a participant-shielding boundary. It composes with the native layer the same way it composes with PQS on the pull side. It only ever delivers events for parties an operator is authorized to read; by Canton's authorization model it cannot expose third-party private events.
+In short: the native WS/gRPC layer is the origin transport; Canton Event Stream is the reverse-proxy/edge above it — classification, per-party-authorized fanout, RecordTime ordering, and a participant-shielding boundary. It composes with the native layer the same way it composes with PQS on the pull side. It only ever delivers events for parties an operator is authorized to read; by Canton's authorization model it cannot expose third-party private events.
+
+**On the scaling benefit (fan-in vs 1-1 passthrough).** The fan-in advantage is real specifically in the **operator-hosted** deployment — the target user (exchange, custodian, fintech) is authorized for many parties and opens one (or a few) multi-party subscriptions, which the service fans out to that operator's many downstream consumers. The decoupling is *downstream client connections ≠ upstream node subscriptions*: thousands of user-facing connections collapse to a handful of upstream subscriptions, and the participant is shielded from direct per-client connections each bearing a ledger token. We state the limit honestly: if instead each party is externally owned and self-subscribes with its own JWT for only its own party, there is no subscription-dedup benefit — in that model the value is connection multiplexing, classification, per-party-authorized delivery, and RecordTime-resumable ordering, not subscription dedup.
+
+### Why standardize via a CIP
+
+This service classifies raw ledger events into a stable application vocabulary and defines how a subscriber selects and authorizes the events it wants. That selection-and-classification model is exactly the kind of thing the ecosystem benefits from agreeing on once, rather than each team inventing incompatible event names and subscribe semantics. Accordingly, Phase 1 includes a **CIP draft** standardizing (a) the event-selection / subscribe model and (b) the classified-event schema, with canton-event-stream as the reference implementation. This turns the work from a single service into a standard plus a reference implementation — the stronger ecosystem outcome — and we will sequence the CIP draft alongside the implementation so the two co-evolve.
 
 ### Why TypeScript / Node.js
 
-Existing Canton event indexing work in the ecosystem is JVM-based (Scala). The Canton SDK itself is TypeScript-native (`@canton-network/wallet-sdk`). For teams already running a Node.js application stack — the majority of dApp and fintech developers — a TypeScript implementation:
+The ecosystem's event-indexing component — PQS (scribe), distributed as a Java JAR on a Scala/ZIO stack — is JVM-based, as is Canton itself; there is no standalone non-JVM indexer (the TypeScript and Go offerings are client SDKs, not indexers). The Canton SDK itself is TypeScript-native (`@canton-network/wallet-sdk`). For teams already running a Node.js application stack — the majority of dApp and fintech developers — a TypeScript implementation:
 
 - Eliminates a JVM dependency from their infrastructure
 - Uses the same SDK they are already familiar with
@@ -304,9 +329,9 @@ Existing Canton event indexing work in the ecosystem is JVM-based (Scala). The C
 
 JVM-stack consumers are not excluded — the WebSocket and SSE endpoints are language-neutral wire protocols, so any client (Java, Python, Rust, Go) connects without a Node.js runtime on its side.
 
-### Why interface-based subscription
+### Why interface-based subscription (with a configurable set)
 
-Building this on top of template-based subscription would lock the ecosystem into per-token rewrites every time a new asset launches; building on Splice interfaces (CIP-0056) means the ingester works with any compliant token without modification, supporting the Canton multi-asset future. The fallback to empty-template subscription preserves compatibility with nodes that do not yet support interface filtering.
+The subscription set is operator-configurable, so the service is not tied to one asset family. Within that, subscribing by interface ID — rather than enumerating individual templates — means a new template implementing an existing interface is picked up with no code change. For the default token profile this matters because any CIP-0056-compliant token works without modification, supporting the Canton multi-asset future; the same mechanism applies to any interface an operator configures. Template-based subscription (and an empty-template fallback) preserves compatibility with nodes that do not yet support interface filtering.
 
 ### Coexistence on the same validator
 
@@ -333,10 +358,12 @@ PQS and Canton Event Stream are independent of one another and can run on the sa
 
 ## Notes for Reviewers
 
-1. **Core transport implementation exists today; edge authorization is the net-new build.** This is not a greenfield design proposal. The ledger ingester (Splice interface subscription, exponential backoff reconnect), Redis Pub/Sub fanout with batch pipeline, WebSocket endpoint, and SSE endpoint are all implemented and running in our DevNet environment as part of the Qasara Canton Gateway. The one piece of genuinely new engineering this grant funds is **per-subscriber party authorization at the streaming edge** (M1) — re-establishing, outside the participant, the per-party visibility boundary the node enforces natively; in the commercial gateway this is currently coupled to Qasara's API-key system, and the open-source version requires a clean, credential-agnostic implementation. The remaining milestone work is packaging, decoupling from Qasara's auth/DB systems, the `lastEventId` replay query, and production hardening (Helm chart, metrics, standalone Docker image). In short: the transport and classification are proven; the authorization layer and the productionization are what the milestones build.
+1. **Core transport and classification exist today; the net-new engineering is authorization, RecordTime ordering, and generalization.** This is not a greenfield design proposal. The ledger ingester (Splice interface subscription, exponential-backoff reconnect), Redis Pub/Sub fanout with batch pipeline, WebSocket endpoint, and SSE endpoint are all implemented and running in our DevNet environment as part of the Qasara Canton Gateway — so the transport and event classification are proven. What this grant funds as genuinely new work is: (a) **per-subscriber party authorization at the streaming edge** (currently coupled to Qasara's API-key system; the open-source version needs a clean, credential-agnostic implementation), (b) **RecordTime ordering + time-based resume** (replacing the current ephemeral event-id buffer with a participant-independent ordering key), and (c) **configurable subscriptions + pluggable classification** to make the surface general-purpose rather than token-specific — plus packaging, decoupling, and production hardening. We are deliberately not claiming "it's just repackaging."
 
 2. **TypeScript choice is intentional.** The Canton Wallet SDK is TypeScript-native. Most dApp developers are TypeScript-first. A JVM-free event stream reduces the operational complexity for the majority of Canton builders, while the language-neutral wire protocols (WebSocket + SSE) keep JVM consumers fully supported.
 
 3. **Commercial relationship.** Qasara operates a hosted version of this infrastructure as part of our commercial Canton Gateway API. The open-source version does not include our API key management, rate limiting, or billing tier logic — those remain part of the commercial product. This is analogous to Uniswap publishing open-source contracts while running a commercial interface.
+
+4. **Phasing reflects what can be demonstrated, not appetite.** Multi-hosted HA and multi-synchronizer reassignment (Phase 2) are deliberately separated because they cannot be built or demonstrated on a single participant / single synchronizer — they require a multi-participant, multi-synchronizer testbed. Phase 1's RecordTime ordering is chosen specifically so Phase 2 is additive (RecordTime is the participant-independent key that multi-hosted failover and dedup depend on). We would rather commit Phase 1 to deliverables we can demonstrate on infrastructure available today and scope Phase 2 once a suitable testbed exists, than over-promise both in one grant.
 
 

--- a/proposals/canton-event-stream.md
+++ b/proposals/canton-event-stream.md
@@ -34,38 +34,6 @@ This proposal funds **Phase 1** — the application-edge layer that is fully dem
 
 **Architecture:**
 
-```mermaid
-flowchart TD
-    subgraph NODE["Canton participant node(s)"]
-      LAPI["JSON Ledger API (WebSocket updates)<br/>Phase 1: one endpoint<br/>Phase 2: several participants host the same parties"]
-    end
-
-    PROF["Profile (operator config, loaded at startup)<br/>subscribe / classify / payload<br/>default = token standard V1 + V2"]
-
-    subgraph CES["Canton Event Stream: single Docker image (Redis is the only dependency)"]
-      ING["Ledger Ingester<br/>one upstream subscription<br/>classify to named events + token payload<br/>RecordTime ordering, backoff reconnect<br/>Phase 2: multi-host failover + dedup"]
-      REDIS[("Redis<br/>per-party channels (party:&lt;id&gt;)<br/>RecordTime replay buffer (minutes to hours)")]
-      SRV["Event Stream Server<br/>token auth + per-party authorization<br/>WebSocket + SSE, RecordTime resume"]
-      ING -->|"publish party:&lt;id&gt;"| REDIS
-      REDIS --> SRV
-    end
-
-    subgraph CLIENTS["Application clients (party-scoped token, never touch the node)"]
-      DAPP["Browser dApp"]
-      MOB["Mobile app"]
-      BE["Server backend / monitor"]
-    end
-
-    LAPI -->|"one WS subscription"| ING
-    PROF -.->|"config"| ING
-    SRV -->|"classified events (WS/SSE)"| DAPP
-    SRV --> MOB
-    SRV --> BE
-    DAPP -.->|"subscribe / unsubscribe partyIds"| SRV
-```
-
-<details><summary>Same architecture as ASCII (for raw-markdown viewers)</summary>
-
 ```
 Canton Participant Node(s)
    Phase 1: one LAPI endpoint
@@ -109,6 +77,38 @@ WebSocket clients        SSE clients
 (browser dApps)        (server backends,
  subscribe [alice],     monitoring tools)
  later +[bob] −[alice]   partyIds set at connect
+```
+
+<details><summary>Same diagram in Mermaid (renders in GitHub's file view)</summary>
+
+```mermaid
+flowchart TD
+    subgraph NODE["Canton participant node(s)"]
+      LAPI["JSON Ledger API (WebSocket updates)<br/>Phase 1: one endpoint<br/>Phase 2: several participants host the same parties"]
+    end
+
+    PROF["Profile (operator config, loaded at startup)<br/>subscribe / classify / payload<br/>default = token standard V1 + V2"]
+
+    subgraph CES["Canton Event Stream: single Docker image (Redis is the only dependency)"]
+      ING["Ledger Ingester<br/>one upstream subscription<br/>classify to named events + token payload<br/>RecordTime ordering, backoff reconnect<br/>Phase 2: multi-host failover + dedup"]
+      REDIS[("Redis<br/>per-party channels (party:&lt;id&gt;)<br/>RecordTime replay buffer (minutes to hours)")]
+      SRV["Event Stream Server<br/>token auth + per-party authorization<br/>WebSocket + SSE, RecordTime resume"]
+      ING -->|"publish party:&lt;id&gt;"| REDIS
+      REDIS --> SRV
+    end
+
+    subgraph CLIENTS["Application clients (party-scoped token, never touch the node)"]
+      DAPP["Browser dApp"]
+      MOB["Mobile app"]
+      BE["Server backend / monitor"]
+    end
+
+    LAPI -->|"one WS subscription"| ING
+    PROF -.->|"config"| ING
+    SRV -->|"classified events (WS/SSE)"| DAPP
+    SRV --> MOB
+    SRV --> BE
+    DAPP -.->|"subscribe / unsubscribe partyIds"| SRV
 ```
 
 </details>

--- a/proposals/canton-event-stream.md
+++ b/proposals/canton-event-stream.md
@@ -9,7 +9,7 @@
 # Canton Event Stream — Real-Time Ledger Events via WebSocket & SSE
 
 > Canton Development Fund Proposal
-> Phase 1 funding request: 300,000 CC across 3 milestones. Build (M1, M2, and the M3 release) is ~12 weeks; the M3 external-adoption window runs up to 6 months. The final milestone is 50% of the grant, released when the service is adopted by at least 3 independent teams on MainNet.
+> Phase 1 funding request: 300,000 CC across 3 milestones. Build (M1, M2, and the M3 release) is ~14 weeks; the M3 external-adoption window runs up to 6 months. The final milestone is 50% of the grant, released when the service is adopted by at least 3 independent teams on MainNet.
 > Phase 2 (multi-hosted HA + multi-synchronizer reassignment) is scoped as a follow-on grant requiring a multi-participant / multi-synchronizer testbed — see **Phasing**.
 
 ---
@@ -115,15 +115,25 @@ flowchart TD
 
 **Workflow:**
 
-1. The Ledger Ingester connects to a Canton participant's JSON Ledger API and subscribes to a **configurable set of interfaces/templates** — operators declare what to subscribe to, with a pluggable classification mapping. The CIP-0056 (Token Standard V1) token interfaces (holdings + transfer instructions) ship as the **default profile**, alongside CIP-0112 (Token Standard V2, now live on DevNet) — whose dedicated transfer-events surface (holdings-change events) lets the ingester read transfer events directly instead of inferring them from exercised choices. Both fall back to template-based subscription on nodes that do not yet support interface filtering, and the mechanism is general-purpose, not fixed to token assets.
-2. Raw DAML contract events are classified into human-readable typed events (`transfer.pending`, `transfer.executed`, `transfer.accepted`, `transfer.rejected`, `transfer.withdrawn`, `contract.created`, `contract.archived`) via the configured mapping.
-3. Events are routed by extracting `signatories`, `observers`, `witnessParties`, and `actingParties` across event types, then fanned out to subscribers via per-party Redis Pub/Sub channels. Subscribers are authorized per party at subscribe time — a client may only stream parties its credential is entitled to, re-establishing at the edge the per-party visibility boundary the participant enforces natively (and that is otherwise lost once clients are decoupled from the node for fanout). The token-based mechanism is detailed under **Authorization model** below.
+1. The Ledger Ingester connects to a Canton participant's JSON Ledger API and subscribes to a **configurable set of interfaces/templates** — operators declare what to subscribe to, with a pluggable classification mapping. The CIP-0056 (Token Standard V1) token interfaces (holdings + transfer instructions) ship as the **default profile**. CIP-0112 (Token Standard V2) extends V1 rather than replacing it — assets implement both — and its `EventLog` interface reports holdings changes as first-class events instead of leaving them to be inferred from choice names, so the default profile covers both where the target network has V2. V2 shipped in Splice 0.6.11 (amulet 0.1.21); because interface packages are vetted per participant, operators should probe their own node for the v2 packages rather than assume them. Both fall back to template-based subscription on nodes that do not yet support interface filtering, and the mechanism is general-purpose, not fixed to token assets.
+2. The ingester subscribes with the **ledger-effects** transaction shape. Both token-standard versions need it. In V1, accept, reject and withdraw are all consuming choices on the same `TransferInstruction`, so ACS-delta shows the same archive for each one and the outcome has to be guessed from the surrounding creates. Ledger-effects carries the choice name, which is what we classify on. In V2, `EventLog_HoldingsChange` is nonconsuming, so it creates and archives nothing and never appears in ACS-delta at all.
+
+   Those raw events are then mapped to named types (`transfer.pending`, `transfer.executed`, `transfer.accepted`, `transfer.rejected`, `transfer.withdrawn`, `contract.created`, `contract.archived`) by the configured profile.
+
+   **Downstream we distribute neither raw shape.** Subscribers get the classified events. We also don't rebuild an ACS-delta view, because that isn't a stateless transform: a consuming exercise doesn't carry the archived contract's stakeholders, so the event alone can't say whether it belongs in a given party's ACS. Consumers who need a per-party ACS mirror should use PQS or their own Ledger API subscription.
+3. **We use the participant's privacy projection rather than recomputing it.** The ingester holds one multi-party subscription. The participant works out who may see each event and puts that on the wire as `witnessParties`, which is present on every event we handle. Routing is then a set intersection: an event's `witnessParties` against the parties a subscriber is authorized for. Matching events go out on per-party Redis Pub/Sub channels.
+
+   Nothing about stakeholders, observers or divulgence is re-derived. We also never split below **party** level, so users sharing one party all receive that party's stream. The party is Canton's unit of privacy and we keep it that way.
+
+   Subscribers are authorized per party when they subscribe. That restores at the edge the boundary the node enforces on its own subscriptions, which is otherwise lost once clients sit behind a fanout tier. The token mechanism is described under **Authorization model** below.
 4. Events are ordered by **RecordTime** — Canton's participant-independent record timestamp, present on every update. RecordTime alone is not unique: one transaction stamps all its events with the same value, and separate transactions can share an instant. So the resume cursor is the tuple **`(synchronizerId, recordTime, updateId, nodeIndex)`**, ordered per synchronizer and resumed **exclusive** of the last event the subscriber processed — `recordTime` selects the instant, `updateId` the transaction within it, `nodeIndex` the event within that transaction. Every component is assigned by the synchronizer, so the cursor is portable across participants, and the exclusive boundary yields neither duplicates nor a gap across a reconnect. (Choosing RecordTime over a participant-local offset is also what makes Phase-2 multi-hosted failover and dedup correct — see Phasing.)
 5. Resume is bounded to a **configurable recent retention window** — a live-reconnect aid on the order of minutes to hours, **not a historical store**; deep historical replay is PQS's role, not this service's. Subscribers resume from a cursor, or from a plain "everything since T" which the server resolves to one. Over that window the service maintains a RecordTime→offset index, since the native resume boundary is offset-based and a requested time has to be translated into a participant offset to subscribe from.
 6. Application clients (browsers, mobile, server backends) connect to the Event Stream Server's WebSocket or SSE endpoint with a short-lived token identifying the user; they never connect to the participant node directly.
 7. The whole service ships as a single Docker image deployable alongside any Canton node, with Redis as its only persistent dependency.
 
-**Authorization model** — the server re-creates the node's per-party visibility boundary at the streaming edge using short-lived, single-use tokens plus a party lookup it performs itself:
+**Authorization model** — the server re-creates the node's per-party visibility boundary at the streaming edge using short-lived, single-use tokens plus a party lookup it performs itself.
+
+*Why the check exists at all, given the node already enforces this.* The node enforces per-party visibility **on the subscription**. Any fanout tier — this service or one a team builds itself — removes that enforcement from the downstream path, so whatever sits there must re-establish it. The alternative is one node subscription per end-user session, which puts a token carrying real ledger authority in every browser and thousands of streaming connections on the participant. This is not a substitute authorization model: with the default resolver the party set is read from the participant's own user rights, so the node remains the source of truth and the edge only enforces its answer one hop out.
 
 - *Who issues tokens.* The operator running the service, or their existing identity system. The issuer's only required job is to assert **who the user is**; it does not need to know Canton party IDs. The server does not decide party ownership; it only accepts tokens signed by an issuer it is configured to trust (a shared key or a JWKS URL). This mirrors what the participant itself does with an IdP-signed JWT: the token carries a subject, and party rights are resolved separately.
 - *Party resolution is pluggable.* Three sources ship: **(a) participant user-rights**, where the server reads the authenticated user's `CanActAs`/`CanReadAs` grants from the participant's user-management API; **(b) operator mapping**, a lookup the operator supplies from its own user directory; **(c) explicit party list in the token**, for issuers that already hold the mapping. Which source is correct depends on how the operator provisions identities. Where each person has their own ledger user, the participant is the authoritative mapping and (a) requires nothing to be synced into the identity system. Where an operator fronts many customer parties with a single shared service account, the participant cannot distinguish those users, so (b) is the only correct source and (a) would over-grant. The resolver interface, these three implementations, and that guidance are the net-new open-source work. (Qasara's commercial gateway uses (b) today, tied to its API-key system.)
@@ -132,6 +142,14 @@ flowchart TD
 - *What the resolver needs.* Resolver (a) needs a participant credential with read access to user rights; (b) needs a lookup endpoint on the operator's side. Resolved party sets are cached for a short, configurable interval to keep subscribe latency low.
 - *Session lifetime and revocation.* The token authorizes the handshake, not the whole session, so a session has a bounded life and the client re-presents a fresh token in-band before it lapses; a normal expiry is invisible to the user. Revocation depends on who revokes. An operator revoking a credential or a mapping signals the service, which closes the affected streams immediately with a distinct close code. A grant revoked directly on the participant has no notification channel — user rights are participant-local admin state and a rights change produces no ledger update, so nothing can push it to us — and is therefore picked up when the cached party set is next re-resolved. That bounds exposure to the cache interval rather than the length of the session, which makes the interval a security setting and not only a performance one.
 - *Optional node-side check.* With resolvers (b) and (c) the service can additionally confirm with the participant that rights for a requested party actually exist, so a mis-issued token or a stale operator mapping cannot grant more than the node allows. This bounds a request to the party set the operator genuinely holds; it cannot confirm that a particular user owns a particular party, since only the operator knows that. With resolver (a) the check is inherent, because the party set already comes from the node.
+
+**dApp integration (how a dApp finds and consumes the stream)** — a dApp knows nothing about the network except what its wallet tells it. So the service has to fit the CIP-0103 wallet-to-dApp architecture, not sit beside it.
+
+- *The stream is the part you can expose.* Providers keep the Ledger API private because it is the raw node: a broad surface, with tokens that carry real ledger authority. This service is built to be exposed instead. It is narrow, classified, authorized per party, and clients never touch the node. So a provider who wants their participant private gets that by running the service and exposing it, rather than hiding both. The same holds for hosted wallets. One exposed instance serves all of a provider's user sessions. Relaying events through the wallet backend instead turns that backend into a second fanout tier doing the same job.
+- *Discovery is one optional field.* The wallet already gives the dApp an endpoint and an access token through CIP-0103's `status` / `getActiveNetwork`. A provider running this service adds the event-stream URL alongside them. No field means no service, and the dApp carries on as it does today. The change is additive, so CIP-0103's own versioning rule means no amendment is needed. We specify the field in the Phase-1 CIP draft, and it can move into CIP-0103 if its maintainers prefer.
+- *No new credentials for the dApp.* It connects with the token it already has for direct ledger reads, and we verify that token against the same issuer the participant trusts. If the token names parties in its ledger-api claim, we use those (resolver c). If it carries a subject for a ledger user, we resolve that user's rights from the participant (resolver a). Either way this reuses the Ledger API authorization model instead of adding a second one.
+- *Direct by default, proxying as a fallback.* CIP-0103 avoids proxying reads through a remote wallet because of the extra hop, and an event stream is a read. For fully closed deployments, a wallet can hold the subscription itself and relay events over its existing dApp-API event channel. The classified event schema is standardized, so both paths deliver identical events. A dApp writes one handler and the transport becomes a deployment detail.
+- *Deployment models.* For browser extensions, the **page** holds the WebSocket, not the extension's background worker. Worker suspension is therefore not a factor, and it is the same thing the page would do for the Ledger API. The extension only passes the endpoint and token through. Desktop wallets work either way. Hosted wallets are where direct connection matters most, for the fanout reason above.
 
 **Event format** — all events follow a consistent schema regardless of source:
 
@@ -189,13 +207,14 @@ A **profile** is the operator-configurable unit, and it defines three things: (1
 subscribe:                        # (1) interfaces to pull (template fallback per node)
   - "#splice-api-token-holding-v1:Splice.Api.Token.HoldingV1:Holding"
   - "#splice-api-token-transfer-instruction-v1:Splice.Api.Token.TransferInstructionV1:TransferInstruction"
-  - "#splice-api-token-transfer-events-v2:...:HoldingsChange"   # CIP-0112 V2 transfer-events
+  # CIP-0112 V2 EventLog — include where the target node has the v2 packages vetted
+  - "#splice-api-token-transfer-events-v2:Splice.Api.Token.TransferEventsV2:EventLog"
 classify:                         # (2) raw event -> named type
   TransferInstruction.created:    transfer.pending
   TransferInstruction.Accept:     transfer.accepted
   TransferInstruction.Reject:     transfer.rejected
   TransferInstruction.Withdraw:   transfer.withdrawn
-  HoldingsChange:                 transfer.executed    # V2 read-events surface
+  EventLog_HoldingsChange:        transfer.executed    # V2 event surface, read not inferred
   "*.created":                    contract.created
   "*.archived":                   contract.archived
 payload:                          # (3) token fields -> event.payload
@@ -222,7 +241,13 @@ Operators can add interfaces/templates and classification rules to this profile,
 
 ### 4. Backward Compatibility
 
-No backward compatibility impact. Canton Event Stream is additive infrastructure that subscribes to the existing JSON Ledger API; it does not modify Canton, Splice, or any existing client interface. Validators electing to deploy it run a new sidecar Docker container — no changes to their participant node, no schema migrations, no client breakage.
+No backward compatibility impact on Canton. Canton Event Stream is additive infrastructure that subscribes to the existing JSON Ledger API; it does not modify Canton, Splice, or any existing client interface. Validators electing to deploy it run a new sidecar Docker container — no changes to their participant node, no schema migrations, no client breakage.
+
+**Compatibility model** — the service has three surfaces, each with its own guarantee:
+
+- *Client-facing (the classified event schema and subscribe semantics).* Versioned; additive within a major version, so new event types and new payload fields never break an existing consumer. The published AsyncAPI specification is the contract, and the Phase-1 CIP draft is the change process for the event vocabulary itself, so changes are proposed in the open rather than shipped unilaterally.
+- *Upstream (the Ledger API).* The service consumes JSON Ledger API v2 and tracks the current protocol line. Milestone 3 publishes a tested compatibility matrix — Canton 3.5+ across Quickstart, DevNet and a MainNet validator, plus Splice 0.5.x and 0.6.x — backed by a documented 12-month maintenance commitment for security patches and Splice/SDK compatibility updates.
+- *DAML package upgrades.* Subscriptions and classification key on **package-name aliases and interface IDs**, not pinned package IDs, so a Splice or token-standard package upgrade is picked up without a code or config change. This is also why the V1/V2 transition is a profile change rather than a rewrite. Resume cursors are participant-independent, so they remain valid across service restarts and, in Phase 2, across a failover to another participant hosting the same parties.
 
 ---
 
@@ -236,29 +261,30 @@ This grant funds **Phase 1** (the three milestones below) — everything that is
 ## Milestones and Deliverables (Phase 1)
 
 ### Milestone 1: Standalone Package + Edge Authorization + RecordTime Ordering
-- **Estimated Delivery:** Week 4
-- **Focus:** Extract the core ingester from Qasara's commercial gateway into a self-contained Apache 2-licensed package; build per-subscriber party authorization at the streaming edge; replace the buffer-based replay with RecordTime ordering and cursor-based resume.
+- **Estimated Delivery:** Week 6
+- **Focus:** Extract the core ingester from Qasara's commercial gateway into a self-contained Apache 2-licensed package; build per-subscriber party authorization at the streaming edge, including pluggable party resolution; replace the buffer-based replay with RecordTime ordering and cursor-based resume.
 - **Deliverables / Value Metrics:**
   - npm package decoupled from Qasara's auth, API key, and database systems; configuration via environment variables only (no Prisma, no external DB)
   - Multi-auth support: sandbox HMAC, DevNet OAuth2 ClientCredentials, configurable per deployment
   - **Per-subscriber party authorization** — a client may only stream parties its credential is authorized for, enforced at subscribe time; re-establishes the node's per-party visibility boundary at the streaming edge
   - **Pluggable party resolver** — participant user-rights, operator mapping, and token-claim implementations behind one interface, with published guidance on which source is correct for which identity topology (and which is unsafe where)
-  - **Session lifetime + revocation handling** — bounded sessions with in-band re-auth, and active teardown of affected streams when a credential or party grant is revoked
   - **RecordTime ordering + resume** — events ordered by RecordTime; subscribers resume from a `(synchronizerId, recordTime, updateId, nodeIndex)` cursor via a RecordTime→offset index built from offset checkpoints
   - Docker image published to GitHub Container Registry
   - Unit tests (≥80% coverage on ingester, classification, ordering, and authorization logic); GitHub Actions CI: lint, test, Docker build on every PR
 
-### Milestone 2: Configurable Subscriptions + Integration Tests + AsyncAPI Spec
-- **Estimated Delivery:** Week 8
-- **Focus:** Make the subscription surface general-purpose, then lock behaviour with end-to-end tests and a published API contract.
+### Milestone 2: Configurable Subscriptions + Session Lifecycle + Integration Tests + AsyncAPI Spec
+- **Estimated Delivery:** Week 11
+- **Focus:** Make the subscription surface general-purpose, complete the session and revocation lifecycle on long-lived channels, then lock behaviour with end-to-end tests and a published API contract.
 - **Deliverables / Value Metrics:**
   - **Configurable subscription set + pluggable classification** — operators declare which interfaces/templates to subscribe to and how they map to event types; CIP-0056 token interfaces ship as the default profile
+  - **Session lifetime + revocation handling** — bounded sessions with in-band re-auth so a normal token expiry is invisible to the user, and active teardown of affected streams (distinct close code) when a credential or operator mapping is revoked
+  - **dApp integration surface** — the event-stream endpoint advertised through CIP-0103 network parameters, acceptance of the wallet-issued access token, and the documented proxy fallback for closed deployments
   - End-to-end integration test suite against Canton Quickstart in CI: WS/SSE connect-subscribe-receive-disconnect; stream-token issue/use-once/reject-reuse; RecordTime resume after disconnect; invalid-token and unauthorized-party rejection; multi-party routing
   - AsyncAPI 3.0 specification for the classified event API (WS and SSE), published and rendered — distinct from Canton's native raw-event AsyncAPI spec; ours documents the classified-event vocabulary and the subscribe/authorize handshake
   - `docker-compose.yml` (redis + canton-event-stream + Canton Quickstart) and a published quickstart guide
 
 ### Milestone 3: Production Release + CIP Draft + External MainNet Adoption
-- **Estimated Delivery:** production release by Week 12; the external-adoption window runs up to 6 months after the M2 release.
+- **Estimated Delivery:** production release by Week 14; the external-adoption window runs up to 6 months after the M2 release.
 - **Focus:** Make the service safely runnable on production validators, get it adopted by independent community teams on MainNet, and propose the model for ecosystem standardization.
 - **Deliverables / Value Metrics:**
   - Helm chart (configurable replicas, resource limits, Redis settings); Prometheus `/metrics` (active connections, events/sec, publish latency, reconnect count) + Grafana dashboard JSON; structured JSON logging
@@ -283,7 +309,8 @@ Acceptance is evaluated on **value demonstrated to the ecosystem**, per Canton D
 ### Milestone 2 — General-purpose and adoptable
 - **A new event type is added via configuration alone** (a template/interface not in the default profile is subscribed and classified) without code changes — demonstrating the subscription surface is general-purpose, not token-specific.
 - An external tester with no prior Canton experience reaches a working event stream by following only the quickstart guide, **unassisted**. *(Design target: ~30 minutes of hands-on time once base images are pulled; the gate is unassisted success, not a stopwatch.)*
-- The documented API behaves as specified: the published AsyncAPI spec renders in standard tooling, and the integration suite — WS/SSE lifecycle, stream-token single-use, RecordTime resume, invalid-token and unauthorized-party rejection, multi-party routing — passes in CI as the evidence.
+- **A revoked subscriber stops receiving events without waiting for the socket to close:** access is revoked on an open stream and delivery to that subscriber ends, demonstrated live. A normal token expiry on the same stream is invisible to the user.
+- The documented API behaves as specified: the published AsyncAPI spec renders in standard tooling, and the integration suite — WS/SSE lifecycle, stream-token single-use, in-band re-auth, RecordTime resume, invalid-token and unauthorized-party rejection, multi-party routing — passes in CI as the evidence.
 
 ### Milestone 3 — It runs in production, is externally adopted, and proposes a standard
 - **Production release:** the service runs alongside a validator, with **Qasara's own MainNet validator as the reference deployment**, verifiable live by the committee. Operational readiness demonstrated: Helm deploy on a real multi-node cluster; Prometheus metrics + Grafana dashboard; and a published compatibility matrix across the listed environments (Canton Quickstart, Canton 3.5+ DevNet, MainNet validator, Splice 0.5.x/0.6.x).
@@ -299,7 +326,7 @@ Acceptance is evaluated on **value demonstrated to the ecosystem**, per Canton D
 
 ### Payment Breakdown by Milestone (Phase 1)
 - Milestone 1 (Standalone Package + Edge Authorization + RecordTime Ordering): **90,000 CC (30%)** upon committee acceptance
-- Milestone 2 (Configurable Subscriptions + Integration Tests + AsyncAPI Spec): **60,000 CC (20%)** upon committee acceptance
+- Milestone 2 (Configurable Subscriptions + Session Lifecycle + Integration Tests + AsyncAPI Spec): **60,000 CC (20%)** upon committee acceptance
 - Milestone 3 (Production Release + CIP Draft + External MainNet Adoption): **150,000 CC (50%)** upon committee acceptance of the full Milestone 3 criteria, including **at least 3 independent community deployments on MainNet**.
 
 The final milestone is **50%** of the grant, released when the service is running in production and adopted by at least 3 independent teams on MainNet — the strongest available signal of ecosystem value.
@@ -308,7 +335,7 @@ The final milestone is **50%** of the grant, released when the service is runnin
 
 ### Volatility Stipulation
 
-Phase 1 build is **~12 weeks** (M1, M2, and the M3 release); the M3 external-adoption window then runs up to 6 months, so total Phase 1 duration is **up to ~6 months**. Should the timeline extend beyond that due to Committee-requested scope changes, any remaining milestones must be renegotiated to account for significant USD/CC price volatility.
+Phase 1 build is **~14 weeks** (M1, M2, and the M3 release); the M3 external-adoption window then runs up to 6 months, so total Phase 1 duration is **up to ~6 months**. Should the timeline extend beyond that due to Committee-requested scope changes, any remaining milestones must be renegotiated to account for significant USD/CC price volatility.
 
 ---
 

--- a/proposals/canton-event-stream.md
+++ b/proposals/canton-event-stream.md
@@ -97,7 +97,7 @@ flowchart TD
       REDIS --> SRV
     end
 
-    subgraph CLIENTS["Application clients (party-scoped token, never touch the node)"]
+    subgraph CLIENTS["Application clients (short-lived user token, never touch the node)"]
       DAPP["Browser dApp"]
       MOB["Mobile app"]
       BE["Server backend / monitor"]
@@ -118,23 +118,26 @@ flowchart TD
 1. The Ledger Ingester connects to a Canton participant's JSON Ledger API and subscribes to a **configurable set of interfaces/templates** — operators declare what to subscribe to, with a pluggable classification mapping. The CIP-0056 (Token Standard V1) token interfaces (holdings + transfer instructions) ship as the **default profile**, alongside CIP-0112 (Token Standard V2, now live on DevNet) — whose dedicated transfer-events surface (holdings-change events) lets the ingester read transfer events directly instead of inferring them from exercised choices. Both fall back to template-based subscription on nodes that do not yet support interface filtering, and the mechanism is general-purpose, not fixed to token assets.
 2. Raw DAML contract events are classified into human-readable typed events (`transfer.pending`, `transfer.executed`, `transfer.accepted`, `transfer.rejected`, `transfer.withdrawn`, `contract.created`, `contract.archived`) via the configured mapping.
 3. Events are routed by extracting `signatories`, `observers`, `witnessParties`, and `actingParties` across event types, then fanned out to subscribers via per-party Redis Pub/Sub channels. Subscribers are authorized per party at subscribe time — a client may only stream parties its credential is entitled to, re-establishing at the edge the per-party visibility boundary the participant enforces natively (and that is otherwise lost once clients are decoupled from the node for fanout). The token-based mechanism is detailed under **Authorization model** below.
-4. Events are ordered by **RecordTime** — Canton's participant-independent record timestamp, present on every update. Subscribers resume from a requested RecordTime ("send me everything since T") within a **configurable recent retention window** — a live-reconnect aid on the order of minutes to hours, **not a historical store**; deep historical replay is PQS's role, not this service's. The service maintains a RecordTime→offset index over that window to translate a requested time into a participant offset to resume from. (Choosing RecordTime over a participant-local offset is also what makes Phase-2 multi-hosted failover and dedup correct — see Phasing.)
-5. Application clients (browsers, mobile, server backends) connect to the Event Stream Server's WebSocket or SSE endpoint with a party-scoped token; they never connect to the participant node directly.
-6. The whole service ships as a single Docker image deployable alongside any Canton node, with Redis as its only persistent dependency.
+4. Events are ordered by **RecordTime** — Canton's participant-independent record timestamp, present on every update. RecordTime alone is not unique: one transaction stamps all its events with the same value, and separate transactions can share an instant. So the resume cursor is the tuple **`(synchronizerId, recordTime, updateId, nodeIndex)`**, ordered per synchronizer and resumed **exclusive** of the last event the subscriber processed — `recordTime` selects the instant, `updateId` the transaction within it, `nodeIndex` the event within that transaction. Every component is assigned by the synchronizer, so the cursor is portable across participants, and the exclusive boundary yields neither duplicates nor a gap across a reconnect. (Choosing RecordTime over a participant-local offset is also what makes Phase-2 multi-hosted failover and dedup correct — see Phasing.)
+5. Resume is bounded to a **configurable recent retention window** — a live-reconnect aid on the order of minutes to hours, **not a historical store**; deep historical replay is PQS's role, not this service's. Subscribers resume from a cursor, or from a plain "everything since T" which the server resolves to one. Over that window the service maintains a RecordTime→offset index, since the native resume boundary is offset-based and a requested time has to be translated into a participant offset to subscribe from.
+6. Application clients (browsers, mobile, server backends) connect to the Event Stream Server's WebSocket or SSE endpoint with a short-lived token identifying the user; they never connect to the participant node directly.
+7. The whole service ships as a single Docker image deployable alongside any Canton node, with Redis as its only persistent dependency.
 
-**Authorization model** — the server re-creates the node's per-party visibility boundary at the streaming edge using short-lived, party-scoped tokens:
+**Authorization model** — the server re-creates the node's per-party visibility boundary at the streaming edge using short-lived, single-use tokens plus a party lookup it performs itself:
 
-- *Who issues tokens.* The operator running the service, or their existing identity system: whoever already knows which user maps to which Canton party (for example, an exchange that knows "this logged-in user = party alice"). The server does not decide party ownership; it only accepts tokens signed by an issuer it is configured to trust (a shared key or a JWKS URL). This is the same trust model the participant already uses for `actAs` claims in an IdP-signed JWT, applied one hop further out.
-- *Two deployment shapes.* (a) the service authenticates the client, looks up its parties from an operator-supplied mapping, and issues the token itself; or (b) the operator's identity system issues the token and the service only verifies it. Making that verify step pluggable, so any operator can use their own identity system, is the net-new open-source work. (Qasara's commercial gateway uses shape (a) today, tied to its API-key system.)
-- *Token contents.* An explicit list of the party IDs the holder may stream, plus standard `iss`/`aud`/`exp` and a single-use id. The allowed-party list is written into the signed token by the issuer; the server never infers it. Tokens are short-lived (around 60 seconds) and single-use.
-- *Subscribe-time check.* Before opening any channel, the server (1) verifies the token (signature, audience, not expired, not already used), (2) reads the allowed-party list, and (3) confirms every requested party is on that list. If any requested party is not, the subscribe is rejected and no channel opens. This is exactly what the Milestone 1 acceptance test demonstrates: request a party the token does not include, and the subscribe is rejected.
-- *Optional node-side check.* Configurably, the service can also confirm with the participant that the token's issuer actually holds read rights for the party, so even a mis-issued token cannot grant more than the node itself would allow.
+- *Who issues tokens.* The operator running the service, or their existing identity system. The issuer's only required job is to assert **who the user is**; it does not need to know Canton party IDs. The server does not decide party ownership; it only accepts tokens signed by an issuer it is configured to trust (a shared key or a JWKS URL). This mirrors what the participant itself does with an IdP-signed JWT: the token carries a subject, and party rights are resolved separately.
+- *Party resolution is pluggable.* Three sources ship: **(a) participant user-rights**, where the server reads the authenticated user's `CanActAs`/`CanReadAs` grants from the participant's user-management API; **(b) operator mapping**, a lookup the operator supplies from its own user directory; **(c) explicit party list in the token**, for issuers that already hold the mapping. Which source is correct depends on how the operator provisions identities. Where each person has their own ledger user, the participant is the authoritative mapping and (a) requires nothing to be synced into the identity system. Where an operator fronts many customer parties with a single shared service account, the participant cannot distinguish those users, so (b) is the only correct source and (a) would over-grant. The resolver interface, these three implementations, and that guidance are the net-new open-source work. (Qasara's commercial gateway uses (b) today, tied to its API-key system.)
+- *Token contents.* Standard `iss`/`aud`/`exp`, a subject identifying the user, and a single-use id. An explicit allowed-party list is optional and used only with resolver (c); with (a) or (b) the server resolves the party set itself and never takes it from unsigned client input. Tokens are short-lived (around 60 seconds) and single-use.
+- *Subscribe-time check.* Before opening any channel, the server (1) verifies the token (signature, audience, not expired, not already used), (2) resolves the allowed party set via the configured resolver, and (3) confirms every requested party is in that set. Any party outside the set rejects the whole subscribe and no channel opens. If the resolver cannot answer, the subscribe fails closed.
+- *What the resolver needs.* Resolver (a) needs a participant credential with read access to user rights; (b) needs a lookup endpoint on the operator's side. Resolved party sets are cached for a short, configurable interval to keep subscribe latency low.
+- *Session lifetime and revocation.* The token authorizes the handshake, not the whole session, so a session has a bounded life and the client re-presents a fresh token in-band before it lapses; a normal expiry is invisible to the user. Revocation depends on who revokes. An operator revoking a credential or a mapping signals the service, which closes the affected streams immediately with a distinct close code. A grant revoked directly on the participant has no notification channel — user rights are participant-local admin state and a rights change produces no ledger update, so nothing can push it to us — and is therefore picked up when the cached party set is next re-resolved. That bounds exposure to the cache interval rather than the length of the session, which makes the interval a security setting and not only a performance one.
+- *Optional node-side check.* With resolvers (b) and (c) the service can additionally confirm with the participant that rights for a requested party actually exist, so a mis-issued token or a stale operator mapping cannot grant more than the node allows. This bounds a request to the party set the operator genuinely holds; it cannot confirm that a particular user owns a particular party, since only the operator knows that. With resolver (a) the check is inherent, because the party set already comes from the node.
 
 **Event format** — all events follow a consistent schema regardless of source:
 
 ```json
 {
-  "eventId": "1220upd...abc:00ctr...def",
+  "eventId": "1220upd...abc:3",
   "partyId": "alice::1220...",
   "type": "transfer.executed",
   "recordTime": "2026-04-07T12:00:00.123456Z",
@@ -157,7 +160,7 @@ flowchart TD
 }
 ```
 
-`eventId` is derived deterministically from the update, not randomly: it combines the `updateId` with the contract event's node identity (its `contractId`), so the same ledger event produces the same `eventId` on every participant that sees it and on any re-ingest after a restart.
+`eventId` is derived deterministically from the update, not randomly: it combines the `updateId` with the event's `nodeIndex` (its position in the transaction), so the same ledger event produces the same `eventId` on every participant that sees it and on any re-ingest after a restart. `nodeIndex` rather than `contractId` is what makes it unique within an update, since one transaction can emit more than one event for the same contract. The ordering and resume key is the cursor in mechanic 4, of which `eventId` carries the last two components.
 
 For token events, `payload` carries the Token Standard semantic fields a consumer actually needs — instrument, amount, sender, receiver, and holding — populated from CIP-0056 (V1) holdings / transfer-instruction data or CIP-0112 (V2) holdings-change events, so a dApp reads "Alice sent Bob 100 Amulet" without decoding the raw contract itself. `data` keeps the raw ledger metadata (contractId, templateId, choice, updateId, synchronizerId) for consumers that need to go deeper. Non-token event types carry their own typed `payload` under the same envelope; the classification mapping defines each type's payload shape.
 
@@ -227,19 +230,21 @@ No backward compatibility impact. Canton Event Stream is additive infrastructure
 
 This grant funds **Phase 1** (the three milestones below) — everything that is demonstrable today on a single participant. **Phase 2** is a scoped follow-on, deliberately separated because it cannot be built or demonstrated without a multi-participant / multi-synchronizer testbed:
 
-- **Phase 1 (this grant):** standalone package, per-party authorization at the edge, RecordTime ordering + time-based resume, configurable subscriptions + pluggable classification, integration tests, AsyncAPI spec, production hardening, and a **CIP draft** standardizing the event-selection and classified-event model.
-- **Phase 2 (follow-on grant):** multi-hosted high availability (failover across the LAPI endpoints of participants hosting the same party set) and multi-synchronizer **reassignment** (`unassigned`/`assigned`) events. When a party is hosted on more than one participant, each hosting participant emits the same update, so Phase 2 must **deduplicate the same event arriving from multiple participants**. The dedup key is the participant-independent update identity: the same logical update carries the same `updateId` and the same `RecordTime` on every participant that sees it, so the ingester keeps a seen-set of `updateId`s within the RecordTime window and drops repeats. This is why Phase 1 orders and resumes by RecordTime (participant-independent) rather than a participant-local offset, which is what makes Phase-2 cross-participant dedup correct, so Phase 2 is additive rather than a rewrite. Scoped and costed when a multi-node/multi-synchronizer testbed is available.
+- **Phase 1 (this grant):** standalone package, per-party authorization at the edge, RecordTime ordering + cursor-based resume within a recent window, configurable subscriptions + pluggable classification, integration tests, AsyncAPI spec, production hardening, and a **CIP draft** standardizing the event-selection and classified-event model.
+- **Phase 2 (follow-on grant):** multi-hosted high availability (failover across the LAPI endpoints of participants hosting the same party set) and multi-synchronizer **reassignment** (`unassigned`/`assigned`) events. When a party is hosted on more than one participant, each hosting participant emits the same update, so Phase 2 must **deduplicate the same event arriving from multiple participants**. The dedup key is the participant-independent update identity: the same logical update carries the same `updateId` and the same `RecordTime` on every participant that sees it, so the ingester keeps a seen-set of `updateId`s within the RecordTime window and drops repeats. This is why Phase 1 orders and resumes by RecordTime (participant-independent) rather than a participant-local offset, which is what makes Phase-2 cross-participant dedup correct, so Phase 2 is additive rather than a rewrite. The Phase-1 cursor already carries `synchronizerId` and orders per synchronizer, so adding a second synchronizer needs no cursor change. Scoped and costed when a multi-node/multi-synchronizer testbed is available.
 
 ## Milestones and Deliverables (Phase 1)
 
 ### Milestone 1: Standalone Package + Edge Authorization + RecordTime Ordering
 - **Estimated Delivery:** Week 4
-- **Focus:** Extract the core ingester from Qasara's commercial gateway into a self-contained Apache 2-licensed package; build per-subscriber party authorization at the streaming edge; replace the buffer-based replay with RecordTime ordering and time-based resume.
+- **Focus:** Extract the core ingester from Qasara's commercial gateway into a self-contained Apache 2-licensed package; build per-subscriber party authorization at the streaming edge; replace the buffer-based replay with RecordTime ordering and cursor-based resume.
 - **Deliverables / Value Metrics:**
   - npm package decoupled from Qasara's auth, API key, and database systems; configuration via environment variables only (no Prisma, no external DB)
   - Multi-auth support: sandbox HMAC, DevNet OAuth2 ClientCredentials, configurable per deployment
   - **Per-subscriber party authorization** — a client may only stream parties its credential is authorized for, enforced at subscribe time; re-establishes the node's per-party visibility boundary at the streaming edge
-  - **RecordTime ordering + resume** — events ordered by RecordTime; subscribers resume from a requested RecordTime via a RecordTime→offset index built from offset checkpoints
+  - **Pluggable party resolver** — participant user-rights, operator mapping, and token-claim implementations behind one interface, with published guidance on which source is correct for which identity topology (and which is unsafe where)
+  - **Session lifetime + revocation handling** — bounded sessions with in-band re-auth, and active teardown of affected streams when a credential or party grant is revoked
+  - **RecordTime ordering + resume** — events ordered by RecordTime; subscribers resume from a `(synchronizerId, recordTime, updateId, nodeIndex)` cursor via a RecordTime→offset index built from offset checkpoints
   - Docker image published to GitHub Container Registry
   - Unit tests (≥80% coverage on ingester, classification, ordering, and authorization logic); GitHub Actions CI: lint, test, Docker build on every PR
 
@@ -271,7 +276,8 @@ Acceptance is evaluated on **value demonstrated to the ecosystem**, per Canton D
 
 ### Milestone 1 — A usable, privacy-correct, correctly-ordered event layer exists
 - A developer outside the core team stands up the service from the published README and receives **classified** events from Canton Quickstart — and a client requesting a party its credential is not authorized for is **rejected at subscribe time**, demonstrated live. *(Supporting evidence: ≥80%-coverage unit suite green in CI; package runs with zero Qasara dependencies; image on npm/GHCR.)*
-- **RecordTime resume demonstrated:** a client reconnects with a requested RecordTime and receives the correctly-ordered events since that time, verified by automated test.
+- **RecordTime resume demonstrated:** a client reconnects with a requested RecordTime and receives the correctly-ordered events since that time, with no duplicated or missing event across the reconnect, verified by automated test.
+- **Party lookup proven against two identity setups:** the same package serves an operator whose users each have their own ledger user, and one that fronts many customer parties with a single shared service account. In both cases a subscriber receives only the parties it is entitled to.
 - Qasara's Canton Gateway runs against the standalone package as the first reference integration, demonstrating the extraction is real and consumable.
 
 ### Milestone 2 — General-purpose and adoptable
@@ -362,10 +368,10 @@ CIP-0100 (PR #67, merged 2026-04-23) approved Digital Asset's grant to open-sour
 | **Consumer-facing interface** | SQL API: `active()`, `creates()`, `archives()`, `exercises()` | WebSocket and Server-Sent Events |
 | **Wire protocol** | PostgreSQL JDBC | WebSocket / HTTP SSE |
 | **Client topology** | Server-side only (browsers cannot speak Postgres) | Browser, mobile, and server clients |
-| **Authentication** | PostgreSQL roles | App-layer party-scoped tokens |
+| **Authentication** | PostgreSQL roles | App-layer user tokens + per-party authorization at subscribe time |
 | **Event shape** | Decoded contracts in JSONB; clients implement classification | Pre-classified app events (`transfer.executed`, `transfer.rejected`, etc.) |
 | **Hot-path latency** | Ledger API → PQS write → Postgres → poll | Ledger API → Redis pub/sub → WebSocket push (no DB write in the hot path) |
-| **Reconnection model** | Client tracks Postgres offset; bespoke replay logic | Resume from a requested **RecordTime** within a recent window (participant-independent); deep history via PQS, not this service |
+| **Reconnection model** | Client tracks Postgres offset; bespoke replay logic | Resume from a **RecordTime-based cursor** within a recent window (participant-independent); deep history via PQS, not this service |
 | **Footprint** | JVM (4 GB / 4 cores min.) plus Postgres (8 GB / 8 cores min.) | Node.js (~150 MB image), Redis only |
 
 The [PQS SQL API documentation](https://docs.digitalasset.com/build/3.5/component-howtos/pqs/references/sql-api.html) confirms the consumer-facing interface is exclusively offset-paged query functions — no LISTEN/NOTIFY, no change feed, no subscription primitive. Adding push to PQS would require building exactly this proposal inside a JVM project, which forces a JVM dependency on every dApp consumer (the very dependency many builders are trying to avoid).
@@ -385,7 +391,7 @@ The moment an application introduces a fanout tier to serve many clients from on
 | **Client topology** | One node subscription per client; each holds a ledger token | One upstream subscription; many clients, none touching the node |
 | **Event shape** | Raw `Created`/`Archived`/`Exercised` | Classified CIP-0056 vocabulary (`transfer.executed`, …) |
 | **Participant exposure** | Every client connects to the participant | Only the gateway connects to the participant |
-| **Reconnection** | Client tracks per-participant offset / `OffsetCheckpoint`s | Resume from a requested **RecordTime** (no client-side offset persistence; participant-independent) |
+| **Reconnection** | Client tracks per-participant offset / `OffsetCheckpoint`s | Resume from a **RecordTime-based cursor** (no client-side offset persistence; participant-independent) |
 
 In short: the native WS/gRPC layer is the origin transport; Canton Event Stream is the reverse-proxy/edge above it — classification, per-party-authorized fanout, RecordTime ordering, and a participant-shielding boundary. It composes with the native layer the same way it composes with PQS on the pull side. It only ever delivers events for parties an operator is authorized to read; by Canton's authorization model it cannot expose third-party private events.
 
@@ -435,7 +441,7 @@ PQS and Canton Event Stream are independent of one another and can run on the sa
 
 ## Notes for Reviewers
 
-1. **Core transport and classification exist today; the net-new engineering is authorization, RecordTime ordering, and generalization.** This is not a greenfield design proposal. The ledger ingester (Splice interface subscription, exponential-backoff reconnect), Redis Pub/Sub fanout with batch pipeline, WebSocket endpoint, and SSE endpoint are all implemented and running in our DevNet environment as part of the Qasara Canton Gateway — so the transport and event classification are proven. What this grant funds as genuinely new work is: (a) **per-subscriber party authorization at the streaming edge** (currently coupled to Qasara's API-key system; the open-source version needs a clean, credential-agnostic implementation), (b) **RecordTime ordering + time-based resume** (replacing the current ephemeral event-id buffer with a participant-independent ordering key), and (c) **configurable subscriptions + pluggable classification** to make the surface general-purpose rather than token-specific — plus packaging, decoupling, and production hardening. We are deliberately not claiming "it's just repackaging."
+1. **Core transport and classification exist today; the net-new engineering is authorization, RecordTime ordering, and generalization.** This is not a greenfield design proposal. The ledger ingester (Splice interface subscription, exponential-backoff reconnect), Redis Pub/Sub fanout with batch pipeline, WebSocket endpoint, and SSE endpoint are all implemented and running in our DevNet environment as part of the Qasara Canton Gateway — so the transport and event classification are proven. What this grant funds as genuinely new work is: (a) **per-subscriber party authorization at the streaming edge** (currently coupled to Qasara's API-key system; the open-source version needs a clean, credential-agnostic implementation), (b) **RecordTime ordering + cursor-based resume** (replacing the current ephemeral event-id buffer with a participant-independent ordering key), and (c) **configurable subscriptions + pluggable classification** to make the surface general-purpose rather than token-specific — plus packaging, decoupling, and production hardening. We are deliberately not claiming "it's just repackaging."
 
 2. **TypeScript choice is intentional.** The Canton Wallet SDK is TypeScript-native. Most dApp developers are TypeScript-first. A JVM-free event stream reduces the operational complexity for the majority of Canton builders, while the language-neutral wire protocols (WebSocket + SSE) keep JVM consumers fully supported.
 
@@ -448,8 +454,9 @@ PQS and Canton Event Stream are independent of one another and can run on the sa
    | Ledger ingester (single upstream subscription, backoff reconnect) | ✅ | uses OSS |
    | Event classification into the typed vocabulary | ✅ | uses OSS |
    | Per-party authorization re-enforced at the edge | ✅ | uses OSS |
-   | Fanout, WebSocket/SSE serving, `lastEventId` replay | ✅ | uses OSS |
+   | Fanout, WebSocket/SSE serving, cursor-based resume | ✅ | uses OSS |
    | Connection authentication (validate client JWT/token → identity) | ✅ (bring-your-own IdP) | Qasara IdP + accounts |
+   | Party resolution (participant user-rights, operator mapping, token claim) | ✅ | uses OSS |
    | Credential issuance for self-hosting (stream tokens / BYO-IdP) | ✅ | uses OSS |
    | Basic connection / backpressure limits | ✅ | uses OSS |
    | AsyncAPI spec, Helm chart, metrics, Docker image | ✅ | uses OSS |


### PR DESCRIPTION
**Proposal file:** /proposals/canton-event-stream.md

**Summary**
Canton Event Stream is a self-hostable, MIT-licensed Node.js service that connects to any Canton participant node and delivers classified, party-routed ledger events to application clients over WebSocket and SSE. It solves the missing push layer in the Canton ecosystem — the infrastructure between the raw JSON Ledger API stream and live UIs, deposit detectors, and reactive backends. The core implementation exists today inside Qasara's commercial Canton Gateway; this proposal extracts and open-sources it as a standalone package in 3 milestones over 6 weeks, funded at 300,000 CC.

**Checklist**
- [x] Proposal file added under `/proposals/`
- [x] Milestones and funding amounts defined
- [x] Acceptance criteria included
- [x] Alignment with Canton priorities described

**Notes for Reviewers**
- The core ingester (Splice interface subscription, Redis pub/sub fanout, WebSocket + SSE endpoints) is already running in Qasara's DevNet environment — this is an extraction + open-sourcing grant, not a greenfield build.
- This proposal complements PQS (CIP-0100, approved 2026-04-23) rather than competing with it. PQS is the pull layer (SQL ODS); Canton Event Stream is the push layer (WebSocket/SSE). The Rationale section explains the coexistence design.
- Champion: Parth (parth@canton.foundation), Canton Foundation.
- Funding request: 300,000 CC across 3 milestones (120k / 100k / 80k).
