### PR TITLE
Added the standard AI policy to this repo.

### DIFF
--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,53 +1,39 @@
 # AI Policy
 
-This policy applies to all contributions — including funding proposals, milestone submissions, code, issues, reviews, comments, and documentation — to this repository, regardless of whether you are a maintainer or an external contributor.
+This policy applies to all contributions — code, issues, reviews, comments, docs — to this repository, regardless of whether you are a maintainer or an external contributor.
 
-Using AI tools is allowed and can be useful. These rules exist to protect the quality and integrity of the Development Fund process, as well as the time of reviewers and other contributors.
+Using AI tools is allowed and often useful. The rules below exist to protect the quality of the codebase and the time of reviewers and other contributors.
 
 ## You are accountable for what you submit
 
 You are 100% responsible for every contribution you make under your name, regardless of which tools were involved in producing it. Reviewers review *your* work, not AI output.
 
-You must understand and be able to defend every material element of your submission, including code, technical claims, citations, budgets, milestones, acceptance criteria, adoption claims, and security findings. You must also be able to explain *why* each element is included. “The AI wrote it” is not an answer.
+You must understand every line of code you submit and be able to explain *why* each change is there. "The AI wrote it" is not an answer.
 
-## Verify material claims
+## Guard reviewers' time
 
-AI-assisted submissions must not include unverified claims about ecosystem demand, adoption, partnerships, prior work, technical performance, security findings, licensing, or third-party commitments.
+Aggressively self-review AI output before asking anyone else to look at it. If you would not ask a colleague to read a specific patch, do not ask the maintainers either.
 
-Material claims must be supported by evidence that reviewers can independently verify. Proposed integrations, partnerships, champions, customers, or contributors must not be presented as confirmed unless the relevant person or organization has agreed to participate.
+Do not open a PR you would not have opened without AI assistance. An AI making code cheap to produce is not a reason to produce more of it.
 
-Security findings and technical claims must be reproducible against the referenced code, version, or environment.
+The same applies to review comments you leave on others' PRs: do not post AI-generated feedback you have not read carefully and are not prepared to defend yourself.
 
-## Guard reviewers’ time
+**Issues and PRs that appear to be unreviewed AI output — overlong and padded, referencing things that do not exist, plausible-sounding but wrong, filled with bot-style prose, or (in the case of security reports) describing a vulnerability that does not reproduce against the actual code — may be closed without further discussion.** Maintainers are not obligated to explain, respond to, or debate the merits of such submissions. Repeated submissions of this kind may lead to being blocked from the repository.
 
-Aggressively self-review AI output before asking anyone else to look at it. If you would not ask a colleague to read a specific proposal, patch, issue, or comment, do not ask the maintainers or Development Fund reviewers to read it either.
+If you believe a closure was in error, a single comment with a concrete, verifiable correction is welcome. Further back-and-forth is at maintainers' discretion.
 
-Do not open a PR you would not have opened without AI assistance. An AI making content inexpensive to produce is not a reason to produce more of it.
+## PRs opened autonomously by AI require two human reviews
 
-The same applies to review comments you leave on others’ PRs. Do not post AI-generated feedback that you have not read carefully, verified, and are not prepared to defend yourself.
+If a PR is opened by a bot account or created through an automated workflow — i.e. without a named human in the loop — it must receive approvals from **two** human reviewers before merging. PRs opened by a named human follow the normal single-approval rules, including those where AI helped produce the changes. The named human author is responsible for the PR contents as always.
 
-**Issues and PRs that appear to be unreviewed AI output — including submissions that are overlong or padded, reference things that do not exist, contain unsupported or fabricated claims, use plausible-sounding but incorrect language, or describe technical or security findings that cannot be reproduced — may be moved to `Needs Revision`, removed from the active review queue, or closed without further discussion.**
-
-Maintainers and reviewers are not obligated to explain, respond to, or debate the merits of submissions that do not meet this standard. Repeated submissions of this kind may lead to being blocked from the repository.
-
-If you believe an action was taken in error, a single comment containing a concrete, verifiable correction is welcome. Further discussion is at the maintainers’ discretion.
-
-## Funding submissions require a named human
-
-Funding proposals, milestone submissions, funding requests, and votes may not be submitted autonomously by AI.
-
-Every such submission must identify a named human and, where applicable, the organization responsible for it. That person is accountable for the accuracy of the submission, the commitments it contains, and the work performed under any resulting award.
-
-AI may assist with preparing these materials, but it may not act as the applicant, project lead, champion, milestone approver, or voting participant.
+Fully deterministic automated workflows (dependency bumps, submodule bumps, and the like) are not subject to this rule.
 
 ## Attribution
 
