### PR TITLE
Proposal: Proof of Audits - Continuous Security & Privacy-Preserving Trust Layer for Canton

### DIFF
--- a/proposals/2026-08-Proof-of-Audits-Continuous-Security-Canton.md
+++ b/proposals/2026-08-Proof-of-Audits-Continuous-Security-Canton.md
@@ -1,0 +1,109 @@
+# Development Fund Proposal
+
+| Field | Value |
+| :---- | :---- |
+| Author | MK Veerendra Vamshi |
+| Org | Proof of Audits |
+| Status | Draft |
+| Created | 2026-08-21 |
+| PR | https://github.com/canton-foundation/canton-dev-fund/pull/653 |
+| Champion | Seeking Champion via SIG - daml-tooling, financial-workflows-composability, regulatory-compliance (contact: dev-fund@canton.foundation, SIG directory) |
+| SIG | daml-tooling, financial-workflows-composability, regulatory-compliance |
+| Labels | daml-tooling |
+| Co-Author | - |
+
+---
+
+# Abstract
+Proof of Audits is the contest platform whose output does not expire. Contest-style discovery (pre-audit readiness, T4->T1 core audit, post-audit fix proof) becomes living evidence: deployed-code match, authority controls, Native v5 scoring /1400, Trust Passport. We propose to build Canton-specific, open-source extensions: Daml-aware Pre-Audit Engine, Privacy-Preserving Trust Passport (permissioned evidence vault), and Canton support for Contract Shield (bytecode + authority match). Delivers shared security infra for all Canton apps. Live at https://proofofaudits.com - public beta 30 Jul 2026, pre-revenue, 40+ auditors scored.
+
+# Specification
+
+## 1. Objective
+**What we are:** Proof of Audits - contest for discovery, proof for protection. Public website + operational app that makes proof easier to trust than a badge or PDF. Trust boundary: we present evidence and remaining risk, not a safety guarantee. Positioning: #contest-to-proof -> #how-we-do-it -> #how-we-are-better.
+
+**What we do:** 4 sequential phases: Pre-Audit (X-Ray + Antigravity bundle: invariants, Halmos verification), Core Audit (4-tier waterfall T4 Function -> T3 Contract -> T2 Cross-Contract -> T1 System, sequential validation), Post-Audit (independent fix verification), Scoring & Evidence (/1400 VTI, Trust Passport, Contract Shield).
+
+**Why for Canton:** Canton is privacy-by-default (need-to-know, Daml signatory/observer/controller, synchronizer sees only metadata). Institutions (Goldman, DTCC, Euroclear) cannot use public EVM static PDFs. Daml authorization leaks and cross-package authority delegation are invisible to Solidity tools (Slither/Halmos). Canton needs continuous compliance proof.
+
+## 2. Implementation Mechanics
+1. **Daml Pre-Audit Adapter:** Parse `.dar` + `daml.yaml`, build call graph for templates/interfaces/choices, port 7-step invariant taxonomy (conservation, guard lift, ratio, state machine, temporal, cross-contract, economic) to Daml choices.
+2. **Cross-Package Analyzer:** Input compiled `.dar`, output for every cross-package interaction: source file, line/col, calling package/version, referenced package/interface, template/choice, consuming flag. Produces stable JSON + visual graph (Graphviz/Mermaid), like 2026-03 Certora proposal but for audit scoping.
+3. **Permissioned Trust Passport:** Public: VTI /1400 + green check + freshness timestamp. Private vault: full Evidence Bundle + key-holder interview, KYC-gated decrypt + ZK attestation (proves keys verified without revealing identities). Solves privacy conflict for banks.
+4. **Contract Shield for Canton:** Extension at /extension + /verify-contract verifies `deployed DAR hash == reviewed DAR hash` and authority controls (party allocation, signatory thresholds) before signing. 100% free for users. Integrates with `dpm`/`daml build` CI.
+
+## 3. Architectural Alignment
+Operates at package level on compiled `.dar` - same artifact deployed. Static only, no ledger mutation, no runtime change. Respects Canton privacy: need-to-know visibility. Complements Zenith EVM (CIP-0091, `external_call`) by covering Daml-native and Daml<>EVM composability. Aligns with Canton polyglot vision.
+
+## 4. Open-Source
+Apache-2.0. All code repos public under Proof of Audits. Proposal docs CC0-1.0.
+
+## 5. Backward Compatibility
+No impact. Tool only reads `.dar`, does not modify code or ledger state.
+
+---
+
+# Milestones and Deliverables
+
+## Milestone 1: Daml Pre-Audit Adapter & Analyzer - 2 months
+CLI that takes `.dar` input, outputs stable JSON + visual graph. Detects choice exercise + template usage with all 6 fields per interaction. Includes docs, validated on representative Daml projects.
+
+## Milestone 2: Permissioned Trust Passport + Pilot - 1 month
+Passport service with public/private split + ZK demo live. Run on Splice + 5 voting member apps / representative deployments (with Foundation intro support). Feedback incorporated, docs updated.
+
+## Milestone 3: Contract Shield for Canton + Broad Adoption - 1 month
+Extension verifies DAR hash + authority on Canton validator. Run on 5 additional production-scale deployments. CI template + tutorial video published.
+
+| Milestone | Duration | Start After Approval | Funding |
+| :---- | :---- | :---- | :---- |
+| M1: Daml Adapter & Analyzer | 2 months | Month 0 | 150,000 CC |
+| M2: Passport Pilot | 1 month | Month 2 | 135,000 CC |
+| M3: Shield Adoption | 1 month | Month 3 | 135,000 CC |
+| **Total** | **4 months** |  | **420,000 CC** |
+
+Volatility: denominated in CC at 0.15 USD reference, 30-day MA band 33.3% (0.10-0.225), monthly rebase if outside band per Zenith model.
+
+---
+
+# Acceptance Criteria
+
+**M1:**
+- CLI runs on Linux/MacOS/Windows, accepts `.dar`, outputs stable JSON + visual
+- Reports all interactions with: source file path, line/col, calling package/version, referenced package/interface, template/choice, consuming flag
+- Detects both choice exercise and template usage
+- Documentation explains usage and interpretation
+- Released Apache-2.0, 3 voting members review and accept
+
+**M2:**
+- Passport live with public score + private vault + ZK attestation demo
+- Splice + 5 voting members/representative deployments have run tool on their codebases
+- Each endorses milestone and expresses interest to continue use
+- Feedback incorporated, docs updated
+
+**M3:**
+- 5 additional production-scale deployments have run tool, endorsed milestone
+- Extension published and verifies deployed DAR matches reviewed DAR on Canton validator
+- CI integration example live, tutorial published
+
+---
+
+# Funding
+**Total: 420,000 Canton Coin**, milestone-based, released after acceptance per CIP-0100. Quarterly reporting. Funding administered by Tech & Ops Committee.
+
+# Co-Marketing
+Joint blog on Daml cross-package security, technical deep-dive on permissioned proof, workshop for Canton devs, demo at quarterly report.
+
+# Motivation
+Makes Canton audits faster, deterministic, privacy-preserving. Reduces manual review time, catches unintended authority delegation in multi-party workflows. Essential for multi-party finance where delegated control over money movement is hardest to detect.
+
+# Rationale
+Analyzing deployed `.dar` is most reliable - reflects exact deployed code and allowed authority. Deterministic, faster and more consistent than manual review, easy to integrate into CI. Complements rather than replaces audits.
+
+# Team
+MK Veerendra Vamshi - solo founder, Proof of Audits. Top 10 Sherlock, 180+ GitHub repos, Cyfrin certified. Full-stack Web3.
+
+# Maintenance
+12 months maintenance included (bug fixes, Daml SDK updates). Future work via follow-on proposal if needed.
+
+# License
+Proposal CC0-1.0, Code Apache-2.0

