### PR TITLE
Add Shreyas Londhe to SIG directory

### DIFF
--- a/sig-directory.md
+++ b/sig-directory.md
@@ -151,6 +151,7 @@ If your expertise does not fit an existing SIG, feel free to submit a Pull Reque
 | Matthieu Le Berre | Peaceful Studio | monsieurleberre |
 | Niko Cherkezishvilli | Cantor8 | cnnickolay |
 | Simon Meier | Digital Asset | meiersi-da |
+| Shreyas Londhe | Independent | shreyas-londhe |
 | Vinh | Five North | v9n |
 
 
@@ -246,6 +247,7 @@ If your expertise does not fit an existing SIG, feel free to submit a Pull Reque
 | Curtis Hrischuk | Digital Asset | hrischuk-da |
 | Rafael Guglielmetti | Digital Asset |  |
 | Shaul Kfir | Digital Asset | shaul-da |
+| Shreyas Londhe | Independent | shreyas-londhe |
 | Vinh | Five North | v9n |
 | Curtis Hrischuk | Digital Asset | hrischuk-da |
 | Remy Haemmerle | Digital Asset | remyhaemmerle-da |
@@ -313,6 +315,7 @@ If your expertise does not fit an existing SIG, feel free to submit a Pull Reque
 | Jack Charlesworth | LayerZero | jackcharlesworth |
 | Jonathan Mayeur | IntellectEU | jonathan-ieu |
 | Matteo Limberto | Digital Asset |  |
+| Shreyas Londhe | Independent | shreyas-londhe |
 
 ---
 
@@ -333,6 +336,7 @@ If your expertise does not fit an existing SIG, feel free to submit a Pull Reque
 |-----|-----|-----|
 | Edward Newman | Digital Asset | nycnewman |
 | Richard Domikis | MPCH | |
+| Shreyas Londhe | Independent | shreyas-londhe |
 | Stanislav German-Evtushenko | SBI Security Solutions | stas-sbi |
 
 ---


### PR DESCRIPTION
Adding myself to the Security, Financial Workflows & Composability, Canton Protocol & Multi-Synchronizer, and Token Standards / Asset Standards SIGs.

Background: cryptography engineer focused on zero-knowledge proof systems — SNARK provers (WHIR, Spartan, Ligero-style protocols), ZK circuit security, and privacy-preserving protocol design. Recent work includes a PoPETs 2026 paper and open-source prover contributions. Interested in helping review proposals at the intersection of ZK and Canton's selective-disclosure model (e.g. the proof-of-supply-cap direction in #517) and contributing in these areas.

GitHub: shreyas-londhe · Site: https://shreyaslondhe.xyz