-There is no requirement to label AI-assisted contributions as such.
+There is no requirement to mark AI-assisted contributions as such.
 
-That said, do not conceal the use of AI if asked. If a reviewer asks how a proposal, claim, analysis, or piece of code was produced, answer honestly.
+That said, do not hide it if asked. If a reviewer asks how a piece of code came about, answer honestly.
 
 ## A note for new contributors
 
-If you are picking up a `good first issue` or similar onboarding-oriented task, remember that the task exists partly so that *you* can learn the repository, its processes, and the surrounding ecosystem.
-
-Using AI to accelerate completion may defeat that purpose — both for you and for the maintainers trying to onboard you. Engage directly with the relevant code, documentation, and Development Fund process, and make sure you understand the contribution you are making.
+If you are picking up a `good first issue` or similar onboarding-oriented task, the task exists partly so that *you* learn the codebase. Using AI to speed up completion of the task may defeat the purpose — for yourself and for the maintainers trying to onboard you. Engage with the code.

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,35 @@
+# AI Policy
+
+This policy applies to all contributions — code, issues, reviews, comments, docs — to this repository, regardless of whether you are a maintainer or an external contributor.
+
+Using AI tools is allowed and often useful. The rules below exist to protect the quality of the codebase and the time of reviewers and other contributors.
+
+## You are accountable for what you submit
+
+You are 100% responsible for every contribution you make under your name, regardless of which tools were involved in producing it. Reviewers review *your* work, not AI output.
+
+You must understand every line of code or text you submit and be able to explain *why* each change is there. "The AI wrote it" is not an answer.
+
+## Guard reviewers' time
+
+Aggressively self-review AI output before asking anyone else to look at it. If you would not ask a colleague to read a specific patch, do not ask the maintainers either.
+
+Do not open a PR you would not have opened without AI assistance. An AI making code cheap to produce is not a reason to produce more of it.
+
+The same applies to review comments you leave on others' PRs: do not post AI-generated feedback you have not read carefully and are not prepared to defend yourself.
+
+**Issues and PRs that appear to be unreviewed AI output — overlong and padded, referencing things that do not exist, plausible-sounding but wrong, filled with bot-style prose, or (in the case of security reports) describing a vulnerability that does not reproduce against the actual code — may be closed without further discussion.** Maintainers are not obligated to explain, respond to, or debate the merits of such submissions. Repeated submissions of this kind may lead to being blocked from the repository.
+
+If you believe a closure was in error, a single comment with a concrete, verifiable correction is welcome. Further back-and-forth is at maintainers' discretion.
+
+## PRs opened autonomously by AI require two human reviews
+
+If a PR is opened by a bot account or created through an automated workflow — i.e. without a named human in the loop — it must receive approvals from **two** human reviewers before merging. PRs opened by a named human follow the normal single-approval rules, including those where AI helped produce the changes. The named human author is responsible for the PR contents as always.
+
+Fully deterministic automated workflows (dependency bumps, submodule bumps, and the like) are not subject to this rule.
+
+## Attribution
+
+There is no requirement to mark AI-assisted contributions as such.
+
+That said, do not hide it if asked. If a reviewer asks how a piece of code came about, answer honestly.

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,20 +1,20 @@
 # AI Policy
 
-This policy applies to all contributions — code, issues, reviews, comments, docs — to this repository, regardless of whether you are a maintainer or an external contributor.
+This policy applies to all contributions — including funding proposals, milestone submissions, code, issues, reviews, comments, and documentation — to this repository, regardless of whether you are a maintainer or an external contributor.
 
