### PR TITLE
Add Cashen team members to sig-directory.md

### DIFF
--- a/sig-directory.md
+++ b/sig-directory.md
@@ -74,6 +74,7 @@ If your expertise does not fit an existing SIG, feel free to submit a Pull Reque
 | Jaroslaw Ratajski | Digital Asset | jarekr-da |
 | Michael Gaare | Denex / Cumberland | mgaare
 | Vinh Nguyễn | Upflam | v9n
+| Phillip Olesen | Cashen | phillip-cashen
 
 
 ---
@@ -124,6 +125,7 @@ If your expertise does not fit an existing SIG, feel free to submit a Pull Reque
 | Ian Hensel | Avro Digital | Ian-avro |
 | Luke Besser | Cosimo Capital | booksbanks|
 | Nate | Obsidian Systems | ApolloUnicorn
+| Luke Farrell | Cashen | cashenLuke
 
 ---
 


### PR DESCRIPTION
Adding Cashen team members to these SIGs :

dApp Integration
DeFi Protocols & Liquidity

Rationale:
- Phillip was a contributing member to CIP-103 and very knowledgable about Canton dApp mechanics
- Cashen is a live Canton DeFi protocol supporting locked CC deals, and building strategy vaults on Canton

