### PR TITLE
CantonNews Ecosystem Intelligence Layer proposal

### DIFF
--- a/proposals/cantonnews.md
+++ b/proposals/cantonnews.md
@@ -1,0 +1,662 @@
+## Development Fund Proposal
+
+**Title:** CantonNews Ecosystem Intelligence Layer  
+**Author:** Canton Army  
+**Created:** 2026-05-18  
+**Label:** ecosystem-growth / onchain-governance  
+**Champion:** To be confirmed  
+
+---
+
+## Abstract
+
+This proposal requests support from the Canton Development Fund to expand CantonNews into a public intelligence and activation layer for Canton Network.
+
+Canton is entering a stage where two problems become increasingly important: governance visibility and high-quality ecosystem growth.
+
+Governance information is public, but fragmented across CIPs, Development Fund pull requests, Foundation pages, validator and super validator materials, vote records, and announcements. At the same time, ecosystem growth incentives are often distributed through broad giveaways, social quests, and access campaigns that can be farmed by low-quality or one-time users.
+
+CantonNews already operates as a Canton-focused hub covering major news, insights, media, press releases, network updates, featured projects, careers, and events. Canton Army already has a deeply engaged Canton-focused audience and relationships across the ecosystem.
+
+This proposal adds the missing intelligence layer:
+
+1. **Governance Intelligence Module:** a public, searchable, source-linked governance hub covering CIPs, Development Fund proposals, validator and super validator activity, governance outcomes, proposal timelines, weekly governance briefs, and monthly governance reports.
+
+2. **Wallet Activation Module:** a consent-based wallet intelligence and campaign layer that helps Canton projects identify active, loyal, high-intent wallets and target them with relevant offers, perks, early access, and onboarding incentives.
+
+The goal is to help Canton projects stop distributing incentives blindly and start using network activity to reach users who are more likely to become active participants.
+
+This is not a grant for general CantonNews operations. It is a grant to build reusable ecosystem infrastructure that improves governance transparency, user activation, project growth, and cross-chain onboarding for Canton Network.
+
+---
+
+## Executive Summary
+
+The CantonNews Ecosystem Intelligence Layer gives Canton Network two pieces of public growth infrastructure:
+
+- A governance layer that makes public governance easier to understand, search, track, and share.
+- A wallet activation layer that helps projects target incentives toward wallets with real network activity and product fit.
+
+Together, the Governance Intelligence Module and Wallet Activation Module create a growth, transparency, and onboarding layer for Canton Network.
+
+The governance layer makes Canton easier to understand by organizing public governance activity into one searchable, source-linked hub.
+
+The wallet activation layer makes Canton easier to grow by helping projects identify active wallets, reach opted-in wallet owners, and offer incentives based on real network activity rather than social task completion.
+
+This creates a practical bridge between projects and users: projects can already observe some wallet activity internally or across the ecosystem, but they usually have no direct way to contact the wallet owner. CantonNews solves this by allowing users to connect wallets, opt in to communication, and receive relevant offers from verified Canton projects.
+
+This creates a stronger growth loop for Canton:
+
+1. Users can understand what is happening in the network.
+2. Users can connect wallets and discover offers they are actually eligible for.
+3. Projects can target active wallets instead of distributing rewards blindly.
+4. Canton can attract proven users from other chains through external wallet qualification.
+5. Governance becomes more visible, and ecosystem growth becomes more data-driven.
+
+Canton Army believes this can become a core growth surface for Canton Network because it combines an existing Canton-focused platform, an engaged community, project relationships, governance reporting, and wallet-level activation infrastructure.
+
+---
+
+## Problem Statement
+
+Canton governance information is public, but scattered and difficult for most users to follow. Important updates are spread across CIPs, Development Fund pull requests, Foundation pages, validator and super validator materials, vote records, public announcements, and technical discussions. Even when this information is available, it can be hard to search, compare, track over time, or understand without reading through multiple technical sources.
+
+This creates a transparency gap for community members, investors, builders, validators, and ecosystem projects. Users may know that governance activity is happening, but not what changed, why it matters, who it affects, or where the original source material lives.
+
+There is also a major incentive-efficiency problem across crypto growth campaigns. Social quests, giveaways, access lists, perks, and sign-up offers are often farmed by users running multiple accounts or by wallets that claim rewards once and disappear. This is especially damaging for emerging ecosystems because projects may distribute CC, fee discounts, bonuses, access, or promotional offers to wallets with little evidence that those users will become active or returning participants.
+
+Social campaigns can be useful for awareness, but they are weak signals for product usage. A user who follows an account, retweets a post, or completes a quest is not necessarily a user who will trade, lend, borrow, stake, bridge, or return to a protocol. For projects looking for active users suited to their products, network activity is a stronger signal than social proof.
+
+Canton projects need a better way to identify wallets that actually use products, return to protocols, and show loyalty through network activity. A wallet that trades prediction markets every day, lends regularly, stakes CC, bridges frequently, or repeatedly uses specific Canton applications should not be treated the same as a wallet with no meaningful activity history.
+
+The Wallet Activation Module addresses this by scoring wallets based on network data and wallet activity rather than social task completion. The goal is to move Canton incentives away from random giveaways and toward targeted offers based on real wallet behavior, product fit, loyalty, and bot/farmer risk signals.
+
+A project should not need to distribute 100 early access codes, bonuses, or sign-up offers blindly. Instead, it can define the type of wallet it wants to reach and target offers toward wallets whose network activity shows relevant behavior.
+
+The key principle is that opportunities should flow toward active network users. New protocols, DeFi platforms, prediction markets, wallets, and other Canton applications should be able to reach users whose activity shows they are more likely to use the product. This improves incentive efficiency for projects and improves relevance for users.
+
+In the second milestone, external wallet qualification extends this logic to onboarding. Active Ethereum, Solana, Sui, Polygon, and other chain users can connect wallets and receive Canton project offers based on prior activity elsewhere. This helps Canton projects attract proven DeFi users, traders, lenders, borrowers, stakers, and prediction market participants into Canton.
+
+---
+
+## Specification
+
+### 1. Objective
+
+The objective is to make CantonNews the primary public surface where Canton users can understand the network and act on relevant ecosystem opportunities.
+
+The project will deliver:
+
+- A source-linked governance transparency layer for Canton Network
+- A wallet-based activation layer for Canton projects
+- A CantonNews Offers Marketplace where users connect wallets and see eligible campaigns
+- A verified project dashboard where Canton projects can create targeted campaigns using wallet activity filters
+- Opt-in email and Telegram campaign routing for users who consent
+- External wallet qualification to help bring high-quality users from other chains into Canton
+
+This is a single platform proposal. The governance and wallet modules serve the same ecosystem objective: turning CantonNews from an information hub into an intelligence and activation hub for Canton Network.
+
+---
+
+## 2. Implementation Mechanics
+
+The project will be built as an extension of CantonNews with two connected modules.
+
+### Governance Intelligence Workflow
+
+- Monitor public governance sources, including the Canton Foundation CIPs repository, Development Fund pull requests, Foundation pages, validator and super validator materials, public vote records, and announcements.
+- Create structured records for CIPs, Dev Fund proposals, validator updates, super validator updates, governance decisions, and proposal outcomes.
+- Add source links, summaries, status labels, categories, timestamps, and timelines.
+- Use automated monitoring to detect updates, with human review before publication.
+- Publish weekly governance briefs and monthly governance reports through CantonNews and Canton Army channels.
+
+### Wallet Activation Workflow
+
+- Users connect a Canton/CC wallet through CantonNews.
+- Users review a clear consent notice and choose communication preferences.
+- The system analyzes available wallet activity and updates scores every 24 hours.
+- Wallets receive an overall score and category-level scores.
+- Verified Canton projects create campaigns using filters such as wallet age, DeFi activity, prediction market activity, swaps, lending, borrowing, staking, bridge activity, retention, and bot/farmer risk.
+- Users see eligible offers in the CantonNews Offers Marketplace.
+- Projects receive campaign analytics, not unrestricted raw database access.
+- Contact sharing only occurs where users have explicitly opted in.
+
+The Wallet Activation Module does not only help projects understand wallets. It helps projects reach wallet owners who have opted in.
+
+A project may know that a wallet is active in DeFi, prediction markets, lending, borrowing, staking, or swaps, but it usually has no direct contact route to that wallet owner. By connecting wallets through CantonNews and allowing users to opt in to email or Telegram notifications, CantonNews becomes the communication bridge between verified Canton projects and active wallet users.
+
+This allows projects to target offers to the right wallets while users stay in control of whether they receive marketplace, email, Telegram, or project-specific communications.
+
+### External Wallet Qualification Workflow
+
+In Milestone 2, users will be able to connect external wallets from at least 10 supported chains. These wallets will be used only as qualification signals for Canton onboarding.
+
+This allows Canton projects to reach active Ethereum, Solana, Sui, Polygon, Base, Arbitrum, Optimism, BNB Chain, Avalanche, and other users with Canton-specific onboarding offers.
+
+---
+
+## 3. Governance Intelligence Module
+
+The Governance Intelligence Module will track and explain public Canton governance activity, including:
+
+- Canton Improvement Proposals
+- CIP statuses, timelines, and outcomes
+- Development Fund proposals
+- Grant milestones and funding decisions
+- Validator applications
+- Super validator applications
+- Governance vote outcomes where source material is available
+- Foundation governance processes where publicly documented
+- Proposal summaries, status labels, and source links
+
+The hub will include:
+
+- Searchable governance database
+- CIP tracker based on the official Canton Foundation CIPs repository
+- Plain-English summaries
+- Source-linked records
+- Last-updated timestamps
+- Status methodology page
+- Timeline pages for major proposals
+- CSV/JSON exports
+- Weekly Governance Brief
+- Monthly Governance Report
+- Mobile access through CantonNews iOS and Android versions
+
+Official Canton sources remain the source of truth. CantonNews will organize, summarize, and link to public material without replacing official governance processes.
+
+---
+
+## 4. Wallet Activation Module
+
+The Wallet Activation Module turns wallet activity into a growth signal for Canton projects.
+
+It helps Canton projects stop distributing incentives blindly and start offering access, bonuses, and perks to wallets whose network activity shows real product fit.
+
+The module is based on wallet activity, not article reads, social quests, follower tasks, or CantonNews engagement farming.
+
+**How it works:**
+
+1. A user connects a Canton/CC wallet on CantonNews.
+2. The user reviews a clear consent notice and chooses whether to opt in to marketplace visibility, email notifications, Telegram notifications, and project-specific contact sharing.
+3. The system reviews available wallet activity and updates scores every 24 hours.
+4. Each wallet receives an overall score plus category scores such as DeFi, prediction markets, lending, borrowing, staking/yield, swaps, bridge activity, wallet age, retention, and bot/farmer risk.
+5. Verified Canton projects create campaigns using wallet filters.
+6. Users see eligible offers in the CantonNews Offers Marketplace.
+7. If users opt in, they may also receive relevant offers by email or Telegram.
+8. Projects receive campaign analytics, but not raw unrestricted database access.
+
+This creates a consent-based matching layer between active wallet users and Canton projects.
+
+**Example project use cases:**
+
+- **Lending and borrowing protocols:** A Canton lending protocol can target wallets that actively swap, bridge, or hold CC but have not yet supplied collateral or borrowed assets. Instead of sending a generic sign-up bonus to every wallet, the protocol can offer a higher-value onboarding incentive to wallets that already show DeFi intent.
+
+- **Prediction markets:** A prediction market can target wallets with frequent trading activity, repeated market participation, or strong activity on rival or adjacent trading products. These users are more likely to understand the product and return after the first campaign.
+
+- **DEXs and swap platforms:** A swap platform can target wallets that bridge into Canton, hold multiple assets, or regularly interact with DeFi apps but have not used its routing or swap product yet. Campaigns can be built around lower fees, trading rebates, or volume-based perks.
+
+- **Staking and yield platforms:** A staking or yield product can target wallets that hold or transact with CC but are not staking, supplying liquidity, or using yield products. This allows the project to offer tailored yield incentives to users already active in the network.
+
+- **Wallets and account infrastructure:** A wallet provider can target active Canton users who have not connected to its wallet, or external-chain users who already show strong on-chain activity and may need an easy entry point into Canton.
+
+- **Bridge and onboarding products:** A bridge or onboarding project can target active Ethereum, Solana, Sui, Polygon, or Base users who match Canton project needs, then route them toward Canton sign-up bonuses, fee discounts, or first-transaction incentives.
+
+- **Trading venues and structured products:** A trading platform can target wallets with high transaction frequency, recurring trading behavior, or prior participation in DeFi markets. Offers can be tailored around early access, reduced fees, or higher-tier account benefits.
+
+- **New Canton protocols:** A new project launching on Canton can distribute early access codes or launch bonuses only to wallets that meet defined activity criteria, instead of giving access blindly to first-come-first-served sign-ups.
+
+- **Reactivation campaigns:** A project can identify wallets that were previously active but have gone dormant and send opt-in reactivation offers, such as fee discounts, loyalty rewards, or limited-time bonuses.
+
+- **Ecosystem-wide onboarding:** Canton ecosystem partners can create campaigns for users who are active on other chains but not yet active on Canton, helping bring proven DeFi users, traders, lenders, borrowers, stakers, and prediction market participants into the network.
+
+**Benefits for projects:**
+
+- Less wasted spend on low-quality giveaways
+- Better targeting for sign-up offers, bonuses, fee discounts, and access codes
+- Higher confidence that incentives reach wallets likely to use the product
+- Ability to reward loyal and returning users
+- Ability to target specific wallet behavior, such as prediction market trading, lending, borrowing, staking, swaps, or bridging
+- Ability to measure campaign performance after launch
+- No need to manually review wallet activity one by one
+- A consent-based communication bridge to wallet owners who would otherwise be unreachable
+
+**Benefits for users:**
+
+- Active network users receive more relevant opportunities
+- Wallets are rewarded for real activity rather than social task farming
+- Users can discover Canton apps based on how they actually use the network
+- Users control whether they receive email or Telegram offers
+- Users can opt out of communication or marketplace visibility
+
+**Benefits for Canton Network:**
+
+- Incentives become more efficient
+- Projects can attract users who are more likely to become active participants
+- Campaigns shift from random giveaways to network-data-based targeting
+- External wallet support can bring proven users from other chains into Canton
+- Canton gains an onboarding layer that connects users, projects, and opportunities through CantonNews
+
+Wallet scores are activity-based signals, not KYC, identity verification, or proof of personhood.
+
+Projects will not receive unrestricted access to the wallet database. Projects will configure filters, preview audience size and quality, and launch campaigns through CantonNews. Contact details will only be used where users have explicitly opted in.
+
+---
+
+## 5. Wallet Scoring Methodology
+
+Each connected wallet will receive an overall score plus category scores.
+
+Wallet data will be gathered through user-connected wallets, available wallet history, transaction activity, protocol interactions, and project-provided campaign data where available.
+
+The system will analyze signals such as:
+
+- Wallet age
+- Transaction history
+- Recent activity
+- Protocol interactions
+- CC usage
+- Swap activity
+- Lending and borrowing activity
+- Staking or yield activity
+- Prediction market activity
+- Bridge activity
+- Repeat usage
+- Dormant or returning wallet behavior
+- Campaign claims and conversions where verifiable
+
+These signals will be grouped into category scores and an overall wallet score. Scores will update every 24 hours.
+
+Initial tracked metrics will include:
+
+- Wallet age
+- Active days
+- Recent activity over 7, 30, and 90 days
+- Transaction count
+- Transaction volume where available
+- Swap activity
+- Lending activity
+- Borrowing activity
+- Staking/yield activity
+- Prediction market activity
+- Bridge activity
+- Protocol diversity
+- Repeat protocol usage
+- Retention/loyalty indicators
+- Dormant/reactivated wallet behavior
+- Bot/farmer risk indicators
+- Campaign claim history
+- Conversion history where project-reported or network-verifiable
+
+Example score categories:
+
+- Overall Wallet Score
+- Trading/Swap Score
+- Prediction Market Score
+- Lending Score
+- Borrowing Score
+- Staking/Yield Score
+- Bridge Score
+- Wallet Age Score
+- Retention/Loyalty Score
+- Protocol Diversity Score
+- Bot/Farmer Risk Score
+
+The scoring model will use available network data, user-consented wallet data, project-provided campaign data, and publicly accessible or permissioned signals where available. Where data is incomplete, the system will show confidence indicators rather than overclaiming.
+
+A public methodology page will explain the scoring framework at category level. Exact anti-gaming thresholds will not be fully exposed.
+
+Milestone 1 will deliver the initial scoring model for Canton/CC wallets. The model will be improved after pilot data, project feedback, and observed campaign performance.
+
+---
+
+## 6. CantonNews Offers Marketplace
+
+Users will be able to connect a wallet on CantonNews and view campaigns they are eligible for.
+
+By default, the marketplace will show eligible campaigns first. Users may also browse public campaigns they are not currently eligible for, with broad eligibility explanations such as “requires more lending activity” or “requires recent Canton activity.” Exact score thresholds will not be exposed.
+
+Campaign types may include:
+
+- Sign-up bonuses
+- Fee discounts
+- Deposit incentives
+- Trading perks
+- Lending/borrowing bonuses
+- Prediction market bonuses
+- Early access offers
+- Loyalty rewards
+- Reactivation offers
+- Partner onboarding campaigns
+
+Projects will be manually verified before they can create campaigns.
+
+---
+
+## 7. Project Campaign Dashboard
+
+Verified Canton projects will be able to configure campaigns using wallet filters.
+
+Example filters:
+
+- Overall wallet score
+- Wallet age
+- Active in last 7/30/90 days
+- Swap score
+- Lending score
+- Borrowing score
+- Staking score
+- Perp score
+- Prediction market score
+- NFT score
+- Memecoin score
+- Bridge activity
+- Chain activity
+- Protocol category activity
+- Specific protocol activity where available
+- Dormant but previously active users
+- New-to-Canton users with strong external-chain history
+- Bot/farmer risk score
+- User-consented region/location where provided
+- Email or Telegram opt-in status
+
+Projects will receive campaign analytics, not raw unrestricted database access.
+
+Analytics may include:
+
+- Eligible wallet count
+- Offer views
+- Claims
+- Wallet connects
+- Conversions where reported or verifiable
+- Repeat activity after 7/30 days where available
+- Cost per claimed wallet
+- Cost per active wallet
+- Retention performance by segment
+
+---
+
+## 8. External Wallet Qualification
+
+Milestone 2 will add support for external wallets as an onboarding signal for Canton projects.
+
+This is not intended to turn CantonNews into a general multichain advertising platform. External wallet support exists to help Canton projects bring high-quality users into Canton.
+
+Supported chains will include:
+
+- EVM
+- Solana
+- Sui
+- One additional chain selected based on project demand
+
+External wallets will be used to identify users who may be valuable Canton participants even if they are new to Canton.
+
+Example: a user active in lending on Ethereum or Solana may be shown onboarding offers from Canton lending protocols. A user active in prediction markets elsewhere may be shown relevant Canton prediction market campaigns.
+
+External wallet support will be used only to support Canton onboarding, Canton project campaign targeting, and Canton app recommendations.
+
+---
+
+## 9. Adoption Targets
+
+Canton Army is confident in the adoption targets below because it is heavily involved in the Canton Network community, has an existing Canton-focused audience, and has relationships with many projects currently live in the ecosystem. Based on early conversations, Canton Army believes multiple established Canton projects would be willing to participate in the pilot program.
+
+These targets are intended as conservative launch estimates rather than aggressive upside projections.
+
+**After Canton/CC Wallet Activation launch:**
+
+- Target 10,000 user sign-ups
+- Target 20 Canton projects onboarded or participating
+- Minimum 5 verified Canton projects participating in the pilot phase
+- Initial campaign activity across DeFi, prediction markets, wallets, staking/yield, and other Canton ecosystem categories
+
+**After external wallet qualification is added:**
+
+- Target 30,000 total user sign-ups
+- Target 40 projects onboarded or participating
+- Campaigns targeting both active Canton wallets and qualified external-chain wallets
+- External wallet support used specifically to bring proven users from Ethereum, Solana, Sui, Polygon, and other supported chains into Canton
+
+---
+
+## 10. Non-Goals
+
+This proposal does not:
+
+- Fund general CantonNews operations
+- Replace official Canton governance sources
+- Modify Canton governance processes
+- Sell raw wallet databases to projects
+- Sell unrestricted email or Telegram lists
+- Score wallets based on article reads or social tasks
+- Create a quest platform
+- Reward fake engagement farming
+- Become a general non-Canton ad network
+- Target institutional private Canton activity without consent or data availability
+- Present wallet scores as KYC, identity verification, or proof of personhood
+
+---
+
+## Architectural Alignment
+
+This proposal aligns with Canton ecosystem growth in two ways.
+
+First, the Governance Intelligence Module improves public understanding of Canton governance without modifying governance itself. It makes public information easier to discover, search, understand, and share while preserving official sources as the source of truth.
+
+Second, the Wallet Activation Module helps Canton projects use network activity to reach users who are more likely to become active participants. This supports ecosystem growth by improving incentive efficiency, reducing low-quality giveaway farming, and helping projects target offers toward users with demonstrated product fit.
+
+Together, these modules create a layer for growth, transparency, and onboarding to Canton Network.
+
+The external wallet expansion is explicitly designed to bring users into Canton, not to operate as a general multichain marketing platform.
+
+---
+
+## Backward Compatibility
+
+No backward compatibility impact.
+
+This proposal does not modify Canton protocol behavior, node software, governance processes, voting systems, wallet standards, Dev Fund processes, validator processes, or official Foundation sources.
+
+---
+
+## Milestones and Deliverables
+
+### Milestone 1: Governance Intelligence and Canton/CC Wallet Activation Launch
+
+- **Estimated Delivery:** 2 months from approval
+- **Funding requested:** 350,000 CC
+- **Focus:** Launch the CantonNews governance hub, Canton/CC wallet scoring, consent system, Offers Marketplace, verified project dashboard, and initial project pilot.
+
+**Deliverables / Value Metrics:**
+
+- Governance section live on CantonNews
+- Searchable governance database
+- CIP tracker based on official Canton Foundation CIPs repository
+- Public Dev Fund proposal tracker
+- Validator and super validator tracker
+- Source-linked governance records
+- Plain-English summaries
+- Status labels and last-updated timestamps
+- Governance methodology page
+- Timeline pages for major proposals
+- CSV/JSON exports
+- Weekly Governance Brief launched
+- First Monthly Governance Report published
+- Governance section accessible through CantonNews mobile apps
+- Canton/CC wallet connection live
+- User consent, opt-in, and opt-out controls live
+- Wallet scoring method implemented
+- Overall score and category scores live
+- Scores update every 24 hours
+- Bot/farmer risk indicators implemented
+- CantonNews Offers Marketplace live
+- User view showing eligible campaigns
+- Verified project campaign dashboard live
+- Filter-based campaign creation live
+- No raw database access for projects
+- Email and Telegram campaign opt-in implemented
+- Minimum 5 verified Canton project pilot campaigns prepared or launched
+- Target 10,000 user sign-ups after launch
+- Target 20 Canton projects onboarded or participating
+- Canton Army distribution campaign completed across its Canton-focused community
+- Initial adoption report published
+
+### Milestone 2: External Wallet Qualification and Ecosystem Expansion
+
+- **Estimated Delivery:** Begins after Milestone 1 acceptance; target 3-4 months after stable Canton/CC launch
+- **Funding requested:** 300,000 CC
+- **Focus:** Add external wallet qualification, support at least 10 chains, improve scoring and campaign analytics, continue governance reporting, and scale user/project adoption.
+
+**Deliverables / Value Metrics:**
+
+- Continue governance database maintenance
+- Continue Weekly Governance Briefs
+- Publish Monthly Governance Reports
+- Improve governance data quality and historical coverage
+- Improve scoring model based on pilot results
+- Add pre-built wallet segments for common Canton project needs
+- Add audience size and quality previews for projects
+- Add campaign attribution dashboard
+- Add dormant/reactivation campaign support
+- Add recommendation logic for Canton apps based on wallet activity
+- Support for at least 10 external chains
+- External wallet connection flow
+- Cross-chain qualification score
+- Chain-specific category scores
+- External activity filters for verified Canton projects
+- Canton app recommendations based on external wallet activity
+- Campaigns for users who are active on other chains but new to Canton
+- Clear separation between Canton activity score and external qualification score
+- Updated consent notice covering external wallets
+- At least 3 Canton project campaigns using external wallet qualification
+- Target 30,000 total user sign-ups after external wallet support is added
+- Target 40 projects onboarded or participating
+- Final report covering governance coverage, wallet activation, campaign adoption, external-chain onboarding, and sustainability plan
+
+---
+
+## Acceptance Criteria
+
+The Tech & Ops Committee can evaluate completion based on:
+
+- Deliverables completed as specified
+- Public functionality live on CantonNews
+- Demonstrated wallet connection and scoring
+- Demonstrated consent and opt-out controls
+- Demonstrated project campaign filtering
+- No raw database access granted to projects
+- Governance records source-linked to original public materials
+- Weekly and monthly governance reporting delivered
+- Minimum 5 verified Canton projects participate in the pilot phase
+- External-chain support limited to Canton onboarding use cases
+- Final report published with adoption, usage, and impact metrics
+
+---
+
+## Funding
+
+**Total Funding Request:** 650,000 CC
+
+### Payment Breakdown by Milestone
+
+| Milestone | Name | Focus | Funding |
+| --- | --- | --- | --- |
+| Milestone 1 | Governance Intelligence and Canton/CC Wallet Activation Launch | Launch governance organization, Canton/CC wallet scoring, consent controls, Offers Marketplace, verified project dashboard, pilot campaigns, and Canton Army launch distribution | 350,000 CC |
+| Milestone 2 | External Wallet Qualification and Ecosystem Expansion | Add external wallet qualification, support at least 10 chains, improve campaign analytics, continue governance reporting, and scale project/user adoption | 300,000 CC |
+| **Total** |  |  | **650,000 CC** |
+
+Milestone 1 funds the core CantonNews intelligence layer: governance transparency plus Canton/CC wallet activation. This includes the public governance database, CIP and Dev Fund tracking, Canton/CC wallet scoring, consent controls, project campaign tools, and the initial pilot with Canton projects.
+
+Milestone 2 funds expansion after the Canton/CC launch is stable. This includes external wallet qualification for Canton onboarding, support for at least 10 external chains, expanded project campaign analytics, improved scoring, continued governance reporting, and ecosystem growth toward the 30,000 user sign-up and 40 project participation targets.
+
+### Volatility Stipulation
+
+The expected delivery period is approximately 6 months of active delivery, with Milestone 2 beginning after the Canton/CC wallet product is stable. If Committee-requested scope changes materially extend delivery, remaining milestones should be reviewed with the Tech & Ops Committee to account for significant USD/CC volatility.
+
+---
+
+## Co-Marketing
+
+Canton Army will support launch and adoption through:
+
+- cantonnews.org distribution
+- CantonNews mobile access
+- Canton Army’s 13.6k Canton-focused follower base
+- Canton Army’s X account and community channels
+- Pilot campaigns with participating Canton projects
+- Project campaign announcements
+- Educational explainers for wallet scoring, consent, and campaign eligibility
+- CantonNews coverage of major governance updates
+- CantonNews articles explaining important CIPs, Dev Fund proposals, validator updates, super validator updates, and governance outcomes
+- Canton Army social distribution of major governance updates
+- Weekly Governance Brief distribution through CantonNews and Canton Army channels
+- Monthly Governance Report distribution through CantonNews and Canton Army channels
+
+A core goal of the Governance Intelligence Module is to make Canton governance more visible and easier to understand. CantonNews and Canton Army will report on governance more consistently by publishing major governance updates, summarizing important developments, and sharing governance information across CantonNews and Canton Army’s social channels.
+
+This gives the Canton ecosystem a clearer public governance communication layer while still linking back to official sources as the source of truth.
+
+---
+
+## Motivation
+
+CantonNews already provides the Canton ecosystem with news, insights, media, press releases, network coverage, featured projects, careers, and events.
+
+The missing pieces are:
+
+1. A structured governance layer that helps users understand what is being proposed, funded, accepted, rejected, or changed.
+2. A wallet activation layer that helps Canton projects reach the users most likely to become active participants.
+
+Together, these additions complete the loop.
+
+Users can discover what is happening in Canton, understand governance, connect their wallet, see relevant opportunities, and receive tailored offers if they opt in.
+
+Projects can stop wasting rewards on broad, low-quality giveaways and instead target wallets that are more likely to use their products.
+
+---
+
+## Rationale
+
+This proposal builds on an existing Canton-focused platform rather than starting from zero.
+
+CantonNews already has the website, audience, mobile distribution, content base, and community presence needed to launch quickly. Canton Army provides an immediate testing and distribution base. Canton Army also has relationships with many projects currently live in the Canton ecosystem, making the pilot and adoption targets realistic.
+
+The Governance Intelligence Module provides a public-good transparency layer.
+
+The Wallet Activation Module provides a practical growth layer for Canton projects.
+
+The key difference from traditional quest platforms is that this system does not reward social task completion. It rewards demonstrated wallet behavior. The goal is to move Canton incentives away from random giveaways and toward targeted offers based on real network activity, loyalty, and product fit.
+
+For projects, this means incentives can become more selective and efficient. Early access codes, fee discounts, CC rewards, onboarding bonuses, and special offers can be directed toward wallets that show the right activity profile instead of being distributed blindly.
+
+For users, this means active network participation can unlock better opportunities. Wallets that genuinely use Canton protocols should have a better chance of receiving relevant offers from new and existing projects.
+
+The external wallet milestone strengthens Canton onboarding by helping projects attract users who have proven activity on other chains but have not yet become active Canton users.
+
+---
+
+## Risk Management
+
+The proposal is designed to reduce implementation and adoption risk by building on CantonNews, an existing Canton-focused platform with an established audience.
+
+The governance module is additive and source-linked. It does not replace official Canton governance sources or alter governance processes.
+
+The wallet activation module is consent-based. Projects will not receive raw database access, and users can opt in or opt out of marketplace visibility, email notifications, Telegram notifications, and project-specific contact sharing.
+
+Wallet scores are activity-based signals, not KYC, identity verification, or proof of personhood. Where network data is incomplete, the system will show confidence indicators rather than overclaiming.
+
+External wallet support is limited to Canton onboarding, Canton project campaign targeting, and Canton app recommendations.
+
+---
+
+## Maintenance and Sustainability
+
+After the grant period, CantonNews will continue operating the platform through a combination of:
+
+- CantonNews operating resources
+- Verified project campaign fees
+- Sponsored Canton project campaigns
+- Optional analytics subscriptions for projects
+- Continued ecosystem reporting partnerships
+
+The grant is for the buildout and launch of the ecosystem intelligence layer, not general CantonNews operations.


