### PR TITLE
Add Oleksii Vasyliev to DeFi Protocols & Liquidity

### DIFF
--- a/sig-directory.md
+++ b/sig-directory.md
@@ -124,6 +124,7 @@ If your expertise does not fit an existing SIG, feel free to submit a Pull Reque
 | Ian Hensel | Avro Digital | Ian-avro |
 | Luke Besser | Cosimo Capital | booksbanks|
 | Nate | Obsidian Systems | ApolloUnicorn
+| Oleksii Vasyliev | Canton Trading Toolkit | olevasyliev |
 
 ---
 


### PR DESCRIPTION
Adding myself to the DeFi Protocols & Liquidity SIG, per the "Contributing to SIGs" section of this file.

I maintain [canton-trading-toolkit](https://github.com/olevasyliev/canton-trading-toolkit), an open-source venue-agnostic Python trading client for Canton. It currently speaks four venues across three market structures through one interface: two spot AMMs on mainnet (Cantex and Tradecraft), the Canton DEX reference implementation's order book and RFQ on its hosted testnet, and Ekiden's perpetuals.

Most of that work has been integration feedback rather than code: [srikanth-bitdynamics/Canton-Dex-Reference-Implementation#126](https://github.com/srikanth-bitdynamics/Canton-Dex-Reference-Implementation/issues/126) is the report from six rounds of testing against the reference DEX, and my evaluations are on #312 and #313. I would be glad to review DeFi and liquidity proposals from the position of someone who has had to integrate against these venues from the outside.