--- a/proposals/2026-08-Proof-of-Audits-Continuous-Security-Canton.md
+++ b/proposals/2026-08-Proof-of-Audits-Continuous-Security-Canton.md
@@ -6,104 +6,116 @@
 | Org | Proof of Audits |
 | Status | Draft |
 | Created | 2026-08-21 |
-| PR | https://github.com/canton-foundation/canton-dev-fund/pull/653 |
-| Champion | Seeking Champion via SIG - daml-tooling, financial-workflows-composability, regulatory-compliance (contact: dev-fund@canton.foundation, SIG directory) |
-| SIG | daml-tooling, financial-workflows-composability, regulatory-compliance |
-| Labels | daml-tooling |
-| Co-Author | - |
+| Champion | TBD - Tech & Ops Champion to be assigned via SIG daml-tooling (per CIP-0100 external proposal flow) |
+| SIG | daml-tooling |
+| PR | https://github.com/canton-foundation/canton-dev-fund/pull/654 |
 
 ---
 
 # Abstract
-Proof of Audits is the contest platform whose output does not expire. Contest-style discovery (pre-audit readiness, T4->T1 core audit, post-audit fix proof) becomes living evidence: deployed-code match, authority controls, Native v5 scoring /1400, Trust Passport. We propose to build Canton-specific, open-source extensions: Daml-aware Pre-Audit Engine, Privacy-Preserving Trust Passport (permissioned evidence vault), and Canton support for Contract Shield (bytecode + authority match). Delivers shared security infra for all Canton apps. Live at https://proofofaudits.com - public beta 30 Jul 2026, pre-revenue, 40+ auditors scored.
+**Proof of Audits is the contest platform whose output does not expire.** Our main is the **T4->T1 sequential waterfall** - the only audit model that guarantees full coverage with zero duplicate pay and zero blind spots. We propose to ship this T4->T1 engine for Canton as open-source, Canton-native infrastructure: Daml-aware analysis + continuous proof (DAR match + authority) + permissioned Trust Passport. All at once - one unified delivery, not piecemeal.
+
+**Core thesis:** Most contests have 10 auditors looking at same high-value lines while boring edge cases are missed. Our T4 (Function) -> T3 (Contract) -> T2 (Cross-Contract) -> T1 (System) waterfall is sequential: T3 must validate T4 findings before work, T2 validates T3, T1 validates T2. No redundancy, 100% coverage. This is the missing shared infra for Canton.
 
 # Specification
 
