### PR TITLE
Refinement of M3 in traffic-based app rewards grant

### DIFF
--- a/proposals/2026-02-DA-Traffic-Based-App-Rewards.md
+++ b/proposals/2026-02-DA-Traffic-Based-App-Rewards.md
@@ -176,7 +176,8 @@ Deliverables:
 - SV app UI: support for new configuration parameters.  
 - Wallet app: `RewardCouponV2` and `MintCoupon` lookup for reward minting.  
 - Dry-run mode deployed and validated on MainNet, confirming deterministic reward computation across SV nodes.  
-- Minimum two-week delay between deploying Dry-run mode on MainNet and enabling actual traffic-based rewards on DevNet. This means that explorers and app builders will be able to see what results would be generated via traffic-based application rewards, and compare them to existing marker-based rewards. Doing this two weeks before enforcing traffic-based app rewards on DevNet means that this computation will be available four weeks before the new rewards logic gets enforced on MainNet. 
+- Minimum four-week delay between the time that activity records are made public via the Scan app on MainNet, and the time that traffic-based app rewards start being enforced. This means that explorers and app builders will be able to see what results would be generated via traffic-based application rewards, and compare them to existing marker-based rewards, during this review period, before traffic-based app rewards go fully live.
+ 
 
 - Governance vote to switch from featured app markers to traffic-based app rewards.  
 - Monitoring: metrics and alerting for trigger health and hidden reward coupon counts.  


### PR DESCRIPTION


## Development Fund Proposal Submission

**Proposal file:**  
/proposals/2026-02-DA-Traffic-Based-App-Rewards.md

---

## Summary
As we are preparing the roll-out plan for this feature, we realized that the precise language used in the original milestone dictates some limitations that would delay roll out unnecessarily. Since the data has been made available on Scan on an earlier release than the full implementation, we can still allow the desired 4 week review period and enable the feature one week earlier. This amendment proposes the corresponding change in the AC text of the milestone for full transparency and pre-approval by the committee.

---

## Checklist
- [x] Proposal file added under `/proposals/`
- [x] Milestones and funding amounts defined
- [x] Acceptance criteria included
- [x] Alignment with Canton priorities described

---

## Notes for Reviewers
None