-Using AI tools is allowed and often useful. The rules below exist to protect the quality of the codebase and the time of reviewers and other contributors.
+Using AI tools is allowed and often useful. The rules below exist to protect the quality and integrity of the Development Fund process and the time of reviewers and other contributors.
 
 ## You are accountable for what you submit
 
 You are 100% responsible for every contribution you make under your name, regardless of which tools were involved in producing it. Reviewers review *your* work, not AI output.
 
-You must understand every line of code you submit and be able to explain *why* each change is there. "The AI wrote it" is not an answer.
+You must understand and be able to defend every material element of your submission, including code, technical claims, citations, budgets, milestones, acceptance criteria, adoption claims, and security findings. You must also be able to explain *why* each element is included. “The AI wrote it” is not an answer.
 
 ## Guard reviewers' time
 
-Aggressively self-review AI output before asking anyone else to look at it. If you would not ask a colleague to read a specific patch, do not ask the maintainers either.
+Aggressively self-review AI output before asking anyone else to look at it. If you would not ask a colleague to read a specific proposal, do not ask the maintainers either.
 
-Do not open a PR you would not have opened without AI assistance. An AI making code cheap to produce is not a reason to produce more of it.
+Do not open a PR you would not have opened without AI assistance. An AI making content cheap to produce is not a reason to produce more of it.
 
 The same applies to review comments you leave on others' PRs: do not post AI-generated feedback you have not read carefully and are not prepared to defend yourself.
 
@@ -22,18 +22,9 @@ The same applies to review comments you leave on others' PRs: do not post AI-gen
 
 If you believe a closure was in error, a single comment with a concrete, verifiable correction is welcome. Further back-and-forth is at maintainers' discretion.
 
-## PRs opened autonomously by AI require two human reviews
-
-If a PR is opened by a bot account or created through an automated workflow — i.e. without a named human in the loop — it must receive approvals from **two** human reviewers before merging. PRs opened by a named human follow the normal single-approval rules, including those where AI helped produce the changes. The named human author is responsible for the PR contents as always.
-
-Fully deterministic automated workflows (dependency bumps, submodule bumps, and the like) are not subject to this rule.
-
 ## Attribution
 
 There is no requirement to mark AI-assisted contributions as such.
 
 That said, do not hide it if asked. If a reviewer asks how a piece of code came about, answer honestly.
 
-## A note for new contributors
-
-If you are picking up a `good first issue` or similar onboarding-oriented task, the task exists partly so that *you* learn the codebase. Using AI to speed up completion of the task may defeat the purpose — for yourself and for the maintainers trying to onboard you. Engage with the code.

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,35 +1,53 @@
 # AI Policy
 
-This policy applies to all contributions — code, issues, reviews, comments, docs — to this repository, regardless of whether you are a maintainer or an external contributor.
+This policy applies to all contributions — including funding proposals, milestone submissions, code, issues, reviews, comments, and documentation — to this repository, regardless of whether you are a maintainer or an external contributor.
 
-Using AI tools is allowed and often useful. The rules below exist to protect the quality of the codebase and the time of reviewers and other contributors.
+Using AI tools is allowed and can be useful. These rules exist to protect the quality and integrity of the Development Fund process, as well as the time of reviewers and other contributors.
 
 ## You are accountable for what you submit
 
 You are 100% responsible for every contribution you make under your name, regardless of which tools were involved in producing it. Reviewers review *your* work, not AI output.
 
-You must understand every line of code or text you submit and be able to explain *why* each change is there. "The AI wrote it" is not an answer.
+You must understand and be able to defend every material element of your submission, including code, technical claims, citations, budgets, milestones, acceptance criteria, adoption claims, and security findings. You must also be able to explain *why* each element is included. “The AI wrote it” is not an answer.
 
-## Guard reviewers' time
+## Verify material claims
 
-Aggressively self-review AI output before asking anyone else to look at it. If you would not ask a colleague to read a specific patch, do not ask the maintainers either.
+AI-assisted submissions must not include unverified claims about ecosystem demand, adoption, partnerships, prior work, technical performance, security findings, licensing, or third-party commitments.
 
