### PR TITLE
[Amendment] CIP-105 Extension

### DIFF
--- a/proposals/2026-04-Obsidian-CIP-0105.md
+++ b/proposals/2026-04-Obsidian-CIP-0105.md
@@ -134,7 +134,7 @@ All contracts produced from the design will be subject to Smart Contract Upgrade
 
 ### M1: Technical Design + Splice Maintainer Sign-Off
 
-**Timeline:** Months 1–3
+**Timeline:** Months 1–5
 
 **Focus:** Produce a technical design doc, a complete implementation plan, and an initial draft Daml model that together satisfy the WG functional requirements within Splice architecture and win maintainer buy-in.
 

--- a/proposals/2026-04-Obsidian-CIP-0105.md
+++ b/proposals/2026-04-Obsidian-CIP-0105.md
@@ -164,7 +164,7 @@ All contracts produced from the design will be subject to Smart Contract Upgrade
 
 Of the total, the following amount is allocated to a contributing party:
 
-- **Digital Asset:** 150,000 CC — scoped for Splice maintainer design review during M1
+- **Digital Asset:** 1,000,000 CC — scoped for Splice maintainer design review during M1
 
 Obsidian takes ownership of driving the design to completion; no additional design obligation on DA in exchange for this payment.
 
@@ -190,7 +190,7 @@ A note on maintenance: this proposal funds design only and does not carry a main
 
 | Phase           | Composition                      |
 | --------------- | -------------------------------- |
-| M1 (Months 1–3) | Senior Daml engineer + architect |
+| M1 (Months 1–5) | Senior Daml engineer + architect |
 
 ## Relationship to Implementation Phase Proposal
 


### PR DESCRIPTION
## Development Fund Proposal Amendment

**Proposal file:**  https://github.com/obsidiansystems/canton-dev-fund/blob/e296ea9514e4ba5ac6d28495eb8b31fd7fe71f4e/proposals/2026-04-Obsidian-CIP-0105.md

---

## Summary

Obsidian Systems requests a time extension to continue work on CIP-105 design. We have been working very closely with the Splice team to explore the design space and have work-in-progress design documentation, Daml models, and a CIP draft. As an example of the discovered complexity, please see the [draft CIP](https://docs.google.com/document/d/1VGtgNSNHrHnSLggqxlvhCTFrMPgaeCs2OLEJ8Fq9Ar4/edit?tab=t.753u8f9hx8hv) that Obsidian and the Splice maintainers have been working on that covers details not previously covered by the existing CIPs.

Upon reviewing with the Splice team, we expect these designs to converge in the coming weeks, and would like to ensure there is enough time to present the design to the SVs and community, and incorporate feedback.

We are **not** requesting a change to the total amount of funding, but in recognition of the depth of the collaboration with the Splice team, we are altering the funding split.

---

## Checklist
- [x] Proposal file added under `/proposals/`
- [x] Milestones and funding amounts defined
- [x] Acceptance criteria included
- [x] Alignment with Canton priorities described

---

## Notes for Reviewers
(Add anything the Tech & Ops Committee should pay attention to.)
