### PR TITLE
ci: bump Node 20 action pins to Node 24 majors

### DIFF
--- a/.github/workflows/aipricheck.yml
+++ b/.github/workflows/aipricheck.yml
@@ -14,14 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR head branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Get changed files
         id: changed
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const files = await github.rest.pulls.listFiles({

--- a/.github/workflows/champion-check.yml
+++ b/.github/workflows/champion-check.yml
@@ -15,14 +15,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR head branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Get changed proposal files
         id: changed
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const files = await github.rest.pulls.listFiles({
@@ -110,7 +110,7 @@ jobs:
 
       - name: Comment and close if no champion
         if: steps.champion-check.outputs.has_champion == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const comments = await github.rest.issues.listComments({
@@ -160,7 +160,7 @@ jobs:
 
       - name: Confirm valid champion
         if: steps.champion-check.outputs.has_champion == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const comments = await github.rest.issues.listComments({

--- a/.github/workflows/sig-label-check.yml
+++ b/.github/workflows/sig-label-check.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check for SIG label
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const SIG_LABELS = [


### PR DESCRIPTION
## Summary

- Pin `actions/checkout` from floating `@v4` to SHA `df4cb1c069e1874edd31b4311f1884172cec0e10` (v6.0.3, Node 24) in `aipricheck.yml` and `champion-check.yml`
- Pin `actions/github-script` from floating `@v7` to SHA `3a2844b7e9c422d3c10d287c895573f7108da1b3` (v9.0.0, Node 24) in `aipricheck.yml`, `champion-check.yml`, and `sig-label-check.yml`

## Test plan

- [ ] Verify CI passes on this PR (workflow files are syntactically valid)
- [ ] Confirm each action uses a SHA pin with version comment per supply-chain best practice