### PR TITLE
Add acceleration extension to accommodate extra scope

### DIFF
--- a/proposals/2026-02-DA-Traffic-Based-App-Rewards.md
+++ b/proposals/2026-02-DA-Traffic-Based-App-Rewards.md
@@ -183,7 +183,7 @@ Deliverables:
 - Resolution of any issues arising during MainNet deployment.  
 - All code merged into the open-source Canton and Splice repositories with appropriate unit and integration test coverage.  
 - Updated Splice documentation covering the traffic-based reward configuration, new Scan API endpoints, `RewardCouponV2` lifecycle, dry-run mode operation, and SV onboarding interaction with reward accounting.  
-- 
+- Featured app weights and mechanisms for adjusting those weights as proposed in [the corresponding CIP-0104 amendment](TODO).
 
 **Acceptance Criteria:** Traffic-based app rewards are live on the Global Synchronizer MainNet, with `RewardCouponV2` contracts being created for featured app provider parties each round. Dry-run validation has confirmed deterministic reward computation across SV nodes prior to the live switch. Scale testing confirms the system operates within acceptable bounds at 2026 MainNet scale.
 
@@ -222,7 +222,7 @@ We propose an Early Completion Bonus if the work of Milestones 1-3 is completed 
 
 | Early Completion | Bonus Percentage | Bonus Amount (CC) |
 | :---- | :---- | :---- |
-| Milestones 1-3 available on MainNet four (4) months after grant approval | 15% of Milestones 1-3 | 525,000: Digital Asset<br>525,000: Obsidian Systems |
+| Milestones 1-3 available on MainNet five (5) months after grant approval | 15% of Milestones 1-3 | 525,000: Digital Asset<br>525,000: Obsidian Systems |
 
 ## Volatility Stipulation
 

--- a/proposals/2026-02-DA-Traffic-Based-App-Rewards.md
+++ b/proposals/2026-02-DA-Traffic-Based-App-Rewards.md
@@ -183,7 +183,7 @@ Deliverables:
 - Resolution of any issues arising during MainNet deployment.  
 - All code merged into the open-source Canton and Splice repositories with appropriate unit and integration test coverage.  
 - Updated Splice documentation covering the traffic-based reward configuration, new Scan API endpoints, `RewardCouponV2` lifecycle, dry-run mode operation, and SV onboarding interaction with reward accounting.  
-- Featured app weights and mechanisms for adjusting those weights as proposed in [the corresponding CIP-0104 amendment](TODO).
+- Featured app weights and mechanisms for adjusting those weights as proposed in [the corresponding CIP-0104 amendment](https://github.com/canton-foundation/cips/pull/238).
 
 **Acceptance Criteria:** Traffic-based app rewards are live on the Global Synchronizer MainNet, with `RewardCouponV2` contracts being created for featured app provider parties each round. Dry-run validation has confirmed deterministic reward computation across SV nodes prior to the live switch. Scale testing confirms the system operates within acceptable bounds at 2026 MainNet scale.
 


### PR DESCRIPTION
Author: Bernhard Elsner
Status: Draft
Created: 2016-06-30 
Label: tokenomics

Champion: Bernhard Elsner

This PR relates to https://github.com/canton-foundation/cips/pull/238.

We are currently on track to activate traffic based app rewards on MainNet within the month of July, which would then trigger the acceleration bonus of the Traffic Based Application Rewards grant.
Should the SVs vote on the amendment to CIP-0104, we'll need to slot the added feature into an upcoming release in July. The release timelines are such that MainNet release would no longer fall into July.

As this delay would be due to a late request of added scope as opposed to DA being late on delivery, we request that if the CIP amendment is ratified by the SVs, then the timeline for the acceleration bonus is extended into August.