### PR DESCRIPTION
This proposal outlines the creation of the CantonNews Ecosystem Intelligence Layer, which includes a Governance Intelligence Module and a Wallet Activation Module to enhance governance transparency and improve user engagement in the Canton Network.

## Development Fund Proposal Submission

**Proposal file:**  
Link to the proposal added in this PR (/proposals/atlas.md)

---

## Summary
Atlas is a Canton-native wallet activity and user acquisition platform that gives Canton projects
a shared, neutral layer for activity-based targeting, campaign delivery, and retention measurement.
Instead of each project running isolated whitelists and quests, Atlas scores wallets based on real
DeFi behavior and matches users to relevant Canton project offers. The platform launches in two
milestones: a Canton pilot with scoring and project portal, followed by cross-chain wallet support
to bring proven DeFi users from other networks into Canton.

---

## Checklist
- [x] Proposal file added under `/proposals/`
- [x] Milestones and funding amounts defined
- [x] Acceptance criteria included
- [x] Alignment with Canton priorities described

---

## Notes for Reviewers
The Atlas team operates Canton Army (14.5K X followers, 4M+ impressions) and Canton News
(1.2k followers, 16K+ website visitors in six weeks), giving Atlas immediate distribution into a Canton-specific
audience from day one.

Pilot agreements or active interest confirmed across 20+ Canton projects including Rho Labs,
EQ Market, Send, Cenote, Raven, Edel, Rapid Chain, ACME, Alpend, OneSwap, Temple, Tradecraft,
EA Finance, Cantex, HANDL, and Nuxaris.

Champion is currently being confirmed.

The scoring engine and anti-abuse logic will remain private to protect system integrity,
but documentation, onboarding guides, scoring methodology, and integration examples will
be publicly available as common-good outputs.