-## 1. Objective
-**What we are:** Proof of Audits - contest for discovery, proof for protection. Public website + operational app that makes proof easier to trust than a badge or PDF. Trust boundary: we present evidence and remaining risk, not a safety guarantee. Positioning: #contest-to-proof -> #how-we-do-it -> #how-we-are-better.
+## 1. What Proof of Audits is (correct wording)
+Proof of Audits - contest for discovery, proof for protection. Public website + operational app that makes proof easier to trust than a badge or PDF. Trust boundary: we present evidence and remaining risk, not a safety guarantee. Live at https://proofofaudits.com - public beta 30 Jul 2026, pre-revenue, 40+ auditors scored, solo founder MK Veerendra Vamshi. Positioning: #contest-to-proof -> #how-we-do-it -> #how-we-are-better.
 
-**What we do:** 4 sequential phases: Pre-Audit (X-Ray + Antigravity bundle: invariants, Halmos verification), Core Audit (4-tier waterfall T4 Function -> T3 Contract -> T2 Cross-Contract -> T1 System, sequential validation), Post-Audit (independent fix verification), Scoring & Evidence (/1400 VTI, Trust Passport, Contract Shield).
+## 2. Why Canton needs T4->T1
+Canton is privacy-by-default (need-to-know, Daml signatory/observer/controller, synchronizer sees only metadata). Institutions cannot trust static PDFs. Daml failures are not Solidity reentrancy - they are **authorization leaks, cross-package choice exercise delegation, and multi-party workflow breaks**. These live exactly in T2 (cross-contract) and T1 (system) - the layers every other audit model ignores. Without T4->T1, Canton has no guarantee those layers were reviewed.
 
-**Why for Canton:** Canton is privacy-by-default (need-to-know, Daml signatory/observer/controller, synchronizer sees only metadata). Institutions (Goldman, DTCC, Euroclear) cannot use public EVM static PDFs. Daml authorization leaks and cross-package authority delegation are invisible to Solidity tools (Slither/Halmos). Canton needs continuous compliance proof.
+## 3. Implementation - all at once
+**Single unified CLI + Passport + Shield - built together, shipped together:**
 
-## 2. Implementation Mechanics
-1. **Daml Pre-Audit Adapter:** Parse `.dar` + `daml.yaml`, build call graph for templates/interfaces/choices, port 7-step invariant taxonomy (conservation, guard lift, ratio, state machine, temporal, cross-contract, economic) to Daml choices.
-2. **Cross-Package Analyzer:** Input compiled `.dar`, output for every cross-package interaction: source file, line/col, calling package/version, referenced package/interface, template/choice, consuming flag. Produces stable JSON + visual graph (Graphviz/Mermaid), like 2026-03 Certora proposal but for audit scoping.
-3. **Permissioned Trust Passport:** Public: VTI /1400 + green check + freshness timestamp. Private vault: full Evidence Bundle + key-holder interview, KYC-gated decrypt + ZK attestation (proves keys verified without revealing identities). Solves privacy conflict for banks.
-4. **Contract Shield for Canton:** Extension at /extension + /verify-contract verifies `deployed DAR hash == reviewed DAR hash` and authority controls (party allocation, signatory thresholds) before signing. 100% free for users. Integrates with `dpm`/`daml build` CI.
+**T4 Engine (Function):** Granular edge cases per choice - delta writes, guard predicates, fund flows per function. Synthetic Halmos-style checks on Daml choices.
 
-## 3. Architectural Alignment
-Operates at package level on compiled `.dar` - same artifact deployed. Static only, no ledger mutation, no runtime change. Respects Canton privacy: need-to-know visibility. Complements Zenith EVM (CIP-0091, `external_call`) by covering Daml-native and Daml<>EVM composability. Aligns with Canton polyglot vision.
+**T3 Engine (Contract):** Whole-contract invariant checks per template/interface. Must validate T4 findings first.
 
-## 4. Open-Source
-Apache-2.0. All code repos public under Proof of Audits. Proposal docs CC0-1.0.
+**T2 Engine (Cross-Contract):** The Canton-critical layer. Parses compiled `.dar`, builds call graph, reports every place package A can exercise a choice or create a template of package B with file:line, package versions, template/choice, consuming flag. Produces stable JSON + Graphviz/Mermaid (as in Certora 2026-03 proposal but wired into T4->T1 chain). This catches delegated money movement.
 