-Do not open a PR you would not have opened without AI assistance. An AI making code cheap to produce is not a reason to produce more of it.
+Material claims must be supported by evidence that reviewers can independently verify. Proposed integrations, partnerships, champions, customers, or contributors must not be presented as confirmed unless the relevant person or organization has agreed to participate.
 
-The same applies to review comments you leave on others' PRs: do not post AI-generated feedback you have not read carefully and are not prepared to defend yourself.
+Security findings and technical claims must be reproducible against the referenced code, version, or environment.
 
-**Issues and PRs that appear to be unreviewed AI output — overlong and padded, referencing things that do not exist, plausible-sounding but wrong, filled with bot-style prose, or (in the case of security reports) describing a vulnerability that does not reproduce against the actual code — may be closed without further discussion.** Maintainers are not obligated to explain, respond to, or debate the merits of such submissions. Repeated submissions of this kind may lead to being blocked from the repository.
+## Guard reviewers’ time
 
-If you believe a closure was in error, a single comment with a concrete, verifiable correction is welcome. Further back-and-forth is at maintainers' discretion.
+Aggressively self-review AI output before asking anyone else to look at it. If you would not ask a colleague to read a specific proposal, patch, issue, or comment, do not ask the maintainers or Development Fund reviewers to read it either.
 
-## PRs opened autonomously by AI require two human reviews
+Do not open a PR you would not have opened without AI assistance. An AI making content inexpensive to produce is not a reason to produce more of it.
 
-If a PR is opened by a bot account or created through an automated workflow — i.e. without a named human in the loop — it must receive approvals from **two** human reviewers before merging. PRs opened by a named human follow the normal single-approval rules, including those where AI helped produce the changes. The named human author is responsible for the PR contents as always.
+The same applies to review comments you leave on others’ PRs. Do not post AI-generated feedback that you have not read carefully, verified, and are not prepared to defend yourself.
 
-Fully deterministic automated workflows (dependency bumps, submodule bumps, and the like) are not subject to this rule.
+**Issues and PRs that appear to be unreviewed AI output — including submissions that are overlong or padded, reference things that do not exist, contain unsupported or fabricated claims, use plausible-sounding but incorrect language, or describe technical or security findings that cannot be reproduced — may be moved to `Needs Revision`, removed from the active review queue, or closed without further discussion.**
+
+Maintainers and reviewers are not obligated to explain, respond to, or debate the merits of submissions that do not meet this standard. Repeated submissions of this kind may lead to being blocked from the repository.
+
+If you believe an action was taken in error, a single comment containing a concrete, verifiable correction is welcome. Further discussion is at the maintainers’ discretion.
+
+## Funding submissions require a named human
+
+Funding proposals, milestone submissions, funding requests, and votes may not be submitted autonomously by AI.
+
+Every such submission must identify a named human and, where applicable, the organization responsible for it. That person is accountable for the accuracy of the submission, the commitments it contains, and the work performed under any resulting award.
+
+AI may assist with preparing these materials, but it may not act as the applicant, project lead, champion, milestone approver, or voting participant.
 
 ## Attribution
 
-There is no requirement to mark AI-assisted contributions as such.
+There is no requirement to label AI-assisted contributions as such.
 
-That said, do not hide it if asked. If a reviewer asks how a piece of code came about, answer honestly.
+That said, do not conceal the use of AI if asked. If a reviewer asks how a proposal, claim, analysis, or piece of code was produced, answer honestly.
+
+## A note for new contributors
+
+If you are picking up a `good first issue` or similar onboarding-oriented task, remember that the task exists partly so that *you* can learn the repository, its processes, and the surrounding ecosystem.
+
+Using AI to accelerate completion may defeat that purpose — both for you and for the maintainers trying to onboard you. Engage directly with the relevant code, documentation, and Development Fund process, and make sure you understand the contribution you are making.


### PR DESCRIPTION
This is the AI POLICY document already used elsewhere: https://github.com/canton-network/splice/blob/main/AI_POLICY.md.