-## 5. Backward Compatibility
-No impact. Tool only reads `.dar`, does not modify code or ledger state.
+**T1 Engine (System):** Global workflow, economics, governance across subnets. Validates T2 findings before system verdict.
+
+**Continuous Proof (all tiers):** DAR hash matching (`deployed DAR == reviewed DAR`), authority controls (party allocation, signatory thresholds), Native v5 scoring /1400, permissioned Trust Passport (public VTI + green check, private vault with KYC-gated full bundle + ZK attestation so banks don't leak IP).
+
+**Contract Shield for Canton:** Extension /verify-contract checks DAR match + authority before signing. 100% free. Integrates with `daml build`/`dpm` CI.
+
+## 4. Architectural Alignment
+Operates at package level on compiled `.dar` - same artifact deployed. Static only, no ledger mutation. Respects need-to-know privacy. Complements Zenith EVM (CIP-0091 `external_call`) by covering Daml-native + Daml<>EVM composability. No backward compatibility impact - only reads `.dar`.
+
+## 5. Open-Source
+Apache-2.0 for code, CC0-1.0 for proposal. All repos public.
 
 ---
 
-# Milestones and Deliverables
+# Milestones and Deliverables - all at once, 4 months
 
-## Milestone 1: Daml Pre-Audit Adapter & Analyzer - 2 months
-CLI that takes `.dar` input, outputs stable JSON + visual graph. Detects choice exercise + template usage with all 6 fields per interaction. Includes docs, validated on representative Daml projects.
+We deliver T4->T1 as one integrated system, but payments stay milestone-based per fund rules:
 
-## Milestone 2: Permissioned Trust Passport + Pilot - 1 month
-Passport service with public/private split + ZK demo live. Run on Splice + 5 voting member apps / representative deployments (with Foundation intro support). Feedback incorporated, docs updated.
+## Milestone 1: T4->T1 Daml Engine (Core) - 2 months - 210,000 CC
+- T4+T3+T2+T1 engines working on `.dar` input
+- CLI on Linux/MacOS/Windows outputs JSON + visual for all tiers
+- T2 cross-package reports with 6 fields (file, line/col, calling pkg/version, referenced template/interface/choice, consuming flag)
+- T4->T3->T2->T1 validation chain enforced (can't skip tier)
+- Docs + Apache-2.0 + validated on 2 representative Daml projects
 
-## Milestone 3: Contract Shield for Canton + Broad Adoption - 1 month
-Extension verifies DAR hash + authority on Canton validator. Run on 5 additional production-scale deployments. CI template + tutorial video published.
+## Milestone 2: Pilot on Live Canton Apps - 1 month - 105,000 CC
+- Run integrated engine on Splice + 5 voting member apps / representative deployments (with Foundation intros)
+- Issue permissioned Trust Passports (public /1400 + private vault)
+- Each deployment endorses milestone, feedback incorporated
 
-| Milestone | Duration | Start After Approval | Funding |
-| :---- | :---- | :---- | :---- |
-| M1: Daml Adapter & Analyzer | 2 months | Month 0 | 150,000 CC |
-| M2: Passport Pilot | 1 month | Month 2 | 135,000 CC |
-| M3: Shield Adoption | 1 month | Month 3 | 135,000 CC |
-| **Total** | **4 months** |  | **420,000 CC** |
+## Milestone 3: Contract Shield + Broad Adoption - 1 month - 105,000 CC
+- Shield extension live verifying DAR hash + authority on Canton validator
+- 5 additional production deployments run integrated T4->T1 engine, endorse
+- CI template for `daml build` + tutorial video
 
-Volatility: denominated in CC at 0.15 USD reference, 30-day MA band 33.3% (0.10-0.225), monthly rebase if outside band per Zenith model.
+| Milestone | Duration | Funding |
+| :---- | :---- | :---- |
+| M1: T4->T1 Engine | 2 months | 210,000 CC |
+| M2: Pilot | 1 month | 105,000 CC |
+| M3: Shield + Adoption | 1 month | 105,000 CC |
+| **Total** | **4 months** | **420,000 CC** |
+
+Volatility: denominated CC at 0.15 USD ref, 30-day MA band 33.3% (0.10-0.225).
 
 ---
 
 # Acceptance Criteria
 
-**M1:**
-- CLI runs on Linux/MacOS/Windows, accepts `.dar`, outputs stable JSON + visual
-- Reports all interactions with: source file path, line/col, calling package/version, referenced package/interface, template/choice, consuming flag
-- Detects both choice exercise and template usage
-- Documentation explains usage and interpretation
-- Released Apache-2.0, 3 voting members review and accept
+**M1 (T4->T1 Engine):**
+- CLI accepts `.dar`, runs all 4 tiers sequentially, enforcement verified (T3 can't run without T4 pass)
+- T2 detects both choice exercise + template usage with all 6 fields
+- JSON stable + visual graph available
+- 3 voting members review and accept, Apache-2.0 released
 
-**M2:**
-- Passport live with public score + private vault + ZK attestation demo
-- Splice + 5 voting members/representative deployments have run tool on their codebases
-- Each endorses milestone and expresses interest to continue use
-- Feedback incorporated, docs updated
+**M2 (Pilot):**
+- Splice + 5 members run full T4->T1 engine, passports issued
+- Each endorses and expresses interest to continue
 
-**M3:**
-- 5 additional production-scale deployments have run tool, endorsed milestone
-- Extension published and verifies deployed DAR matches reviewed DAR on Canton validator
-- CI integration example live, tutorial published
+**M3 (Shield):**
+- Extension verifies deployed DAR == reviewed DAR + authority
+- 5 additional deployments run full engine, endorse
+- CI example + tutorial published
 
 ---
 
 # Funding
-**Total: 420,000 Canton Coin**, milestone-based, released after acceptance per CIP-0100. Quarterly reporting. Funding administered by Tech & Ops Committee.
+**Total: 420,000 Canton Coin**, milestone-based per CIP-0100. Quarterly reporting via Tech & Ops Committee.
 
 # Co-Marketing
-Joint blog on Daml cross-package security, technical deep-dive on permissioned proof, workshop for Canton devs, demo at quarterly report.
+Joint blog: "Why T4->T1 is the missing coverage model for Daml", deep-dive on cross-package delegation risk, workshop for Canton devs.
 
 # Motivation
-Makes Canton audits faster, deterministic, privacy-preserving. Reduces manual review time, catches unintended authority delegation in multi-party workflows. Essential for multi-party finance where delegated control over money movement is hardest to detect.
+Canton has EVM compatibility (Zenith) and a Daml analyzer (Certora) but no guaranteed-coverage audit model. T4->T1 fills that gap - the only model that proves every layer was reviewed by the right specialist with no overlap and no blind spot.
 
 # Rationale
-Analyzing deployed `.dar` is most reliable - reflects exact deployed code and allowed authority. Deterministic, faster and more consistent than manual review, easy to integrate into CI. Complements rather than replaces audits.
+Deployed `.dar` analysis is most reliable - reflects exact deployed code. T4->T1 sequential validation is faster and more deterministic than crowd re-review, easy CI integration.
 
 # Team
 MK Veerendra Vamshi - solo founder, Proof of Audits. Top 10 Sherlock, 180+ GitHub repos, Cyfrin certified. Full-stack Web3.
 
 # Maintenance
-12 months maintenance included (bug fixes, Daml SDK updates). Future work via follow-on proposal if needed.
+12 months maintenance (bug fixes, Daml SDK updates).
 
 # License
 Proposal CC0-1.0, Code Apache-2.0

--- a/proposals/2026-08-Proof-of-Audits-Continuous-Security-Canton.md
+++ b/proposals/2026-08-Proof-of-Audits-Continuous-Security-Canton.md
@@ -1,121 +1,79 @@
-# Development Fund Proposal
+# Development Fund Proposal - Proof of Audits for Canton
 
 | Field | Value |
 | :---- | :---- |
-| Author | MK Veerendra Vamshi |
+| Author | MK Veerendra Vamshi - Proof of Audits (solo founder, https://proofofaudits.com) |
 | Org | Proof of Audits |
-| Status | Draft |
-| Created | 2026-08-21 |
-| Champion | TBD - Tech & Ops Champion to be assigned via SIG daml-tooling (per CIP-0100 external proposal flow) |
+| Champion | Seeking Champion - I would love a Tech & Ops member to champion this (SIG: daml-tooling) |
 | SIG | daml-tooling |
-| PR | https://github.com/canton-foundation/canton-dev-fund/pull/654 |
+| Created | 2026-08-21 |
+| Status | Draft for Champion review |
 
 ---
 
-# Abstract
-**Proof of Audits is the contest platform whose output does not expire.** Our main is the **T4->T1 sequential waterfall** - the only audit model that guarantees full coverage with zero duplicate pay and zero blind spots. We propose to ship this T4->T1 engine for Canton as open-source, Canton-native infrastructure: Daml-aware analysis + continuous proof (DAR match + authority) + permissioned Trust Passport. All at once - one unified delivery, not piecemeal.
+Hi Canton team - I am MK, I built Proof of Audits.
 
-**Core thesis:** Most contests have 10 auditors looking at same high-value lines while boring edge cases are missed. Our T4 (Function) -> T3 (Contract) -> T2 (Cross-Contract) -> T1 (System) waterfall is sequential: T3 must validate T4 findings before work, T2 validates T3, T1 validates T2. No redundancy, 100% coverage. This is the missing shared infra for Canton.
+**What I built:** I run a contest platform where the report does not die after the audit. We find bugs with contests, then we keep the proof alive - we match the deployed DAR to the reviewed DAR, we check authority controls, we score it /1400, and we show it in a Trust Passport. Anyone can verify before they sign via our free Contract Shield extension.
 
-# Specification
+**Our core is T4->T1.** I do not run a crowd where 10 people check the same lines. I run 4 tiers in sequence:
+- **T4** checks functions (edge cases)
+- **T3** checks contracts (must first validate T4)
+- **T2** checks cross-contract calls (must first validate T3)
+- **T1** checks the whole system (must first validate T2)
 
-## 1. What Proof of Audits is (correct wording)
-Proof of Audits - contest for discovery, proof for protection. Public website + operational app that makes proof easier to trust than a badge or PDF. Trust boundary: we present evidence and remaining risk, not a safety guarantee. Live at https://proofofaudits.com - public beta 30 Jul 2026, pre-revenue, 40+ auditors scored, solo founder MK Veerendra Vamshi. Positioning: #contest-to-proof -> #how-we-do-it -> #how-we-are-better.
+No duplicate pay, no blind spots. T3 cannot start until T4 is done, and so on. That is our main.
 
-## 2. Why Canton needs T4->T1
-Canton is privacy-by-default (need-to-know, Daml signatory/observer/controller, synchronizer sees only metadata). Institutions cannot trust static PDFs. Daml failures are not Solidity reentrancy - they are **authorization leaks, cross-package choice exercise delegation, and multi-party workflow breaks**. These live exactly in T2 (cross-contract) and T1 (system) - the layers every other audit model ignores. Without T4->T1, Canton has no guarantee those layers were reviewed.
+**Why this matters for Canton:**
+Canton hides data by default - only the right parties see the right data. That is great for banks, but it also hides the exact risk: in Daml, the bug is not reentrancy, it is "package A quietly exercising a choice of package B and moving money" or a bad signatory. That risk lives in T2 and T1 - the layers most audits skip. Canton has EVM support (Zenith) and a great Daml analyzer (Certora), but no one guarantees T4->T1 was actually covered. I want to build that guarantee for Canton.
 
-## 3. Implementation - all at once
-**Single unified CLI + Passport + Shield - built together, shipped together:**
+**What I will ship for Canton - all at once, not piecemeal:**
 
-**T4 Engine (Function):** Granular edge cases per choice - delta writes, guard predicates, fund flows per function. Synthetic Halmos-style checks on Daml choices.
+I will ship one unified system - CLI + Passport + Shield - built together:
 
-**T3 Engine (Contract):** Whole-contract invariant checks per template/interface. Must validate T4 findings first.
+1. **T4-T1 Daml engine:** Give it a `.dar`, it builds the call graph, it checks all 4 tiers in order. T2 specifically lists every place where one package can use another package's template/choice - with file, line, package versions, template/choice name, and whether it consumes. You get JSON you can use in CI plus a visual graph.
 
-**T2 Engine (Cross-Contract):** The Canton-critical layer. Parses compiled `.dar`, builds call graph, reports every place package A can exercise a choice or create a template of package B with file:line, package versions, template/choice, consuming flag. Produces stable JSON + Graphviz/Mermaid (as in Certora 2026-03 proposal but wired into T4->T1 chain). This catches delegated money movement.
+2. **Permissioned Trust Passport:** Because banks cannot leak IP, I will make passports permissioned. Public sees a green check and a /1400 score. The full bundle and the interview stay in a private vault - only a KYC'd counterparty you approve can open it. I can also give a ZK attestation: "keys are verified" without revealing who holds them.
 
-**T1 Engine (System):** Global workflow, economics, governance across subnets. Validates T2 findings before system verdict.
+3. **Contract Shield for Canton:** My free extension already does this for EVM at proofofaudits.com/verify-contract. I will add Canton - it checks "does the DAR on the validator equal the DAR we reviewed?" and "are the signatories right?" before you sign.
 
-**Continuous Proof (all tiers):** DAR hash matching (`deployed DAR == reviewed DAR`), authority controls (party allocation, signatory thresholds), Native v5 scoring /1400, permissioned Trust Passport (public VTI + green check, private vault with KYC-gated full bundle + ZK attestation so banks don't leak IP).
-
-**Contract Shield for Canton:** Extension /verify-contract checks DAR match + authority before signing. 100% free. Integrates with `daml build`/`dpm` CI.
-
-## 4. Architectural Alignment
-Operates at package level on compiled `.dar` - same artifact deployed. Static only, no ledger mutation. Respects need-to-know privacy. Complements Zenith EVM (CIP-0091 `external_call`) by covering Daml-native + Daml<>EVM composability. No backward compatibility impact - only reads `.dar`.
-
-## 5. Open-Source
-Apache-2.0 for code, CC0-1.0 for proposal. All repos public.
+All of this runs on the compiled `.dar` - the same file you deploy. It only reads, it never changes the ledger. It fits right into `daml build` / `dpm` / CI. I will open-source it Apache-2.0.
 
 ---
 
-# Milestones and Deliverables - all at once, 4 months
+# How I will deliver it - 4 months, milestone-based
 
-We deliver T4->T1 as one integrated system, but payments stay milestone-based per fund rules:
+**M1 - Build the T4->T1 engine (2 months, 210k CC):**
+I will deliver a CLI that runs on Linux/Mac/Windows, takes a `.dar`, runs T4->T3->T2->T1 in order, and blocks T3 if T4 has not passed. T2 will report all 6 fields for every cross-package use. I will docs it and release it Apache-2.0, tested on 2 real Daml projects.
 
-## Milestone 1: T4->T1 Daml Engine (Core) - 2 months - 210,000 CC
-- T4+T3+T2+T1 engines working on `.dar` input
-- CLI on Linux/MacOS/Windows outputs JSON + visual for all tiers
-- T2 cross-package reports with 6 fields (file, line/col, calling pkg/version, referenced template/interface/choice, consuming flag)
-- T4->T3->T2->T1 validation chain enforced (can't skip tier)
-- Docs + Apache-2.0 + validated on 2 representative Daml projects
+**M2 - Pilot it on real Canton apps (1 month, 105k CC):**
+With your intros, I will run it on Splice + 5 voting member apps. I will issue their first permissioned passports and fix what you tell me to fix.
 
-## Milestone 2: Pilot on Live Canton Apps - 1 month - 105,000 CC
-- Run integrated engine on Splice + 5 voting member apps / representative deployments (with Foundation intros)
-- Issue permissioned Trust Passports (public /1400 + private vault)
-- Each deployment endorses milestone, feedback incorporated
+**M3 - Shield + broad adoption (1 month, 105k CC):**
+I will ship the Canton Shield extension, verify DAR hash + authority on a live validator, run the engine on 5 more production apps, and publish a CI template + short video.
 
-## Milestone 3: Contract Shield + Broad Adoption - 1 month - 105,000 CC
-- Shield extension live verifying DAR hash + authority on Canton validator
-- 5 additional production deployments run integrated T4->T1 engine, endorse
-- CI template for `daml build` + tutorial video
-
-| Milestone | Duration | Funding |
-| :---- | :---- | :---- |
-| M1: T4->T1 Engine | 2 months | 210,000 CC |
-| M2: Pilot | 1 month | 105,000 CC |
-| M3: Shield + Adoption | 1 month | 105,000 CC |
-| **Total** | **4 months** | **420,000 CC** |
-
-Volatility: denominated CC at 0.15 USD ref, 30-day MA band 33.3% (0.10-0.225).
+Total: 420k CC, paid per milestone per CIP-0100 (0.15 USD ref, 30-day MA band 33.3%).
 
 ---
 
-# Acceptance Criteria
+# How you can check I delivered
 
-**M1 (T4->T1 Engine):**
-- CLI accepts `.dar`, runs all 4 tiers sequentially, enforcement verified (T3 can't run without T4 pass)
-- T2 detects both choice exercise + template usage with all 6 fields
-- JSON stable + visual graph available
-- 3 voting members review and accept, Apache-2.0 released
+**M1:** You run `prove --dar app.dar` and you get JSON + graph with the 6 fields, and you see T3 blocked until T4 passes. 3 voting members try it and say "yes".
 
-**M2 (Pilot):**
-- Splice + 5 members run full T4->T1 engine, passports issued
-- Each endorses and expresses interest to continue
+**M2:** Splice + 5 members ran it, got passports, and say they want to keep using it.
 
-**M3 (Shield):**
-- Extension verifies deployed DAR == reviewed DAR + authority
-- 5 additional deployments run full engine, endorse
-- CI example + tutorial published
+**M3:** Shield shows green for a correct DAR and red for a wrong DAR on a validator. 5 more members ran it and endorsed. CI template works.
 
 ---
 
-# Funding
-**Total: 420,000 Canton Coin**, milestone-based per CIP-0100. Quarterly reporting via Tech & Ops Committee.
+# Why I am asking Canton
+You give me milestone funding, I give Canton open infra that makes every future audit provably covered. This fills the gap between Zenith (EVM) and Certora (analyzer) - I give you the guaranteed-coverage model.
 
-# Co-Marketing
-Joint blog: "Why T4->T1 is the missing coverage model for Daml", deep-dive on cross-package delegation risk, workshop for Canton devs.
+I will also write a joint blog on cross-package delegation risk and run a workshop for Canton devs.
 
-# Motivation
-Canton has EVM compatibility (Zenith) and a Daml analyzer (Certora) but no guaranteed-coverage audit model. T4->T1 fills that gap - the only model that proves every layer was reviewed by the right specialist with no overlap and no blind spot.
+**About me:** Solo founder, Top 10 Sherlock, 180+ repos, Cyfrin certified. I live at proofofaudits.com (beta 30 Jul 2026, pre-revenue, 40 auditors scored). I will maintain this for 12 months.
 
-# Rationale
-Deployed `.dar` analysis is most reliable - reflects exact deployed code. T4->T1 sequential validation is faster and more deterministic than crowd re-review, easy CI integration.
+Happy to jump on a 15-min call and adapt this to what SIG daml-tooling needs most.
 
-# Team
-MK Veerendra Vamshi - solo founder, Proof of Audits. Top 10 Sherlock, 180+ GitHub repos, Cyfrin certified. Full-stack Web3.
+- MK
 
-# Maintenance
-12 months maintenance (bug fixes, Daml SDK updates).
-
-# License
-Proposal CC0-1.0, Code Apache-2.0
+License: Proposal CC0-1.0, Code Apache-2.0


### PR DESCRIPTION
Hi Canton team - I am MK, solo founder of Proof of Audits (https://proofofaudits.com).

I built a contest platform where the report does not die after the audit. We run T4->T1: Function -> Contract -> Cross-Contract -> System in sequence. T3 cannot start until T4 is validated, T2 until T3, T1 until T2. No duplicate pay, no blind spots.

For Canton I want to ship this T4->T1 engine as open-source, all at once:

- Give it a `.dar`, it lists every place package A can use package B's template/choice (file, line, versions, choice, consuming) - JSON + graph for CI
- Permissioned Trust Passport: public green check + /1400, private vault for full bundle/interview (banks don't leak IP) + ZK attestation
- Contract Shield for Canton: free extension checks "deployed DAR == reviewed DAR" + signatories before you sign

This fills the gap outside Zenith (EVM) and Certora (analyzer) - guaranteed coverage.

**Full proposal is in the file below - pasted directly here as you do for other PRs:**

---

# Development Fund Proposal - Proof of Audits for Canton

| Field | Value |
| :---- | :---- |
| Author | MK Veerendra Vamshi - Proof of Audits (solo founder, https://proofofaudits.com) |
| Org | Proof of Audits |
| Champion | Seeking Champion - I would love a Tech & Ops member to champion this (SIG: daml-tooling) |
| SIG | daml-tooling |
| Created | 2026-08-21 |
| Status | Draft for Champion review |

---

Hi Canton team - I am MK, I built Proof of Audits.

**What I built:** I run a contest platform where the report does not die after the audit. We find bugs with contests, then we keep the proof alive - we match the deployed DAR to the reviewed DAR, we check authority controls, we score it /1400, and we show it in a Trust Passport. Anyone can verify before they sign via our free Contract Shield extension.

**Our core is T4->T1.** I do not run a crowd where 10 people check the same lines. I run 4 tiers in sequence:
- **T4** checks functions (edge cases)
- **T3** checks contracts (must first validate T4)
- **T2** checks cross-contract calls (must first validate T3)
- **T1** checks the whole system (must first validate T2)

No duplicate pay, no blind spots. T3 cannot start until T4 is done, and so on. That is our main.

**Why this matters for Canton:**
Canton hides data by default - only the right parties see the right data. That is great for banks, but it also hides the exact risk: in Daml, the bug is not reentrancy, it is "package A quietly exercising a choice of package B and moving money" or a bad signatory. That risk lives in T2 and T1 - the layers most audits skip. Canton has EVM support (Zenith) and a great Daml analyzer (Certora), but no one guarantees T4->T1 was actually covered. I want to build that guarantee for Canton.

**What I will ship for Canton - all at once, not piecemeal:**

I will ship one unified system - CLI + Passport + Shield - built together:

1. **T4-T1 Daml engine:** Give it a `.dar`, it builds the call graph, it checks all 4 tiers in order. T2 specifically lists every place where one package can use another package's template/choice - with file, line, package versions, template/choice name, and whether it consumes. You get JSON you can use in CI plus a visual graph.

2. **Permissioned Trust Passport:** Because banks cannot leak IP, I will make passports permissioned. Public sees a green check and a /1400 score. The full bundle and the interview stay in a private vault - only a KYC'd counterparty you approve can open it. I can also give a ZK attestation: "keys are verified" without revealing who holds them.

3. **Contract Shield for Canton:** My free extension already does this for EVM at proofofaudits.com/verify-contract. I will add Canton - it checks "does the DAR on the validator equal the DAR we reviewed?" and "are the signatories right?" before you sign.

All of this runs on the compiled `.dar` - the same file you deploy. It only reads, it never changes the ledger. It fits right into `daml build` / `dpm` / CI. I will open-source it Apache-2.0.

---

# How I will deliver it - 4 months, milestone-based

**M1 - Build the T4->T1 engine (2 months, 210k CC):**
I will deliver a CLI that runs on Linux/Mac/Windows, takes a `.dar`, runs T4->T3->T2->T1 in order, and blocks T3 if T4 has not passed. T2 will report all 6 fields for every cross-package use. I will docs it and release it Apache-2.0, tested on 2 real Daml projects.

**M2 - Pilot it on real Canton apps (1 month, 105k CC):**
With your intros, I will run it on Splice + 5 voting member apps. I will issue their first permissioned passports and fix what you tell me to fix.

**M3 - Shield + broad adoption (1 month, 105k CC):**
I will ship the Canton Shield extension, verify DAR hash + authority on a live validator, run the engine on 5 more production apps, and publish a CI template + short video.

Total: 420k CC, paid per milestone per CIP-0100 (0.15 USD ref, 30-day MA band 33.3%).

---

# How you can check I delivered

**M1:** You run `prove --dar app.dar` and you get JSON + graph with the 6 fields, and you see T3 blocked until T4 passes. 3 voting members try it and say "yes".

**M2:** Splice + 5 members ran it, got passports, and say they want to keep using it.

**M3:** Shield shows green for a correct DAR and red for a wrong DAR on a validator. 5 more members ran it and endorsed. CI template works.

---

# Why I am asking Canton
You give me milestone funding, I give Canton open infra that makes every future audit provably covered. This fills the gap between Zenith (EVM) and Certora (analyzer) - I give you the guaranteed-coverage model.

I will also write a joint blog on cross-package delegation risk and run a workshop for Canton devs.

**About me:** Solo founder, Top 10 Sherlock, 180+ repos, Cyfrin certified. I live at proofofaudits.com (beta 30 Jul 2026, pre-revenue, 40 auditors scored). I will maintain this for 12 months.

Happy to jump on a 15-min call and adapt this to what SIG daml-tooling needs most.

- MK

License: Proposal CC0-1.0, Code Apache-2.0
